### PR TITLE
Use CrowdIn's In-Context Localization Feature

### DIFF
--- a/app/config/langs.php
+++ b/app/config/langs.php
@@ -4,6 +4,7 @@ return [
     // Enabled langs
     'de'    => 'Deutsch',
     'en'    => 'English',
+    'en-UD' => 'CrowdIn - InContext Localization',
     'fr'    => 'Français',
     'pt-BR' => 'Portuguese, Brazilian',
 ];

--- a/app/lang/en-UD/cachet.php
+++ b/app/lang/en-UD/cachet.php
@@ -1,0 +1,47 @@
+<?php
+
+return [
+    // Components
+    'components' => [
+        'status' => [
+            1 => 'crwdns265:0crwdne265:0',
+            2 => 'crwdns293:0crwdne293:0',
+            3 => 'crwdns294:0crwdne294:0',
+            4 => 'crwdns295:0crwdne295:0',
+        ],
+    ],
+
+    // Incidents
+    'incidents' => [
+        'none'          => 'crwdns266:0crwdne266:0',
+        'past'          => 'crwdns296:0crwdne296:0',
+        'previous_week' => 'crwdns297:0crwdne297:0',
+        'next_week'     => 'crwdns298:0crwdne298:0',
+        'none'          => 'crwdns266:0crwdne266:0',
+        'status'        => [
+            1 => 'crwdns299:0crwdne299:0',
+            2 => 'crwdns300:0crwdne300:0',
+            3 => 'crwdns301:0crwdne301:0',
+            4 => 'crwdns302:0crwdne302:0',
+        ],
+    ],
+
+    // Service Status
+    'service' => [
+        'good' => 'crwdns9:0crwdne9:0',
+        'bad'  => 'crwdns303:0crwdne303:0',
+    ],
+
+    'api' => [
+        'regenerate' => 'crwdns271:0crwdne271:0',
+        'revoke'     => 'crwdns304:0crwdne304:0',
+    ],
+
+    // Other
+    'powered_by'      => 'crwdns11:0crwdne11:0',
+    'about_this_site' => 'crwdns150:0crwdne150:0',
+    'rss-feed'        => 'crwdns273:0crwdne273:0',
+    'atom-feed'       => 'crwdns274:0crwdne274:0',
+    'feed'            => 'crwdns275:0crwdne275:0',
+
+];

