### PR TITLE
Add steps to install requirements to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For more information on why I started developing Cachet, check out my [blog post
 - Node.js
     + Bower
     + Gulp
+- Composer
 - mcrypt extension
 
 ## Installation

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -36,7 +36,18 @@ $ git clone https://github.com/cachethq/Cachet.git
 $ cd Cachet
 ```
 
-You will also need to build the assets.
+## Install requirements
+
+You need to have a modern version of node.js installed (with NPM) - see https://github.com/nodesource/distributions
+```bash
+apt-get install nodejs
+npm install bower
+npm install gulp
+curl -sS https://getcomposer.org/installer | php  #always be careful when piping from the internet!
+```
+
+
+## Build the assets.
 
 ```bash
 $ npm install

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -41,8 +41,8 @@ $ cd Cachet
 You need to have a modern version of node.js installed (with NPM) - see https://github.com/nodesource/distributions
 ```bash
 apt-get install nodejs
-npm install bower
-npm install gulp
+npm install -g bower
+npm install -g gulp
 curl -sS https://getcomposer.org/installer | php  #always be careful when piping from the internet!
 ```
 


### PR DESCRIPTION
JS requirements are a pain, I've added the steps to install them.
This may help people get up and going before there are packaged versions of Cachet available.