### PR TITLE
Update 404 to show only on dashboard and api

### DIFF
--- a/app/lang/en/cachet.php
+++ b/app/lang/en/cachet.php
@@ -55,6 +55,9 @@ return [
         'logged_incidents'         => '{0} There are no incidents, good work.|You have logged one incident.|You have reported <strong>:count</strong> incidents.',
         'settings_saved'           => 'Settings saved.',
         'settings_not_saved'       => 'Settings could not be saved.',
+        'not_found'                => 'Page Not Found',
+        'not_found_message'        => 'Sorry, but the page you are looking for has not been found. Check the URL for errors and try again.',
+        'not_found_link'           => 'Return to homepage',
     ],
     // Forms
     'forms' => [

--- a/app/start/global.php
+++ b/app/start/global.php
@@ -57,9 +57,13 @@ API::error(function (\Illuminate\Database\Eloquent\ModelNotFoundException $excep
 });
 
 App::missing(function ($exception) {
-    return Response::view('errors.404', [
-        'pageTitle' => 'That page went missing!'
-    ], 404);
+    if (Request::is('dashboard*') or Request::is('api*')) {
+        return Response::view('errors.404', [
+            'pageTitle' => 'That page went missing!',
+        ], 404);
+    }
+
+    return Redirect::route('status-page');
 });
 
 /*

--- a/app/views/errors/404.blade.php
+++ b/app/views/errors/404.blade.php
@@ -2,13 +2,17 @@
 
 @section('content')
     <div class="middle-box text-center">
+        <div>
+            <img class="logo" height="65" src="{{ url('img/cachet-logo.svg') }}" alt="Cachet"/>
+        </div>
         <h1>404</h1>
-        <h3 class="font-bold">Page Not Found</h3>
+        <h3>{{ Lang::get('cachet.dashboard.not_found') }}</h3>
 
         <div class="error-desc">
-            <p>Sorry, but the page you are looking for has not been found. Check the URL for errors and try again.</p>
+            <p>{{ Lang::get('cachet.dashboard.not_found_message') }}</p>
+            <br/>
             <p>
-                <a href='/' class='btn btn-default btn-lg'>Home</a>
+                <a href='/' class='btn btn-default btn-lg'>{{ Lang::get('cachet.dashboard.not_found_link') }}</a>
             </p>
         </div>
     </div>


### PR DESCRIPTION
I think if is the users status page just redirect them to the status page, if it's a 404 on the dashboard then we show the 404 page. 

![screen shot 2014-12-31 at 7 13 06 pm](https://cloud.githubusercontent.com/assets/1803556/5591442/199d56dc-9121-11e4-9398-4d8215b026c0.png)