--- a/app/lang/en-UD/dashboard.php
+++ b/app/lang/en-UD/dashboard.php
@@ -1,0 +1,153 @@
+<?php
+
+return [
+
+    'dashboard' => 'crwdns152:0crwdne152:0',
+
+    // Incidents
+    'incidents' => [
+        'incidents'                => 'crwdns153:0crwdne153:0',
+        'logged'                   => 'crwdns305:0{0}crwdne305:0',
+        'incident-create-template' => 'crwdns306:0crwdne306:0',
+        'incident-templates'       => 'crwdns307:0crwdne307:0',
+        'add'                      => [
+            'title'   => 'crwdns308:0crwdne308:0',
+            'success' => 'crwdns309:0crwdne309:0',
+            'failure' => 'crwdns310:0crwdne310:0',
+        ],
+        'edit' => [
+            'title'   => 'crwdns311:0crwdne311:0',
+            'success' => 'crwdns312:0crwdne312:0',
+            'failure' => 'crwdns313:0crwdne313:0',
+        ],
+
+        // Incident templates
+        'templates' => [
+            'title' => 'crwdns314:0crwdne314:0',
+            'add'   => [
+                'title'   => 'crwdns315:0crwdne315:0',
+                'success' => 'crwdns316:0crwdne316:0',
+                'failure' => 'crwdns317:0crwdne317:0',
+            ],
+            'edit' => [
+                'title'   => 'crwdns318:0crwdne318:0',
+                'success' => 'crwdns319:0crwdne319:0',
+                'failure' => 'crwdns320:0crwdne320:0',
+            ],
+        ],
+    ],
+
+    // Components
+    'components' => [
+        'components'         => 'crwdns165:0crwdne165:0',
+        'component_statuses' => 'crwdns321:0crwdne321:0',
+        'add'                => [
+            'title'   => 'crwdns322:0crwdne322:0',
+            'message' => 'crwdns323:0crwdne323:0',
+            'success' => 'crwdns324:0crwdne324:0',
+            'failure' => 'crwdns325:0crwdne325:0',
+        ],
+        'edit' => [
+            'title'   => 'crwdns326:0crwdne326:0',
+            'success' => 'crwdns327:0crwdne327:0',
+            'failure' => 'crwdns328:0crwdne328:0',
+        ],
+
+        // Component groups
+        'groups' => [
+            'groups' => 'crwdns329:0crwdne329:0',
+            'add'    => [
+                'title'   => 'crwdns330:0crwdne330:0',
+                'success' => 'crwdns331:0crwdne331:0',
+                'failure' => 'crwdns332:0crwdne332:0',
+            ],
+        ],
+    ],
+
+    // Metrics
+    'metrics' => [
+        'metrics' => 'crwdns178:0crwdne178:0',
+        'add'     => [
+            'title'   => 'crwdns333:0crwdne333:0',
+            'success' => 'crwdns334:0crwdne334:0',
+            'failure' => 'crwdns335:0crwdne335:0',
+        ],
+    ],
+
+    // Team
+    'team' => [
+        'team'        => 'crwdns182:0crwdne182:0',
+        'member'      => 'crwdns336:0crwdne336:0',
+        'profile'     => 'crwdns337:0crwdne337:0',
+        'description' => 'crwdns338:0crwdne338:0',
+        'add'         => [
+            'title'   => 'crwdns339:0crwdne339:0',
+            'success' => 'crwdns340:0crwdne340:0',
+            'failure' => 'crwdns341:0crwdne341:0',
+        ],
+        'edit'        => [
+            'title'   => 'crwdns342:0crwdne342:0',
+            'success' => 'crwdns343:0crwdne343:0',
+            'failure' => 'crwdns344:0crwdne344:0',
+        ],
+    ],
+
+    // Settings
+    'settings' => [
+        'settings'  => 'crwdns192:0crwdne192:0',
+        'app-setup' => [
+            'app-setup'   => 'crwdns345:0crwdne345:0',
+            'images-only' => 'crwdns346:0crwdne346:0',
+            'too-big'     => 'crwdns347:0crwdne347:0',
+        ],
+        'security' => [
+            'security' => 'crwdns348:0crwdne348:0',
+        ],
+        'stylesheet' => [
+            'stylesheet' => 'crwdns349:0crwdne349:0',
+        ],
+        'theme' => [
+            'theme' => 'crwdns350:0crwdne350:0',
+        ],
+        'edit' => [
+            'success' => 'crwdns351:0crwdne351:0',
+            'failure' => 'crwdns352:0crwdne352:0',
+        ],
+    ],
+
+    // Login
+    'login' => [
+        'login'      => 'crwdns199:0crwdne199:0',
+        'logged_in'  => 'crwdns353:0crwdne353:0',
+        'welcome'    => 'crwdns354:0crwdne354:0',
+        'two-factor' => 'crwdns355:0crwdne355:0',
+    ],
+
+    // Sidebar footer
+    'help'        => 'crwdns202:0crwdne202:0',
+    'status_page' => 'crwdns203:0crwdne203:0',
+    'logout'      => 'crwdns204:0crwdne204:0',
+
+    // Notifications
+    'notifications'     => [
+        'notifications' => 'crwdns205:0crwdne205:0',
+        'awesome'       => 'crwdns356:0crwdne356:0',
+        'whoops'        => 'crwdns357:0crwdne357:0',
+    ],
+
+    // Welcome modal
+    'welcome' => [
+        'welcome' => 'crwdns358:0crwdne358:0',
+        'message' => 'crwdns359:0crwdne359:0',
+        'close'   => 'crwdns360:0crwdne360:0',
+        'steps'   => [
+            'component'  => 'crwdns361:0crwdne361:0',
+            'incident'   => 'crwdns362:0crwdne362:0',
+            'customize'  => 'crwdns363:0crwdne363:0',
+            'team'       => 'crwdns364:0crwdne364:0',
+            'api'        => 'crwdns365:0crwdne365:0',
+            'two-factor' => 'crwdns366:0crwdne366:0',
+        ],
+    ],
+
+];

