### PR TITLE
Add PHP pgsql driver to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "APT::Install-Recommends \"0\";" >> /etc/apt/apt.conf.d/02recommends &&
     apt-get -qq update && \
     apt-get -qq install \
     ca-certificates nginx php5-fpm=5.* php5-curl php5-readline php5-mcrypt php5-mysql php5-apcu php5-cli \
-    git sqlite libsqlite3-dev curl supervisor && \
+    git sqlite libsqlite3-dev curl supervisor php5-pgsql && \
     apt-get clean && apt-get autoremove -qq && \
     rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man /tmp/* && \
     chown -R www-data /var/www/html


### PR DESCRIPTION
This fixes not being able to use Cachet with Docker and Postgres (with the `-e DB_DRIVER=pgsql` option)