### PR TITLE
Anonymous tracking with Segment.com

### DIFF
--- a/app/config/app.php
+++ b/app/config/app.php
@@ -127,16 +127,16 @@ return [
          * Packages Service Providers...
          */
         'Dingo\Api\Provider\ApiServiceProvider',
-        'GrahamCampbell\Security\SecurityServiceProvider',
+        'Fideloper\Proxy\ProxyServiceProvider',
         'GrahamCampbell\Binput\BinputServiceProvider',
-        'GrahamCampbell\Throttle\ThrottleServiceProvider',
         'GrahamCampbell\Markdown\MarkdownServiceProvider',
-        'Roumen\Feed\FeedServiceProvider',
-        'Thujohn\Rss\RssServiceProvider',
+        'GrahamCampbell\Security\SecurityServiceProvider',
+        'GrahamCampbell\Throttle\ThrottleServiceProvider',
         'Jenssegers\Date\DateServiceProvider',
         'McCool\LaravelAutoPresenter\LaravelAutoPresenterServiceProvider',
         'PragmaRX\Google2FA\Vendor\Laravel\ServiceProvider',
-        'Fideloper\Proxy\ProxyServiceProvider',
+        'Roumen\Feed\FeedServiceProvider',
+        'Thujohn\Rss\RssServiceProvider',
 
         /*
          * Application Service Providers...
@@ -148,6 +148,8 @@ return [
         'CachetHQ\Cachet\Providers\ViewComposerServiceProvider',
         'CachetHQ\Cachet\Providers\LoadConfigServiceProvider',
         'CachetHQ\Cachet\Providers\SettingsServiceProvider',
+        'CachetHQ\Cachet\Providers\SegmentApiServiceProvider',
+        'CachetHQ\Segment\SegmentServiceProvider',
 
     ],
 

--- a/app/config/packages/cachethq/segment/config.php
+++ b/app/config/packages/cachethq/segment/config.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'write_key'     => '',
+    'consumer'      => 'socket',
+    'debug'         => false,
+    'ssl'           => true,
+    'error_handler' => null,
+];

--- a/app/lang/de/setup.php
+++ b/app/lang/de/setup.php
@@ -10,4 +10,5 @@ return [
     'complete_setup'    => 'Setup abschließen',
     'completed'         => 'Cachet wurde erfolgreich eingerichtet!',
     'finish_setup'      => 'Zum Dashboard',
+    'allow_tracking'    => 'Allow anonymous usage tracking?',
 ];

--- a/app/lang/en/setup.php
+++ b/app/lang/en/setup.php
@@ -10,4 +10,5 @@ return [
     'complete_setup'    => 'Complete Setup',
     'completed'         => 'Cachet has been configured successfully!',
     'finish_setup'      => 'Go to dashboard',
+    'allow_tracking'    => 'Allow anonymous usage tracking?',
 ];

--- a/app/lang/fr/setup.php
+++ b/app/lang/fr/setup.php
@@ -10,4 +10,5 @@ return [
     'complete_setup'    => 'Terminer l\'installation',
     'completed'         => 'Cachet a été configuré avec succès !',
     'finish_setup'      => 'Aller au tableau de bord',
+    'allow_tracking'    => 'Allow anonymous usage tracking?',
 ];

--- a/app/start/global.php
+++ b/app/start/global.php
@@ -61,3 +61,14 @@ App::missing(function ($exception) {
 App::down(function () {
     return Response::make("Be right back!", 503);
 });
+
+/*
+|--------------------------------------------------------------------------
+| Analytics
+|--------------------------------------------------------------------------
+|
+| We handle all Segment.com tracking here. The function call will only do
+| something if tracking is enabled.
+|
+*/
+segment_identify();

--- a/app/views/dashboard/settings/app-setup.blade.php
+++ b/app/views/dashboard/settings/app-setup.blade.php
@@ -111,6 +111,15 @@
                             <div class="row">
                                 <div class="col-xs-12">
                                     <div class="form-group">
+                                        <label>{{ trans('setup.allow_tracking') }}</label>
+                                        <input type="hidden" value="0" name="app_track">
+                                        <input type="checkbox" value="1" name="app_track" class="form-control" {{ Setting::get('app_track') ? 'checked' : null }}>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-12">
+                                    <div class="form-group">
                                         <label>{{ trans('forms.settings.app-setup.banner') }}</label>
                                         @if($banner = Setting::get('app_banner'))
                                         <div id="banner-view" class="well">

--- a/app/views/setup.blade.php
+++ b/app/views/setup.blade.php
@@ -78,6 +78,12 @@
                                 {{ trans("setup.show_support") }}
                             </label>
                         </div>
+                        <div class="form-group">
+                            <label>
+                                <input type="checkbox" name="settings[app_track]" value="1" checked >
+                                {{ trans("setup.allow_tracking") }}
+                            </label>
+                        </div>
                         <hr>
                         <div class="form-group text-center">
                             <span class="wizard-next btn btn-success" data-current-block="1" data-next-block="2" data-loading-text="<i class='icon ion-load-c'></i>">

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "ext-mcrypt": "*",
         "ext-openssl": "*",
         "laravel/framework": "4.2.*",
+        "cachethq/segment": "1.0.*@dev",
         "dingo/api": "0.8.*",
         "doctrine/dbal": "2.5.*",
         "graham-campbell/binput": "2.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,63 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3752fec41d40201f38e46974caa27d62",
+    "hash": "b32031bb1053f393308be4f68d1d0c94",
     "packages": [
+        {
+            "name": "cachethq/segment",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cachethq/Laravel-Segment.git",
+                "reference": "39121d7953cb91197f0474b9cf43ae198fca1e26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cachethq/Laravel-Segment/zipball/39121d7953cb91197f0474b9cf43ae198fca1e26",
+                "reference": "39121d7953cb91197f0474b9cf43ae198fca1e26",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/config": "~4.1",
+                "illuminate/support": "~4.1",
+                "php": ">=5.4.7",
+                "segmentio/analytics-php": "~1.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "CachetHQ\\Segment\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "James Brooks",
+                    "email": "james@cachethq.io"
+                }
+            ],
+            "description": "Segment.com wrapper written for Laravel 4",
+            "keywords": [
+                "CachetHQ",
+                "Laravel Segment",
+                "api",
+                "cachet",
+                "framework",
+                "laravel",
+                "segment",
+                "segment.com",
+                "segment.io"
+            ],
+            "time": "2015-01-23 22:49:00"
+        },
         {
             "name": "classpreloader/classpreloader",
             "version": "1.0.2",
@@ -2109,6 +2164,51 @@
             "time": "2014-12-09 14:53:34"
         },
         {
+            "name": "segmentio/analytics-php",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/segmentio/analytics-php.git",
+                "reference": "db24fa9a2e1110570c338fea7a6f46bbb7ef105c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/segmentio/analytics-php/zipball/db24fa9a2e1110570c338fea7a6f46bbb7ef105c",
+                "reference": "db24fa9a2e1110570c338fea7a6f46bbb7ef105c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/Segment.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Segment.io <friends@segment.io>",
+                    "homepage": "https://segment.io/"
+                }
+            ],
+            "description": "Segmentio Analytics PHP Library",
+            "homepage": "https://segment.io/libraries/php",
+            "keywords": [
+                "analytics",
+                "analytics.js",
+                "segmentio"
+            ],
+            "time": "2015-01-07 07:11:38"
+        },
+        {
             "name": "stack/builder",
             "version": "v1.0.3",
             "source": {
@@ -3997,7 +4097,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "cachethq/segment": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Console/Commands/OneClickDeployCommand.php
+++ b/src/Console/Commands/OneClickDeployCommand.php
@@ -50,7 +50,13 @@ class OneClickDeployCommand extends Command
     public function fire()
     {
         if ($this->migrate) {
-            return $this->runMigrations();
+            $migrations = $this->runMigrations();
+
+            segment_track('Installation', [
+                'event' => 'Heroku Deployment',
+            ]);
+
+            return $migrations;
         }
 
         $this->info('Please run "php artisan migrate" to finish the installation.');

--- a/src/Http/Controllers/DashComponentController.php
+++ b/src/Http/Controllers/DashComponentController.php
@@ -109,6 +109,11 @@ class DashComponentController extends Controller
         $component->update($_component);
 
         if (! $component->isValid()) {
+            segment_track('Dashboard', [
+                'event'   => 'Edit Component',
+                'success' => false,
+            ]);
+
             return Redirect::back()->withInput(Binput::all())
                 ->with('title', sprintf(
                     '<strong>%s</strong> %s',
@@ -117,6 +122,11 @@ class DashComponentController extends Controller
                 ))
                 ->with('errors', $component->getErrors());
         }
+
+        segment_track('Dashboard', [
+            'event'   => 'Edit Component',
+            'success' => true,
+        ]);
 
         // The component was added successfully, so now let's deal with the tags.
         $tags = preg_split('/ ?, ?/', $tags);
@@ -168,6 +178,11 @@ class DashComponentController extends Controller
         $component = Component::create($_component);
 
         if (! $component->isValid()) {
+            segment_track('Dashboard', [
+                'event'   => 'Created Component',
+                'success' => false,
+            ]);
+
             return Redirect::back()->withInput(Binput::all())
                 ->with('title', sprintf(
                     '<strong>%s</strong> %s',
@@ -176,6 +191,11 @@ class DashComponentController extends Controller
                 ))
                 ->with('errors', $component->getErrors());
         }
+
+        segment_track('Dashboard', [
+            'event'   => 'Created Component',
+            'success' => true,
+        ]);
 
         // The component was added successfully, so now let's deal with the tags.
         $tags = preg_split('/ ?, ?/', $tags);
@@ -207,6 +227,10 @@ class DashComponentController extends Controller
      */
     public function deleteComponentAction(Component $component)
     {
+        segment_track('Dashboard', [
+            'event' => 'Deleted Component',
+        ]);
+
         $component->delete();
 
         return Redirect::back();
@@ -221,6 +245,10 @@ class DashComponentController extends Controller
      */
     public function deleteComponentGroupAction(ComponentGroup $group)
     {
+        segment_track('Dashboard', [
+            'event' => 'Deleted Component Group',
+        ]);
+
         $group->delete();
 
         return Redirect::back();
@@ -248,6 +276,11 @@ class DashComponentController extends Controller
         $group = ComponentGroup::create(Binput::get('group'));
 
         if (! $group->isValid()) {
+            segment_track('Dashboard', [
+                'event'   => 'Created Component Group',
+                'success' => false,
+            ]);
+
             return Redirect::back()->withInput(Binput::all())
                 ->with('title', sprintf(
                     '<strong>%s</strong> %s',
@@ -256,6 +289,11 @@ class DashComponentController extends Controller
                 ))
                 ->with('errors', $group->getErrors());
         }
+
+        segment_track('Dashboard', [
+            'event'   => 'Created Component Group',
+            'success' => true,
+        ]);
 
         $successMsg = sprintf(
             '<strong>%s</strong> %s',

--- a/src/Http/Controllers/DashIncidentController.php
+++ b/src/Http/Controllers/DashIncidentController.php
@@ -66,6 +66,11 @@ class DashIncidentController extends Controller
         $incident = Incident::create($incidentData);
 
         if (! $incident->isValid()) {
+            segment_track('Dashboard', [
+                'event'   => 'Created Incident',
+                'success' => false,
+            ]);
+
             return Redirect::back()->withInput(Binput::all())
                 ->with('title', sprintf(
                     '<strong>%s</strong> %s',
@@ -81,6 +86,11 @@ class DashIncidentController extends Controller
                 'status' => $componentStatus,
             ]);
         }
+
+        segment_track('Dashboard', [
+            'event'   => 'Created Incident',
+            'success' => true,
+        ]);
 
         $successMsg = sprintf(
             '<strong>%s</strong> %s',
@@ -127,6 +137,10 @@ class DashIncidentController extends Controller
      */
     public function deleteTemplateAction(IncidentTemplate $template)
     {
+        segment_track('Dashboard', [
+            'event' => 'Deleted Incident Template',
+        ]);
+
         $template->delete();
 
         return Redirect::back();
@@ -143,6 +157,11 @@ class DashIncidentController extends Controller
         $template = IncidentTemplate::create($_template);
 
         if (! $template->isValid()) {
+            segment_track('Dashboard', [
+                'event'   => 'Created Incident Template',
+                'success' => false,
+            ]);
+
             return Redirect::back()->withInput(Binput::all())
                 ->with('title', sprintf(
                     '<strong>%s</strong> %s',
@@ -151,6 +170,11 @@ class DashIncidentController extends Controller
                 ))
                 ->with('errors', $template->getErrors());
         }
+
+        segment_track('Dashboard', [
+            'event'   => 'Created Incident Template',
+            'success' => true,
+        ]);
 
         $successMsg = sprintf(
             '<strong>%s</strong> %s',
@@ -170,6 +194,10 @@ class DashIncidentController extends Controller
      */
     public function deleteIncidentAction(Incident $incident)
     {
+        segment_track('Dashboard', [
+            'event' => 'Deleted Incident',
+        ]);
+
         $incident->delete();
 
         return Redirect::back();
@@ -204,6 +232,11 @@ class DashIncidentController extends Controller
         $incident->update($_incident);
 
         if (! $incident->isValid()) {
+            segment_track('Dashboard', [
+                'event'   => 'Edited Incident',
+                'success' => false,
+            ]);
+
             return Redirect::back()->withInput(Binput::all())
                 ->with('title', sprintf(
                     '<strong>%s</strong> %s',
@@ -212,6 +245,11 @@ class DashIncidentController extends Controller
                 ))
                 ->with('errors', $incident->getErrors());
         }
+
+        segment_track('Dashboard', [
+            'event'   => 'Edited Incident',
+            'success' => true,
+        ]);
 
         $successMsg = sprintf(
             '<strong>%s</strong> %s',
@@ -231,6 +269,10 @@ class DashIncidentController extends Controller
      */
     public function editTemplateAction(IncidentTemplate $template)
     {
+        segment_track('Dashboard', [
+            'event' => 'Edited Incident Template',
+        ]);
+
         $template->update(Binput::get('template'));
 
         return Redirect::back()->with('updatedTemplate', $template);

--- a/src/Http/Controllers/DashTeamController.php
+++ b/src/Http/Controllers/DashTeamController.php
@@ -60,6 +60,11 @@ class DashTeamController extends Controller
         $user = User::create(Binput::all());
 
         if (! $user->isValid()) {
+            segment_track('Dashboard', [
+                'event'   => 'Added User',
+                'success' => false,
+            ]);
+
             return Redirect::back()->withInput(Binput::except('password'))
                 ->with('title', sprintf(
                     '<strong>%s</strong> %s',
@@ -68,6 +73,11 @@ class DashTeamController extends Controller
                 ))
                 ->with('errors', $user->getErrors());
         }
+
+        segment_track('Dashboard', [
+            'event'   => 'Added User',
+            'success' => true,
+        ]);
 
         $successMsg = sprintf(
             '<strong>%s</strong> %s',
@@ -98,6 +108,11 @@ class DashTeamController extends Controller
         $user->update($items);
 
         if (! $user->isValid()) {
+            segment_track('Dashboard', [
+                'event'   => 'Updated User',
+                'success' => false,
+            ]);
+
             return Redirect::back()->withInput(Binput::except('password'))
                 ->with('title', sprintf(
                     '<strong>%s</strong> %s',
@@ -106,6 +121,11 @@ class DashTeamController extends Controller
                 ))
                 ->with('errors', $user->getErrors());
         }
+
+        segment_track('Dashboard', [
+            'event'   => 'Updated User',
+            'success' => true,
+        ]);
 
         $successMsg = sprintf(
             '<strong>%s</strong> %s',

--- a/src/Http/Controllers/DashUserController.php
+++ b/src/Http/Controllers/DashUserController.php
@@ -39,8 +39,18 @@ class DashUserController extends Controller
         // Let's enable/disable auth
         if ($enable2FA && ! Auth::user()->hasTwoFactor) {
             $items['google_2fa_secret'] = Google2FA::generateSecretKey();
+
+            segment_track('User Management', [
+                'event' => 'enabled_two_factor',
+                'value' => true,
+            ]);
         } elseif (! $enable2FA) {
             $items['google_2fa_secret'] = '';
+
+            segment_track('User Management', [
+                'event' => 'enabled_two_factor',
+                'value' => false,
+            ]);
         }
 
         if (trim($passwordChange) === '') {
@@ -76,6 +86,10 @@ class DashUserController extends Controller
      */
     public function regenerateApiKey(User $user)
     {
+        segment_track('User Management', [
+            'event' => 'regenrated_api_token'
+        ]);
+
         $user->api_key = User::generateApiKey();
         $user->save();
 

--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -22,6 +22,10 @@ class HomeController extends Controller
      */
     public function showIndex()
     {
+        segment_track('Status Page', [
+            'event' => 'Landed',
+        ]);
+
         $components = Component::orderBy('order')->orderBy('created_at')->get();
 
         $allIncidents = [];
@@ -38,6 +42,21 @@ class HomeController extends Controller
             try {
                 // If date provided is valid
                 $oldDate = Date::createFromFormat('Y-m-d', Binput::get('start_date'));
+
+                segment_track('Status Page', [
+                    'start_date' => $oldDate->format('Y-m-d'),
+                ]);
+
+                if (Setting::get('app_tracking')) {
+                    Segment::track([
+                        'userId'     => Config::get('app.key'),
+                        'event'      => 'Home Page',
+                        'properties' => [
+                            'start_date' => $oldDate,
+                        ],
+                    ]);
+                }
+
                 // If trying to get a future date fallback to today
                 if ($today->gt($oldDate)) {
                     $startDate = $oldDate;

--- a/src/Http/Controllers/SetupController.php
+++ b/src/Http/Controllers/SetupController.php
@@ -47,6 +47,10 @@ class SetupController extends Controller
     {
         $postData = Binput::all();
 
+        segment_track('Setup', [
+            'step' => '1',
+        ]);
+
         $v = Validator::make($postData, [
             'settings.app_name'     => 'required',
             'settings.app_domain'   => 'required',
@@ -71,6 +75,10 @@ class SetupController extends Controller
     public function postStep2()
     {
         $postData = Binput::all();
+
+        segment_track('Setup', [
+            'step' => '2',
+        ]);
 
         $v = Validator::make($postData, [
             'settings.app_name'     => 'required',

--- a/src/Providers/LoadConfigServiceProvider.php
+++ b/src/Providers/LoadConfigServiceProvider.php
@@ -25,6 +25,10 @@ class LoadConfigServiceProvider extends ServiceProvider
             // Don't throw any errors, we may not be setup yet.
         }
 
+        // Set the Segment.com settings.
+        $segmentRepository = $this->app->make('CachetHQ\Cachet\Segment\RepositoryInterface');
+        $this->app->config->set('cachethq/segment::write_key', $segmentRepository->fetch());
+
         // Override default app values.
         $this->app->config->set('app.url', $appDomain ?: $this->app->config->get('app.url'));
         $this->app->config->set('app.locale', $appLocale ?: $this->app->config->get('app.locale'));

--- a/src/Providers/SegmentApiServiceProvider.php
+++ b/src/Providers/SegmentApiServiceProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace CachetHQ\Cachet\Providers;
+
+use CachetHQ\Cachet\Segment\CacheRepository;
+use CachetHQ\Cachet\Segment\HttpRepository;
+use GuzzleHttp\Client;
+use Illuminate\Support\ServiceProvider;
+
+class SegmentApiServiceProvider extends ServiceProvider
+{
+    /**
+     * Boot the service provider.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->singleton('CachetHQ\Cachet\Segment\RepositoryInterface', function () {
+            $url = 'https://gist.githubusercontent.com/jbrooksuk/5de24bc1cf90fb1a3d57/raw/cachet.json';
+            $guzzleClient = new Client();
+            $client = new HttpRepository($guzzleClient, $url);
+
+            return new CacheRepository($client);
+        });
+    }
+}

--- a/src/Segment/CacheRepository.php
+++ b/src/Segment/CacheRepository.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace CachetHQ\Cachet\Segment;
+
+use CachetHQ\Cachet\Facades\Setting;
+use CachetHQ\Cachet\Models\Setting as SettingModel;
+use Carbon\Carbon;
+
+class CacheRepository implements RepositoryInterface
+{
+    /**
+     * @var \CachetHQ\Cachet\Segment\HttpRepository
+     */
+    protected $repository;
+
+    /**
+     * Instantiates a new instance of the Cache Repository.
+     *
+     * @param \CachetHQ\Cachet\Segment\HttpRepository $repository
+     */
+    public function __construct(RepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * Determines whether to use the segment_write_key setting or to fetch a new.
+     *
+     * @return string
+     */
+    public function fetch()
+    {
+        // Firstly, does the setting exist?
+        if (false === ($writeKey = Setting::get('segment_write_key'))) {
+            // No, let's go fetch it.
+            $writeKey = $this->repository->fetch();
+            Setting::set('segment_write_key', $writeKey);
+        } else {
+            // It does, but how old is it?
+            $setting = SettingModel::where('name', 'segment_write_key')->first();
+
+            // It's older than an hour, let's refresh
+            if ($setting->updated_at->lt(Carbon::now()->subHour())) {
+                $writeKey = $this->repository->fetch();
+
+                // Update the setting. This is done manual to make sure updated_at is overwritten.
+                $setting->value = $writeKey;
+                $setting->updated_at = Carbon::now();
+                $setting->save();
+            }
+        }
+
+        return $writeKey;
+    }
+}

--- a/src/Segment/HttpRepository.php
+++ b/src/Segment/HttpRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace CachetHQ\Cachet\Segment;
+
+use GuzzleHttp\ClientInterface;
+
+class HttpRepository implements RepositoryInterface
+{
+    /**
+     * @var \Guzzle\GuzzleClient
+     */
+    protected $client;
+
+    /**
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * Instantiates a new instance of the SegmentApi class.
+     *
+     * @param \Guzzle\GuzzleClient $client
+     * @param string               $url
+     */
+    public function __construct(ClientInterface $client, $url)
+    {
+        $this->client = $client;
+        $this->url = $url;
+    }
+
+    /**
+     * Fetches the segment_write_key from the given url.
+     *
+     * @return string
+     */
+    public function fetch()
+    {
+        return $this->client->get($this->url)->json()['segment_write_key'];
+    }
+}

--- a/src/Segment/RepositoryInterface.php
+++ b/src/Segment/RepositoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace CachetHQ\Cachet\Segment;
+
+interface RepositoryInterface
+{
+    /**
+     * Returns the segment_write_key.
+     *
+     * @return string
+     */
+    public function fetch();
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+use CachetHQ\Cachet\Facades\Setting;
+use CachetHQ\Segment\Facades\Segment;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Request;
 
@@ -76,5 +78,79 @@ if (!function_exists('set_active')) {
         $class = implode(' ', $classes);
 
         return empty($classes) ? '' : "class=\"{$class}\"";
+    }
+}
+
+if (!function_exists('segment_identify')) {
+    /**
+     * Identifies the user for Segment.com.
+     *
+     * @return bool
+     */
+    function segment_identify()
+    {
+        if (Setting::get('app_track')) {
+            return Segment::identify([
+                'anonymousId' => Config::get('app.key'),
+                'context'     => [
+                    'locale'   => Config::get('app.locale'),
+                    'timezone' => Setting::get('app_timezone'),
+                ],
+            ]);
+        } else {
+            return false;
+        }
+    }
+}
+
+if (!function_exists('segment_track')) {
+    /**
+     * Tracks events in Segment.com.
+     *
+     * @param string $event
+     * @param array  $properties
+     *
+     * @return bool
+     */
+    function segment_track($event, array $properties)
+    {
+        if (Setting::get('app_track')) {
+            return Segment::track([
+                'anonymousId' => Config::get('app.key'),
+                'event'       => $event,
+                'properties'  => $properties,
+                'context'     => [
+                    'locale'   => Config::get('app.locale'),
+                    'timezone' => Setting::get('app_timezone'),
+                ],
+            ]);
+        } else {
+            return false;
+        }
+    }
+}
+
+if (!function_exists('segment_page')) {
+    /**
+     * Tracks pages in Segment.com.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    function segment_page($page)
+    {
+        if (Setting::get('app_track')) {
+            return Segment::page([
+                'anonymousId' => Config::get('app.key'),
+                'page'        => $page,
+                'context'     => [
+                    'locale'   => Config::get('app.locale'),
+                    'timezone' => Setting::get('app_timezone'),
+                ],
+            ]);
+        } else {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Closes #91.

We track a few things, but could easily add more, plus it's all anonymous!

# Things to do:

- [x] Setting of the Segment.com `write_key` should be based on an API result we fetch and store somewhere, this allows us to revoke it at any time from all status pages.
- [x] What happens if the API key is completely wrong and the new one is not installed? Does Segment lose its shit? **Nothing. It just doesn't work - this is good.**