--- a/app/lang/en-UD/errors.php
+++ b/app/lang/en-UD/errors.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'not-found' => [
+        'code'    => 'crwdns208:0crwdne208:0',
+        'title'   => 'crwdns367:0crwdne367:0',
+        'message' => 'crwdns368:0crwdne368:0',
+        'link'    => 'crwdns369:0crwdne369:0',
+    ],
+    'unauthorized' => [
+        'code'    => 'crwdns370:0crwdne370:0',
+        'title'   => 'crwdns371:0crwdne371:0',
+        'message' => 'crwdns372:0crwdne372:0',
+        'link'    => 'crwdns373:0crwdne373:0',
+    ],
+];

--- a/app/lang/en-UD/forms.php
+++ b/app/lang/en-UD/forms.php
@@ -1,0 +1,107 @@
+<?php
+
+return [
+
+    // Setup form fields
+    'setup' => [
+        'email'            => 'crwdns212:0crwdne212:0',
+        'username'         => 'crwdns374:0crwdne374:0',
+        'password'         => 'crwdns375:0crwdne375:0',
+        'site_name'        => 'crwdns376:0crwdne376:0',
+        'site_domain'      => 'crwdns377:0crwdne377:0',
+        'site_timezone'    => 'crwdns378:0crwdne378:0',
+        'site_locale'      => 'crwdns379:0crwdne379:0',
+        'enable_google2fa' => 'crwdns380:0crwdne380:0',
+    ],
+
+    // Login form fields
+    'login' => [
+        'email'         => 'crwdns217:0crwdne217:0',
+        'password'      => 'crwdns381:0crwdne381:0',
+        '2fauth'        => 'crwdns382:0crwdne382:0',
+        'invalid'       => 'crwdns383:0crwdne383:0',
+        'invalid-token' => 'crwdns384:0crwdne384:0',
+    ],
+
+    // Incidents form fields
+    'incidents' => [
+        'name'         => 'crwdns219:0crwdne219:0',
+        'status'       => 'crwdns385:0crwdne385:0',
+        'component'    => 'crwdns386:0crwdne386:0',
+        'message'      => 'crwdns387:0crwdne387:0',
+        'message-help' => 'crwdns388:0crwdne388:0',
+
+        'templates' => [
+            'name'     => 'crwdns389:0crwdne389:0',
+            'template' => 'crwdns390:0crwdne390:0',
+        ],
+    ],
+
+    // Components form fields
+    'components' => [
+        'name'        => 'crwdns225:0crwdne225:0',
+        'status'      => 'crwdns391:0crwdne391:0',
+        'group'       => 'crwdns392:0crwdne392:0',
+        'description' => 'crwdns393:0crwdne393:0',
+        'link'        => 'crwdns394:0crwdne394:0',
+        'tags'        => 'crwdns395:0crwdne395:0',
+        'tags-help'   => 'crwdns396:0crwdne396:0',
+
+        'groups' => [
+            'name' => 'crwdns397:0crwdne397:0',
+        ],
+    ],
+
+    // Settings
+    'settings' => [
+        /// Application setup
+        'app-setup' => [
+            'site-name'         => 'crwdns233:0crwdne233:0',
+            'site-url'          => 'crwdns398:0crwdne398:0',
+            'site-timezone'     => 'crwdns399:0crwdne399:0',
+            'site-locale'       => 'crwdns400:0crwdne400:0',
+            'date-format'       => 'crwdns401:0crwdne401:0',
+            'about-this-page'   => 'crwdns402:0crwdne402:0',
+            'days-of-incidents' => 'crwdns403:0crwdne403:0',
+            'banner'            => 'crwdns404:0crwdne404:0',
+            'banner-help'       => "crwdns405:0crwdne405:0",
+            'google-analytics'  => "crwdns406:0crwdne406:0",
+        ],
+        'security' => [
+            'allowed-domains'      => 'crwdns407:0crwdne407:0',
+            'allowed-domains-help' => 'crwdns408:0crwdne408:0',
+        ],
+        'stylesheet' => [
+            'custom-css' => 'crwdns409:0crwdne409:0',
+        ],
+        'theme' => [
+            'background-color' => 'crwdns410:0crwdne410:0',
+            'text-color'       => 'crwdns411:0crwdne411:0',
+        ],
+    ],
+
+    'user' => [
+        'username'       => 'crwdns244:0crwdne244:0',
+        'email'          => 'crwdns412:0crwdne412:0',
+        'password'       => 'crwdns413:0crwdne413:0',
+        'api-token'      => 'crwdns414:0crwdne414:0',
+        'api-token-help' => 'crwdns415:0crwdne415:0',
+        '2fa'            => [
+            'help' => 'crwdns416:0crwdne416:0',
+        ],
+    ],
+
+    // Buttons
+    'add'    => 'crwdns249:0crwdne249:0',
+    'save'   => 'crwdns250:0crwdne250:0',
+    'update' => 'crwdns251:0crwdne251:0',
+    'create' => 'crwdns252:0crwdne252:0',
+    'edit'   => 'crwdns253:0crwdne253:0',
+    'delete' => 'crwdns254:0crwdne254:0',
+    'submit' => 'crwdns255:0crwdne255:0',
+    'cancel' => 'crwdns256:0crwdne256:0',
+    'remove' => 'crwdns257:0crwdne257:0',
+
+    // Other
+    'optional' => 'crwdns417:0crwdne417:0',
+];

