### PR TITLE
Fixed failing docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN echo "APT::Install-Recommends \"0\";" >> /etc/apt/apt.conf.d/02recommends &&
     apt-get -qq install \
     ca-certificates nginx php5-fpm=5.* php5-curl php5-readline php5-mcrypt php5-mysql php5-apcu php5-cli \
     git sqlite libsqlite3-dev curl supervisor && \
-    apt-get clean && apt-get autoremove -qq \
+    apt-get clean && apt-get autoremove -qq && \
     rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man /var/log/* /tmp/* && \
     chown -R www-data /var/www/html
 


### PR DESCRIPTION
I've fixed the issue with the failing docker build. Looks like two && where missing from one of the RUN commands.

Fixes #480 