### PR TITLE
Incident visibility

### DIFF
--- a/app/Http/Controllers/Api/IncidentController.php
+++ b/app/Http/Controllers/Api/IncidentController.php
@@ -24,13 +24,16 @@ class IncidentController extends AbstractApiController
      * Get all incidents.
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \CachetHQ\Cachet\Models\Incident          $incident
+     * @param \Illuminate\Contracts\Auth\Guard          $auth
      *
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function getIncidents(Request $request)
+    public function getIncidents(Request $request, Guard $auth)
     {
-        $incidents = Incident::paginate(Binput::get('per_page', 20));
+        $incidentVisiblity = $auth->check() ? 0 : 1;
+
+        $incidents = Incident::where('visible', '>=', $incidentVisiblity)
+            ->paginate(Binput::get('per_page', 20));
 
         return $this->paginator($incidents, $request);
     }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -19,6 +19,7 @@ use CachetHQ\Cachet\Models\Metric;
 use Exception;
 use GrahamCampbell\Binput\Facades\Binput;
 use GrahamCampbell\Markdown\Facades\Markdown;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\View;
 use Jenssegers\Date\Date;
 
@@ -65,7 +66,9 @@ class HomeController extends AbstractController
         $incidentDays = range(0, $daysToShow - 1);
         $dateTimeZone = Setting::get('app_timezone');
 
-        $allIncidents = Incident::notScheduled()->whereBetween('created_at', [
+        $incidentVisiblity = Auth::check() ? 0 : 1;
+
+        $allIncidents = Incident::notScheduled()->where('visible', '>=', $incidentVisiblity)->whereBetween('created_at', [
             $startDate->copy()->subDays($daysToShow)->format('Y-m-d').' 00:00:00',
             $startDate->format('Y-m-d').' 23:59:59',
         ])->orderBy('created_at', 'desc')->get()->groupBy(function (Incident $incident) use ($dateTimeZone) {

--- a/app/Models/Incident.php
+++ b/app/Models/Incident.php
@@ -42,6 +42,7 @@ class Incident extends Model implements HasPresenter
         'component_id' => 'integer',
         'name'         => 'required',
         'status'       => 'required|integer',
+        'visible'      => 'required|boolean',
         'message'      => 'required',
     ];
 
@@ -54,6 +55,7 @@ class Incident extends Model implements HasPresenter
         'component_id',
         'name',
         'status',
+        'visible',
         'message',
         'scheduled_at',
         'created_at',
@@ -73,6 +75,18 @@ class Incident extends Model implements HasPresenter
      * @var string[]
      */
     protected $dates = ['scheduled_at', 'deleted_at'];
+
+    /**
+     * Finds all visible incidents.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeVisible($query)
+    {
+        return $query->where('visible', 1);
+    }
 
     /**
      * Finds all scheduled incidents (maintenance).

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -36,6 +36,7 @@ $factory->define('CachetHQ\Cachet\Models\Incident', function ($faker) {
         'name'    => $faker->sentence(),
         'message' => $faker->paragraph(),
         'status'  => 1,
+        'visible' => 1,
     ];
 });
 

--- a/database/migrations/2015_05_20_073041_AlterTableIncidentsAddVisibileColumn.php
+++ b/database/migrations/2015_05_20_073041_AlterTableIncidentsAddVisibileColumn.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) James Brooks <james@cachethq.io>
+ * (c) Joseph Cohen <joseph.cohen@dinkbit.com>
+ * (c) Graham Campbell <graham@mineuk.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterTableIncidentsAddVisibileColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('incidents', function (Blueprint $table) {
+            $table->boolean('visible')->after('status')->default(1);
+
+            $table->index('visible');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('incidents', function (Blueprint $table) {
+            $table->dropColumn('visible');
+        });
+    }
+}

--- a/resources/lang/en/forms.php
+++ b/resources/lang/en/forms.php
@@ -45,8 +45,10 @@ return [
         'scheduled_at'       => 'When to schedule the maintenance for?',
         'incident_time'      => 'When did this incident occur?',
         'notify_subscribers' => 'Notify subscribers',
-
-        'templates' => [
+        'visibility'         => 'Incident Visibility',
+        'public'             => 'Viewable by public',
+        'logged_in_only'     => 'Only visible logged in users',
+        'templates'          => [
             'name'     => 'Name',
             'template' => 'Template',
         ],

--- a/resources/views/dashboard/incidents/add.blade.php
+++ b/resources/views/dashboard/incidents/add.blade.php
@@ -55,6 +55,13 @@
                                 {{ trans('cachet.incidents.status')[4] }}
                             </label>
                         </div>
+                        <div class="form-group">
+                            <label for="incident-name">{{ trans('forms.incidents.visibility') }}</label>
+                            <select name='incident[visible]' class="form-control">
+                                <option value='1' selected>{{ trans('forms.incidents.public') }}</option>
+                                <option value='0'>{{ trans('forms.incidents.logged_in_only') }}</option>
+                            </select>
+                        </div>
                         @if(!$componentsInGroups->isEmpty() || !$componentsOutGroups->isEmpty())
                         <div class="form-group">
                             <label>{{ trans('forms.incidents.component') }}</label>

--- a/resources/views/dashboard/incidents/edit.blade.php
+++ b/resources/views/dashboard/incidents/edit.blade.php
@@ -45,6 +45,13 @@
                             </label>
                         </div>
                         <div class="form-group">
+                            <label for="incident-visibility">{{ trans('forms.incidents.visibility') }}</label>
+                            <select name='incident[visible]' id="incident-visibility" class="form-control">
+                                <option value='1' {{ $incident->visible === 1 ? 'selected' : null }}>{{ trans('forms.incidents.public') }}</option>
+                                <option value='0' {{ $incident->visible === 0 ? 'selected' : null }}>{{ trans('forms.incidents.logged_in_only') }}</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
                             <label>{{ trans('forms.incidents.message') }}</label>
                             <div class='markdown-control'>
                                 <textarea name="incident[message]" class="form-control autosize" rows="5" required>{{ $incident->message }}</textarea>

--- a/tests/Api/IncidentTest.php
+++ b/tests/Api/IncidentTest.php
@@ -58,6 +58,7 @@ class IncidentTest extends AbstractTestCase
             'name'    => 'Foo',
             'message' => 'Lorem ipsum dolor sit amet',
             'status'  => 1,
+            'visible' => 1,
         ]);
         $this->seeJson(['name' => 'Foo']);
         $this->assertResponseOk();


### PR DESCRIPTION
Working on #602 but cannot finish this until we can see if the user is logged in when using the API as we'll need to default to showing public incidents, unless a valid `X-Cachet-Token` is received in which case we'll send the hidden ones too.