### PR TITLE
Fix composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,11 +38,6 @@
             "CachetHQ\\Cachet\\": "src/"
         }
     },
-    "autoload-dev": {
-        "classmap": [
-            "tests/TestCase.php"
-        ]
-    },
     "extra": {
         "paas": {
             "document-root": "public",


### PR DESCRIPTION
Fixes an error during installation, the error was:

      [RuntimeException]
        Could not scan for classes inside "tests/TestCase.php" which does not appear to be a file nor a folder