### PR TITLE
Don't show the group picker if we have no groups.

### DIFF
--- a/app/views/dashboard/components/add.blade.php
+++ b/app/views/dashboard/components/add.blade.php
@@ -41,6 +41,7 @@
                             <label>{{ trans('forms.components.description') }}</label>
                             <textarea name='component[description]' class='form-control' rows='5'></textarea>
                         </div>
+                        @if($groups->count() > 0)
                         <div class='form-group'>
                             <label>{{ trans('forms.components.group') }}</label>
                             <select name='component[group_id]' class='form-control'>
@@ -50,6 +51,7 @@
                                 @endforeach
                             </select>
                         </div>
+                        @endif
                         <hr />
                         <div class='form-group'>
                             <label>{{ trans('forms.components.link') }}</label>

--- a/app/views/dashboard/components/edit.blade.php
+++ b/app/views/dashboard/components/edit.blade.php
@@ -41,6 +41,7 @@
                             <label>{{ trans('forms.components.group') }}</label>
                             <textarea name='component[description]' class='form-control' rows='5'>{{ $component->description }}</textarea>
                         </div>
+                        @if($groups->count() > 0)
                         <div class='form-group'>
                             <label>Group</label>
                             <select name='component[group_id]' class='form-control'>
@@ -50,6 +51,7 @@
                                 @endforeach
                             </select>
                         </div>
+                        @endif
                         <hr />
                         <div class='form-group'>
                             <label>{{ trans('forms.components.link') }}</label>


### PR DESCRIPTION
If we have no groups configured, we don't want to show an empty select.
