### PR TITLE
update timezone names

### DIFF
--- a/src/Http/Controllers/SetupController.php
+++ b/src/Http/Controllers/SetupController.php
@@ -65,6 +65,8 @@ class SetupController extends Controller
 
                 // Remove region name and add a sample time
                 $timezones[$name][$timezone] = substr($timezone, strlen($name) + 1).' - '.$time->format('H:i').$ampm;
+
+                $timezones[$name] = str_replace('_', ' ', $timezones[$name]);
             }
         }
 


### PR DESCRIPTION
Enhances the timezone selection on the setup page

before:
New_York - 14:10 (2:10 pm)

after:
New York - 14:10 (2:10 pm)