### PR TITLE
Use nginx instead of apache in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
-FROM php:5.6-apache
-
-# before building
-# run npm install
-# run node_modules/.bin/bower install
-# run node_modules/.bin/gulp
+FROM debian:jessie
 
 ENV DB_DRIVER=mysql \
     ENV=production \
@@ -11,43 +6,47 @@ ENV DB_DRIVER=mysql \
     DB_HOST= \
     DB_USERNAME= \
     DB_PASSWORD=
+
 COPY . /var/www/html/
 WORKDIR /var/www/html/
 
-RUN curl http://nodejs.org/dist/v0.10.35/node-v0.10.35-linux-x64.tar.gz -o /tmp/nodejs.tar.gz && \
-    tar xzf /tmp/nodejs.tar.gz -C /tmp && export PATH=/tmp/node-v0.10.35-linux-x64/bin:$PATH && \
+#using nodesource and debian jessie packages instead of compiling from scratch
+RUN DEBIAN_FRONTEND=noninteractive  \
+    echo "APT::Install-Recommends \"0\";" >> /etc/apt/apt.conf.d/02recommends && \
+    echo "APT::Install-Suggests \"0\";" >> /etc/apt/apt.conf.d/02recommends && \
+    apt-get -qq update && \
+    apt-get -qq install ca-certificates apt-transport-https && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68576280 && \
+    echo 'deb https://deb.nodesource.com/node jessie main' > /etc/apt/sources.list.d/nodesource.list && \
+    apt-get -qq update && \
+    apt-get -qq install \
+    nginx php5-fpm=5.* php5-curl php5-readline php5-mcrypt php5-mysql php5-apcu php5-cli \
+    git sqlite libsqlite3-dev nodejs curl supervisor && \
     npm install && node_modules/.bin/bower install --allow-root && node_modules/.bin/gulp && \
-    rm -rf /tmp/* node_modules/
+    rm -rf /tmp/* node_modules/ && \
+    apt-get clean && \
+    rm -r /var/lib/apt/lists/* && \
+    chown -R www-data /var/www/html
+
 # ensure the assets have been compiled
 RUN for d in public/{build,css,js} ; do test ! -d public/build && \
   echo "Run 'gulp' before building container" >&2 && exit 1 || : ; done
-
-RUN apt-get update && \
-  apt-get install -y curl libmcrypt-dev zlib1g-dev libxml2-dev \
-  git sqlite libsqlite3-dev --no-install-recommends && \
-  rm -r /var/lib/apt/lists/*
 
 # hardcode the Illuminate key in app/config/app.php. If you want security, feel free
 # to override the key in your own container with a 'php artisan key:generate' :)
 RUN sed -i "s/'key' => '\w.*/'key' => 'f20d3e5ae02125a94bd60203a4edfbde',/" app/config/app.php && \
     grep key app/config/app.php
 
