### PR TITLE
Pulled Dingo back to 0.6.* - Basic Auth not working with new version

### DIFF
--- a/app/CachetHq/Cachet/Repositories/Component/EloquentComponentRepository.php
+++ b/app/CachetHq/Cachet/Repositories/Component/EloquentComponentRepository.php
@@ -18,9 +18,7 @@
 			$component = new $this->model($array);
 			$component->user_id = $user_id;
 
-			if ($component->isInvalid()) {
-				throw new Exception('Invalid model validation', $component->getErrors());
-			}
+			$this->validate($component);
 
 			$component->saveOrFail();
 			return $component;

--- a/app/CachetHq/Cachet/Repositories/EloquentRepository.php
+++ b/app/CachetHq/Cachet/Repositories/EloquentRepository.php
@@ -100,4 +100,15 @@
 			$model = $this->model->whereId($id)->first(['id']);
 			$model->update($array);
 		}
+
+		/**
+		 * Validate a given model with Watson validation
+		 * @param  object $model
+		 * @return Exception
+		 */
+		public function validate($model) {
+			if ($model->isInvalid()) {
+				throw new Exception('Invalid model validation');
+			}
+		}
 	}

--- a/app/config/app.php
+++ b/app/config/app.php
@@ -122,7 +122,7 @@ return array(
 		'Illuminate\View\ViewServiceProvider',
 		'Illuminate\Workbench\WorkbenchServiceProvider',
 
-		'Dingo\Api\Provider\ApiServiceProvider',
+		'Dingo\Api\ApiServiceProvider',
 		'Thujohn\Rss\RssServiceProvider',
 
 		'CachetHQ\Cachet\Support\ServiceProviders\RepositoryServiceProvider',

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	"require": {
 		"laravel/framework": "4.2.*",
 		"guzzlehttp/guzzle": "~5.0",
-		"dingo/api": "0.7.*",
+		"dingo/api": "0.6.*",
 		"watson/validating": "0.10.*",
 		"thujohn/rss": "dev-master"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "62ab8c6b87bf3b5342d449b46df2d76b",
+    "hash": "a869e5c2586d00bb96110dc4fd24e123",
     "packages": [
         {
             "name": "classpreloader/classpreloader",
@@ -89,45 +89,43 @@
         },
         {
             "name": "dingo/api",
-            "version": "v0.7.0",
+            "version": "v0.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dingo/api.git",
-                "reference": "eea61d886bab386785f619d4c470d350e81f6435"
+                "reference": "87ce1b823941deddf266d2fcbf537145c0530716"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dingo/api/zipball/eea61d886bab386785f619d4c470d350e81f6435",
-                "reference": "eea61d886bab386785f619d4c470d350e81f6435",
+                "url": "https://api.github.com/repos/dingo/api/zipball/87ce1b823941deddf266d2fcbf537145c0530716",
+                "reference": "87ce1b823941deddf266d2fcbf537145c0530716",
                 "shasum": ""
             },
             "require": {
-                "illuminate/support": "~4.1",
-                "league/fractal": "0.10.*",
+                "illuminate/support": "~4.1|~5.0",
+                "league/fractal": "0.8.*",
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "illuminate/auth": "4.2.*",
-                "illuminate/console": "4.2.*",
-                "illuminate/database": "4.2.*",
-                "illuminate/events": "4.2.*",
-                "illuminate/filesystem": "4.2.*",
-                "illuminate/pagination": "4.2.*",
-                "illuminate/routing": "4.2.*",
-                "lucadegasperi/oauth2-server-laravel": "3.0.*",
+                "illuminate/auth": "~4.1",
+                "illuminate/console": "~4.1",
+                "illuminate/database": "~4.1",
+                "illuminate/events": "~4.1",
+                "illuminate/pagination": "~4.1",
+                "illuminate/routing": "~4.1",
+                "lucadegasperi/oauth2-server-laravel": "1.0.*",
                 "mockery/mockery": "~0.9",
                 "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~1.5",
-                "tymon/jwt-auth": "0.3.*"
+                "squizlabs/php_codesniffer": "1.*"
             },
             "suggest": {
-                "lucadegasperi/oauth2-server-laravel": "Use the League OAuth 2.0 server to protect your API.",
-                "tymon/jwt-auth": "Protect your API with JSON Web Tokens"
+                "lucadegasperi/oauth2-server-laravel": "Use the League OAuth 2.0 server to protect your API."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.7-dev"
+                    "dev-master": "0.6-dev",
+                    "dev-develop": "0.7-dev"
                 }
             },
             "autoload": {
@@ -152,7 +150,7 @@
                 "laravel",
                 "restful"
             ],
-            "time": "2014-11-27 00:56:56"
+            "time": "2014-09-29 00:06:33"
         },
         {
             "name": "filp/whoops",
@@ -577,16 +575,16 @@
         },
         {
             "name": "league/fractal",
-            "version": "0.10.0",
+            "version": "0.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/fractal.git",
-                "reference": "557e1803dabe8ce252a4549a29da6d439f62d3c2"
+                "reference": "9985eee7efc42ef472da07856cdd3fd29c57642c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/fractal/zipball/557e1803dabe8ce252a4549a29da6d439f62d3c2",
-                "reference": "557e1803dabe8ce252a4549a29da6d439f62d3c2",
+                "url": "https://api.github.com/repos/thephpleague/fractal/zipball/9985eee7efc42ef472da07856cdd3fd29c57642c",
+                "reference": "9985eee7efc42ef472da07856cdd3fd29c57642c",
                 "shasum": ""
             },
             "require": {
@@ -604,7 +602,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.10-dev"
+                    "dev-master": "0.8-dev"
                 }
             },
             "autoload": {
@@ -619,8 +617,8 @@
             "authors": [
                 {
                     "name": "Phil Sturgeon",
-                    "email": "me@philsturgeon.uk",
-                    "homepage": "http://philsturgeon.uk/",
+                    "email": "email@philsturgeon.co.uk",
+                    "homepage": "http://philsturgeon.co.uk/",
                     "role": "Developer"
                 }
             ],
@@ -632,7 +630,7 @@
                 "league",
                 "rest"
             ],
-            "time": "2014-10-17 17:12:38"
+            "time": "2014-06-14 11:11:41"
         },
         {
             "name": "monolog/monolog",


### PR DESCRIPTION
Even though the controllers need changing for `.7`, the Basic Auth won't seem to work.  Raised an issue: https://github.com/dingo/api/issues/261
