### PR TITLE
renameColumn function requires the doctrine/dbal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "guzzlehttp/guzzle": "~5.0",
     "dingo/api": "0.8.*",
     "watson/validating": "0.10.*",
-    "thujohn/rss": "~1.0"
+    "thujohn/rss": "~1.0",
+    "doctrine/dbal": "2.3.5"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.3",


### PR DESCRIPTION
Migrations using `renameColumn` function requires the doctrine/dbal.
Please refer http://laravel.com/docs/4.2/schema#renaming-columns

RenameColumn function being used at 
- https://github.com/cachethq/Cachet/blob/master/app/database/migrations/2014_12_01_121947_AlterTableIncidentsRenameComponentColumn.php
