### PR TITLE
add maintenance translations

### DIFF
--- a/app/lang/fr/cachet.php
+++ b/app/lang/fr/cachet.php
@@ -18,6 +18,8 @@ return [
         'previous_week' => 'Semaine précédente',
         'next_week'     => 'Semaine suivante',
         'none'          => 'Rien à reporter',
+        'scheduled'     => 'Maintenance planifiée',
+        'scheduled_at'  => ', prévue à :timestamp',
         'status'        => [
             0 => '',
             1 => 'Enquête en cours',
@@ -36,6 +38,15 @@ return [
     'api' => [
         'regenerate' => 'Regénérer une clé d\'API',
         'revoke'     => 'Révoquer cette clé d\'API',
+    ],
+
+    // Metrics
+    'metrics' => [
+        'filter' => [
+            'hourly'  => 'Par heure',
+            'daily'   => 'Par jour',
+            'monthly' => 'Par mois',
+        ],
     ],
 
     // Other

--- a/app/lang/fr/dashboard.php
+++ b/app/lang/fr/dashboard.php
@@ -36,6 +36,26 @@ return [
         ],
     ],
 
+    // Incident Maintenance
+    'schedule' => [
+        'schedule'     => 'Maintenance planifiée',
+        'scheduled_at' => 'Prévue à :timestamp',
+        'add'          => [
+            'title'   => 'Ajouter une maintenance planifiée',
+            'success' => 'Maintenance ajoutée.',
+            'failure' => 'Une erreur s\'est produite lors de l\'ajout de la maintenance.',
+        ],
+        'edit' => [
+            'title'   => 'Éditer la maintenance',
+            'success' => 'Maintenance mise à jour!',
+            'failure' => 'Une erreur s\'est produite lors de la modification de la maintenance.',
+        ],
+        'delete' => [
+            'success' => 'La maintenance a été effacée et ne s\'affihera plus..',
+            'failure' => 'La maintenance n\'a pu être effacée. Veuillez essayez de nouveau.',
+        ],
+    ],
+
     // Components
     'components' => [
         'components'         => 'Composantes',


### PR DESCRIPTION
it's unclear to me why those parts of the array weren't present in the first place.

it would be easier to maintain translations if it was using standard formats like the de-facto `gettext` standard: https://en.wikipedia.org/wiki/Gettext