--- a/app/lang/en-UD/pagination.php
+++ b/app/lang/en-UD/pagination.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => 'crwdns89:0crwdne89:0',
+    'next'     => 'crwdns90:0crwdne90:0',
+
+];

--- a/app/lang/en-UD/reminders.php
+++ b/app/lang/en-UD/reminders.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reminder Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'password' => 'crwdns91:0crwdne91:0',
+    'user'     => 'crwdns92:0crwdne92:0',
+    'token'    => 'crwdns93:0crwdne93:0',
+    'sent'     => 'crwdns94:0crwdne94:0',
+    'reset'    => 'crwdns95:0crwdne95:0',
+
+];

--- a/app/lang/en-UD/setup.php
+++ b/app/lang/en-UD/setup.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'setup'             => 'crwdns258:0crwdne258:0',
+    'title'             => 'crwdns259:0crwdne259:0',
+    'service_details'   => 'crwdns260:0crwdne260:0',
+    'status_page_setup' => 'crwdns261:0crwdne261:0',
+    'show_support'      => 'crwdns262:0crwdne262:0',
+    'admin_account'     => 'crwdns263:0crwdne263:0',
+    'complete_setup'    => 'crwdns264:0crwdne264:0',
+    'completed'         => 'crwdns291:0crwdne291:0',
+    'finish_setup'      => 'crwdns292:0crwdne292:0',
+];

--- a/app/lang/en-UD/validation.php
+++ b/app/lang/en-UD/validation.php
@@ -1,0 +1,106 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | as the size rules. Feel free to tweak each of these messages here.
+    |
+    */
+
+    "accepted"             => "crwdns96:0crwdne96:0",
+    "active_url"           => "crwdns97:0crwdne97:0",
+    "after"                => "crwdns98:0crwdne98:0",
+    "alpha"                => "crwdns99:0crwdne99:0",
+    "alpha_dash"           => "crwdns100:0crwdne100:0",
+    "alpha_num"            => "crwdns101:0crwdne101:0",
+    "array"                => "crwdns102:0crwdne102:0",
+    "before"               => "crwdns103:0crwdne103:0",
+    "between"              => [
+        "numeric" => "crwdns104:0crwdne104:0",
+        "file"    => "crwdns418:0crwdne418:0",
+        "string"  => "crwdns419:0crwdne419:0",
+        "array"   => "crwdns420:0crwdne420:0",
+    ],
+    "boolean"              => "crwdns108:0crwdne108:0",
+    "confirmed"            => "crwdns109:0crwdne109:0",
+    "date"                 => "crwdns110:0crwdne110:0",
+    "date_format"          => "crwdns111:0crwdne111:0",
+    "different"            => "crwdns112:0crwdne112:0",
+    "digits"               => "crwdns113:0crwdne113:0",
+    "digits_between"       => "crwdns114:0crwdne114:0",
+    "email"                => "crwdns115:0crwdne115:0",
+    "exists"               => "crwdns116:0crwdne116:0",
+    "image"                => "crwdns117:0crwdne117:0",
+    "in"                   => "crwdns118:0crwdne118:0",
+    "integer"              => "crwdns119:0crwdne119:0",
+    "ip"                   => "crwdns120:0crwdne120:0",
+    "max"                  => [
+        "numeric" => "crwdns121:0crwdne121:0",
+        "file"    => "crwdns421:0crwdne421:0",
+        "string"  => "crwdns422:0crwdne422:0",
+        "array"   => "crwdns423:0crwdne423:0",
+    ],
+    "mimes"                => "crwdns125:0crwdne125:0",
+    "min"                  => [
+        "numeric" => "crwdns126:0crwdne126:0",
+        "file"    => "crwdns424:0crwdne424:0",
+        "string"  => "crwdns425:0crwdne425:0",
+        "array"   => "crwdns426:0crwdne426:0",
+    ],
+    "not_in"               => "crwdns130:0crwdne130:0",
+    "numeric"              => "crwdns131:0crwdne131:0",
+    "regex"                => "crwdns132:0crwdne132:0",
+    "required"             => "crwdns133:0crwdne133:0",
+    "required_if"          => "crwdns134:0crwdne134:0",
+    "required_with"        => "crwdns135:0crwdne135:0",
+    "required_with_all"    => "crwdns136:0crwdne136:0",
+    "required_without"     => "crwdns137:0crwdne137:0",
+    "required_without_all" => "crwdns138:0crwdne138:0",
+    "same"                 => "crwdns139:0crwdne139:0",
+    "size"                 => [
+        "numeric" => "crwdns140:0crwdne140:0",
+        "file"    => "crwdns427:0crwdne427:0",
+        "string"  => "crwdns428:0crwdne428:0",
+        "array"   => "crwdns429:0crwdne429:0",
+    ],
+    "unique"               => "crwdns144:0crwdne144:0",
+    "url"                  => "crwdns145:0crwdne145:0",
+    "timezone"             => "crwdns146:0crwdne146:0",
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom' => [
+        'attribute-name' => [
+            'rule-name' => 'crwdns147:0crwdne147:0',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap attribute place-holders
+    | with something more reader friendly such as E-Mail Address instead
+    | of "email". This simply helps us make messages a little cleaner.
+    |
+    */
+
+    'attributes' => [],
+
+];

