### PR TITLE
Allow supplying of metric point timestamps. Closes #519.

### DIFF
--- a/src/Http/Controllers/Api/MetricPointController.php
+++ b/src/Http/Controllers/Api/MetricPointController.php
@@ -51,7 +51,20 @@ class MetricPointController extends Controller
      */
     public function postMetricPoints($id)
     {
-        return $this->metricPoint->create($id, Binput::all());
+        $pointData = Binput::except('timestamp');
+
+        if ($metric = $this->metricPoint->create($id, $pointData)) {
+            if ($tstamp = Binput::get('timestamp')) {
+                $timestamp = date('Y-m-d H:i:s', $tstamp);
+
+                $metric->update([
+                    'created_at' => $timestamp,
+                    'updated_at' => $timestamp,
+                ]);
+            }
+        }
+
+        return $metric;
     }
 
     /**

--- a/src/Models/MetricPoint.php
+++ b/src/Models/MetricPoint.php
@@ -21,7 +21,7 @@ class MetricPoint extends Model
      *
      * @var string[]
      */
-    protected $fillable = ['metric_id', 'value'];
+    protected $fillable = ['metric_id', 'value', 'created_at', 'updated_at'];
 
     /**
      * The validation rules.


### PR DESCRIPTION
If you supply a `timestamp` (in unix) it'll be applied to the `created_at` and `updated_at` values, so you can backfill metric points.