### PR TITLE
Incident texts now support Markdown

### DIFF
--- a/app/models/Incident.php
+++ b/app/models/Incident.php
@@ -54,6 +54,17 @@ class Incident extends Eloquent implements \Dingo\Api\Transformer\TransformableI
     }
 
     /**
+     * Returns a Markdown formatted version of the status.
+     * @return string
+     */
+    public function getFormattedMessageAttribute()
+    {
+        $parseDown = new ParsedownExtra();
+
+        return $parseDown->text($this->message);
+    }
+
+    /**
      * Get the transformer instance.
      * @return CachetHQ\Cachet\Transformers\IncidentTransformer
      */

--- a/app/views/dashboard/incident-add.blade.php
+++ b/app/views/dashboard/incident-add.blade.php
@@ -52,6 +52,7 @@
                         <div class="form-group">
                             <label>Message</label>
                             <textarea name="incident[message]" class="form-control" rows="5"></textarea>
+                            <span class='help-block'>You may also use Markdown.</span>
                         </div>
                     </fieldset>
 

--- a/app/views/partials/incident.blade.php
+++ b/app/views/partials/incident.blade.php
@@ -25,7 +25,7 @@
                         </div>
                         @if($incident->hasMessage())
                         <div class="panel-body">
-                            <p>{{ $incident->message }}</p>
+                            <p>{{ $incident->formattedMessage }}</p>
                         </div>
                         @endif
                     </div>

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,14 @@
     "license": "MIT",
     "type": "project",
     "require": {
+        "php": ">=5.4",
         "laravel/framework": "4.2.*",
         "guzzlehttp/guzzle": "~5.0",
         "dingo/api": "0.8.*",
         "watson/validating": "0.10.*",
         "thujohn/rss": "~1.0",
-        "doctrine/dbal": "2.5.*"
+        "doctrine/dbal": "2.5.*",
+        "erusev/parsedown-extra": "~0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a401eb624daf649d5d1cc19a416dd233",
+    "hash": "2b05058fab4b2fa831e500985b506c1f",
     "packages": [
         {
             "name": "classpreloader/classpreloader",
@@ -628,6 +628,89 @@
             "time": "2013-01-12 18:59:04"
         },
         {
+            "name": "erusev/parsedown",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/erusev/parsedown.git",
+                "reference": "495e7ac73bb5fde6b857b88ff2bb1b5e79a4263a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/495e7ac73bb5fde6b857b88ff2bb1b5e79a4263a",
+                "reference": "495e7ac73bb5fde6b857b88ff2bb1b5e79a4263a",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Parsedown": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Emanuil Rusev",
+                    "email": "hello@erusev.com",
+                    "homepage": "http://erusev.com"
+                }
+            ],
+            "description": "Parser for Markdown.",
+            "homepage": "http://parsedown.org",
+            "keywords": [
+                "markdown",
+                "parser"
+            ],
+            "time": "2014-11-29 02:29:14"
+        },
+        {
+            "name": "erusev/parsedown-extra",
+            "version": "0.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/erusev/parsedown-extra.git",
+                "reference": "77f604b65b08550f229c2e79c0427c84c0c0979e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/erusev/parsedown-extra/zipball/77f604b65b08550f229c2e79c0427c84c0c0979e",
+                "reference": "77f604b65b08550f229c2e79c0427c84c0c0979e",
+                "shasum": ""
+            },
+            "require": {
+                "erusev/parsedown": "~1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "ParsedownExtra": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Emanuil Rusev",
+                    "email": "hello@erusev.com",
+                    "homepage": "http://erusev.com"
+                }
+            ],
+            "description": "An extension of Parsedown that adds support for Markdown Extra.",
+            "homepage": "https://github.com/erusev/parsedown-extra",
+            "keywords": [
+                "markdown",
+                "markdown extra",
+                "parsedown",
+                "parser"
+            ],
+            "time": "2014-11-20 20:21:03"
+        },
+        {
             "name": "filp/whoops",
             "version": "1.1.3",
             "source": {
@@ -1113,16 +1196,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.11.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "ec3961874c43840e96da3a8a1ed20d8c73d7e5aa"
+                "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/ec3961874c43840e96da3a8a1ed20d8c73d7e5aa",
-                "reference": "ec3961874c43840e96da3a8a1ed20d8c73d7e5aa",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1fbe8c2641f2b163addf49cc5e18f144bec6b19f",
+                "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f",
                 "shasum": ""
             },
             "require": {
@@ -1136,7 +1219,7 @@
                 "aws/aws-sdk-php": "~2.4, >2.4.8",
                 "doctrine/couchdb": "~1.0@dev",
                 "graylog2/gelf-php": "~1.0",
-                "phpunit/phpunit": "~3.7.0",
+                "phpunit/phpunit": "~4.0",
                 "raven/raven": "~0.5",
                 "ruflin/elastica": "0.90.*",
                 "videlalvaro/php-amqplib": "~2.4"
@@ -1155,7 +1238,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.12.x-dev"
                 }
             },
             "autoload": {
@@ -1181,7 +1264,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2014-09-30 13:30:58"
+            "time": "2014-12-29 21:29:35"
         },
         {
             "name": "nesbot/carbon",
@@ -3394,6 +3477,8 @@
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.4"
+    },
     "platform-dev": []
 }


### PR DESCRIPTION
Markdown support with [erusev/parsedown-extra](https://github.com/erusev/parsedown-extra).

You can use the `$incident->formattedMessage` attribute to get the formatted text of the message.

![screen shot 2014-12-30 at 10 33 13](https://cloud.githubusercontent.com/assets/246103/5577711/63c4d2f2-900f-11e4-84f5-3902884d4d78.png)