-# Override the apache.conf in php:5.4-apache to point to the proper DocumentRoot
-# TODO this is pretty brittle and may break if php:5.4-apache changes
-RUN sed -i 's/^DocumentRoot .*/DocumentRoot \/var\/www\/html\/public/' /etc/apache2/apache2.conf && \
-    grep /var/www/html/public /etc/apache2/apache2.conf
-# public/.htaccess needs to use rewrite to let laravel do its thang
-RUN a2enmod rewrite
+# copy the various nginx and supervisor conf (to handle both fpm and nginx)
+RUN sed -i -e "s/;daemonize\s*=\s*yes/daemonize = no/g" /etc/php5/fpm/php-fpm.conf ;\
+    echo "daemon off;" >> /etc/nginx/nginx.conf ;\
+    ln -sf /var/www/html/php-fpm-pool.conf /etc/php5/fpm/pool.d/www.conf ;\
+    rm -f /etc/nginx/sites-enabled/* && rm -f /etc/nginx/conf.d/* && ln -sf /var/www/html/nginx-site.conf /etc/nginx/conf.d/default.conf
 
-# install dependencies. Note: PDO and XML are already in this base image
-RUN docker-php-ext-install zip && \
-    docker-php-ext-install mcrypt && \
-    docker-php-ext-install mbstring && \
-    docker-php-ext-install pdo_mysql
-RUN curl http://pecl.php.net/get/apcu-4.0.7.tgz -o /usr/src/php/ext/apcu.tar.gz && \
-    tar xzvf /usr/src/php/ext/apcu.tar.gz -C /usr/src/php/ext && \
-    mv /usr/src/php/ext/apcu-4.0.7 /usr/src/php/ext/apcu && \
-    docker-php-ext-install apcu
-RUN curl -sS https://getcomposer.org/installer | php
-RUN php composer.phar install --no-dev -o
+RUN curl -sS https://getcomposer.org/installer | php && php composer.phar install --no-dev -o
 
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+EXPOSE 8000
+
+CMD ["/usr/bin/supervisord"]

--- a/README.md
+++ b/README.md
@@ -53,14 +53,15 @@ Run a DB container (you can either pass in environment variables for the DB, or 
 ```bash
 $ export DB_USERNAME=cachet
 $ export DB_PASSWORD=cachet
+$ export DB_ROOT_PASSWORD=cachet
 $ export DB_DATABASE=cachet
-$ docker run --name mysql -e MYSQL_USER=$DB_USERNAME -e MYSQL_PASSWORD=$DB_PASSWORD -e MYSQL_DATABASE=$DB_DATABASE -d mysql
+$ docker run --name mysql -e MYSQL_USER=$DB_USERNAME -e MYSQL_PASSWORD=$DB_PASSWORD  -e MYSQL_ROOT_PASSWORD=$DB_ROOT_PASSWORD -e MYSQL_DATABASE=$DB_DATABASE -d mysql
 ```
 
 Initialize the DB if you havent yet:
 
 ```bash
-$ docker run --link mysql:mysql -e DB_HOST=mysql -e DB_DATABASE=$DB_DATABASE -e DB_USERNAME=$DB_USERNAME -e DB_PASSWORD=$DB_PASSWORD cachethq/cachet:latest php artisan migrate
+$ docker run --link mysql:mysql -e DB_HOST=mysql -e DB_DATABASE=$DB_DATABASE -e DB_USERNAME=$DB_USERNAME -e DB_PASSWORD=$DB_PASSWORD cachethq/cachet:latest php artisan migrate --force
 ```
 
 Run Cachet:

--- a/nginx-site.conf
+++ b/nginx-site.conf
@@ -1,0 +1,28 @@
+server {
+  listen   8000 default; ## listen for ipv4; this line is default and implied
+
+
+  root /var/www/html/public;
+  index index.php;
+
+  # Make site accessible from http://localhost/
+  server_name localhost;
+
+  location / {
+	 try_files $uri /index.php$is_args$args;	
+  }
+
+  # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+  #
+  location ~ \.php$ {
+
+		include fastcgi_params;
+								fastcgi_pass 127.0.0.1:9000;
+                fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+                fastcgi_index index.php;
+                fastcgi_keep_conn on;
+
+  }
+
+
+}

--- a/php-fpm-pool.conf
+++ b/php-fpm-pool.conf
@@ -1,0 +1,26 @@
+[www]
+
+user = www-data
+group = www-data
+
+listen = 127.0.0.1:9000
+
+request_terminate_timeout = 120s
+
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+chdir = /
+
+env[DB_DRIVER] = $DB_DRIVER
+env[DB_HOST] = $DB_HOST
+env[DB_DATABASE] = $DB_DATABASE
+env[DB_USERNAME] = $DB_USERNAME
+env[DB_PASSWORD] = $DB_PASSWORD
+
+
+[global]
+
+daemonize = no

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,25 @@
+[unix_http_server]
+file=/var/run/supervisor.sock   ; (the path to the socket file)
+
+[supervisord]
+logfile=/dev/null             ; (main log file;default $CWD/supervisord.log)
+logfile_maxbytes=0            ; (max main logfile bytes b4 rotation;default 50MB)
+logfile_backups=0             ; (num of main logfile rotation backups;default 10)
+loglevel=info                 ; (log level;default info; others: debug,warn,trace)
+pidfile=/tmp/supervisord.pid  ; (supervisord pidfile;default supervisord.pid)
+nodaemon=true                 ; (start in foreground if true;default false)
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[program:php5-fpm]
+command=/usr/sbin/php5-fpm -c /etc/php5/fpm
+
+[program:nginx]
+command=/usr/sbin/nginx


### PR DESCRIPTION
As discussed in https://github.com/cachethq/Cachet/issues/448

This image use debian:jessie instead of php:56-apache (which uses jessie as well)

I'm sure it could be optimised further, but it's working as expected. I also amended the documentation as I could not get artisan migrate to work without passing it --force.