### PR TITLE
controller class names made case sensitive for router

### DIFF
--- a/app/Http/Routes/AdminRoutes.php
+++ b/app/Http/Routes/AdminRoutes.php
@@ -198,9 +198,9 @@ class AdminRoutes
             // Internal API.
             // This should only be used for making requests within the dashboard.
             $router->group(['prefix' => 'api'], function ($router) {
-                $router->get('incidents/templates', 'APIController@getIncidentTemplate');
-                $router->post('components/order', 'APIController@postUpdateComponentOrder');
-                $router->post('components/{component}', 'APIController@postUpdateComponent');
+                $router->get('incidents/templates', 'ApiController@getIncidentTemplate');
+                $router->post('components/order', 'ApiController@postUpdateComponentOrder');
+                $router->post('components/{component}', 'ApiController@postUpdateComponent');
             });
         });
     }


### PR DESCRIPTION
The internal dashboard API routes (sorting components, changing component status) were giving 500 errors.

Turns out, my server is pretty strict about case sensitive class names.
The class is called **ApiController**, but was referenced as **APIController** in the router.

I did not have this problem on my OSX dev machine, but it might also be the problem of #524