### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ APP_ENV=local
 APP_DEBUG=true
 APP_KEY=SomeRandomString
 
+DB_DRIVER=sqlite
 DB_HOST=localhost
 DB_DATABASE=cachet
 DB_USERNAME=user


### PR DESCRIPTION
DB_DRIVER is default set to sqlite. Anyone starting the project intending to use MySQL will have to look around to see to add that declaration here. Best add it to the example file to save them the hassle.