### PR TITLE
Refactored the way incidents are pulled out of the database on the homepage

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -74,23 +74,24 @@ class HomeController extends AbstractController
             $metrics = Metric::where('display_chart', 1)->get();
         }
 
-        $allIncidents = [];
         $daysToShow = Setting::get('app_incident_days') ?: 7;
         $incidentDays = range(0, $daysToShow);
         $dateFormat = Setting::get('date_format') ?: 'jS F Y';
 
-        foreach ($incidentDays as $i) {
+        $allIncidents = Incident::notScheduled()->whereBetween('created_at', [
+            $startDate->copy()->subDays($daysToShow)->format('Y-m-d').' 00:00:00',
+            $startDate->format('Y-m-d').' 23:59:59',
+        ])->orderBy('created_at', 'desc')->get()->groupBy(function(Incident $incident) use ($dateFormat) {
+            return $incident->created_at->format($dateFormat);
+        });
+
+        // Add in days that have no incidents
+        foreach($incidentDays as $i) {
             $date = $startDate->copy()->subDays($i);
 
-            $incidents = Incident::notScheduled()->whereBetween('created_at', [
-                $date->format('Y-m-d').' 00:00:00',
-                $date->format('Y-m-d').' 23:59:59',
-            ])->orderBy('created_at', 'desc')->get();
-
-            $allIncidents[] = [
-                'date'      => (new Date($date->toDateString()))->format($dateFormat),
-                'incidents' => $incidents,
-            ];
+            if (!isset($allIncidents[$date->format($dateFormat)])) {
+                $allIncidents[$date->format($dateFormat)] = [];
+            }
         }
 
         // Scheduled maintenance code.

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -81,12 +81,12 @@ class HomeController extends AbstractController
         $allIncidents = Incident::notScheduled()->whereBetween('created_at', [
             $startDate->copy()->subDays($daysToShow)->format('Y-m-d').' 00:00:00',
             $startDate->format('Y-m-d').' 23:59:59',
-        ])->orderBy('created_at', 'desc')->get()->groupBy(function(Incident $incident) use ($dateFormat) {
+        ])->orderBy('created_at', 'desc')->get()->groupBy(function (Incident $incident) use ($dateFormat) {
             return $incident->created_at->format($dateFormat);
         });
 
         // Add in days that have no incidents
-        foreach($incidentDays as $i) {
+        foreach ($incidentDays as $i) {
             $date = $startDate->copy()->subDays($i);
 
             if (!isset($allIncidents[$date->format($dateFormat)])) {

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -34,8 +34,8 @@
     @endif
 
     <h1>{{ trans('cachet.incidents.past') }}</h1>
-    @foreach($allIncidents as $incidents)
-    @include('partials.incidents', $incidents)
+    @foreach($allIncidents as $date => $incidents)
+    @include('partials.incidents', compact('date', 'incidents'))
     @endforeach
     <hr>
 


### PR DESCRIPTION
Rather than run a query for _each_ day, this will pull all incidents for the given range out at once and then add the days with no incidents in it.