### PR TITLE
BInput XSS protection using get instead of all - setup fails

### DIFF
--- a/src/Http/Controllers/SetupController.php
+++ b/src/Http/Controllers/SetupController.php
@@ -42,7 +42,7 @@ class SetupController extends Controller
      */
     public function postIndex()
     {
-        $postData = Binput::get();
+        $postData = Binput::all();
 
         $v = Validator::make($postData, [
             'settings.app_name'     => 'required',


### PR DESCRIPTION
When setting up a fresh install of Cachet it fails due to some missing arguments on `Binput::get()`. I don't think it should be using get so i've changed it back to `Binput::all()` and setup now works correctly.