--- a/app/views/layout/error.blade.php
+++ b/app/views/layout/error.blade.php
@@ -32,6 +32,8 @@
     </style>
     @endif
 
+    @include('partials.crowdin')
+
     <script src="{{ elixir('js/all.js') }}"></script>
 </head>
 <body class="error-page">

--- a/app/views/layout/master.blade.php
+++ b/app/views/layout/master.blade.php
@@ -40,6 +40,8 @@
 
     @include('partials.stylesheet')
 
+    @include('partials.crowdin')
+
     @if($stylesheet = Setting::get('stylesheet'))
     <style type="text/css">
     {{ $stylesheet }}

--- a/app/views/partials/crowdin.blade.php
+++ b/app/views/partials/crowdin.blade.php
@@ -1,0 +1,7 @@
+@if(Setting::get('app_locale') === 'en-UD')
+<script type="text/javascript">
+    var _jipt = [];
+    _jipt.push(['project', 'cachet']);
+</script>
+<script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
+@endif

--- a/app/views/partials/dashboard/head.blade.php
+++ b/app/views/partials/dashboard/head.blade.php
@@ -23,6 +23,8 @@
     <link href="//fonts.googleapis.com/css?family=Lato:300,400,700" rel="stylesheet" type="text/css">
     <link rel="stylesheet" href="{{ elixir('css/all.css') }}">
 
+    @include('partials.crowdin')
+
     <script type="text/javascript">
         var Global = {};
         Global.locale = '{{ Setting::get('app_locale') }}';


### PR DESCRIPTION
This is pretty cool, but will require some maintenance on my side.

Essentially if you set the locale to `en-UD` (via the dashboard) you'll then be shown the In-Context feature, where you can translate to a target language within the application. You have to set some kind of psuedo-language for the translation to sit within, I've chosen `en-UD` but it could be anything. This is just the simplest.

![image](https://cloud.githubusercontent.com/assets/246103/5899026/0524bc68-a54e-11e4-819e-53383cdec5fe.png)

Then you'll get all of this:

![image](https://cloud.githubusercontent.com/assets/246103/5899038/2b33d7c2-a54e-11e4-87be-030010b6cde3.png)

And now you can submit translations.

# Things to do

- [x] Turn CrowdIn JS into a partial file.
- [x] Perhaps move the pseudo language to something more obscure than `en-US`.

~~Once CrowdIn have fixed using of the short-array syntax this will be so much more awesome for us!~~