### PR TITLE
Upgraded to laravel exceptions 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "graham-campbell/binput": "^3.0",
         "graham-campbell/markdown": "^3.0",
         "graham-campbell/throttle": "^3.0",
-        "graham-campbell/exceptions": "^1.0",
+        "graham-campbell/exceptions": "^2.0",
         "guzzlehttp/guzzle": "^5.0",
         "jenssegers/date": "^2.0.21",
         "mccool/laravel-auto-presenter": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5df75070dd0d8fd0c65522680dd5614a",
+    "hash": "e9aed955b875697ff5c3c5314ab2cd2e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -955,34 +955,34 @@
         },
         {
             "name": "graham-campbell/exceptions",
-            "version": "v1.0.0",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GrahamCampbell/Laravel-Exceptions.git",
-                "reference": "ac5412d5aca9a2d4dafebf5f85dcb5abcc6d4e25"
+                "reference": "c114242ab593a6693ff96e72aeeb44ce76e27d9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GrahamCampbell/Laravel-Exceptions/zipball/ac5412d5aca9a2d4dafebf5f85dcb5abcc6d4e25",
-                "reference": "ac5412d5aca9a2d4dafebf5f85dcb5abcc6d4e25",
+                "url": "https://api.github.com/repos/GrahamCampbell/Laravel-Exceptions/zipball/c114242ab593a6693ff96e72aeeb44ce76e27d9b",
+                "reference": "c114242ab593a6693ff96e72aeeb44ce76e27d9b",
                 "shasum": ""
             },
             "require": {
                 "filp/whoops": "1.1.*",
-                "illuminate/contracts": "5.0.*",
-                "illuminate/support": "5.0.*",
-                "php": ">=5.5.0",
+                "illuminate/contracts": "5.0.*|5.1.*",
+                "illuminate/support": "5.0.*|5.1.*",
+                "php": ">=5.5.9",
                 "psr/log": "~1.0",
-                "symfony/debug": "2.6.*",
-                "symfony/http-foundation": "2.6.*"
+                "symfony/debug": "2.6.*|2.7.*",
+                "symfony/http-foundation": "2.6.*|2.7.*"
             },
             "require-dev": {
-                "graham-campbell/testbench": "~2.0"
+                "graham-campbell/testbench": "~2.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1014,7 +1014,7 @@
                 "laravel",
                 "whoops"
             ],
-            "time": "2015-02-04 20:18:59"
+            "time": "2015-05-21 19:37:10"
         },
         {
             "name": "graham-campbell/markdown",

--- a/config/exceptions.php
+++ b/config/exceptions.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Cachet HQ <support@cachethq.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Exception Displayers
+    |--------------------------------------------------------------------------
+    |
+    | Here are each of the exception displayers setup for your application.
+    |
+    | These displayers are sorted by priority. Note that when we are in debug
+    | mode, we will select the first valid displayer from the list, and when we
+    | are not in debug mode, we'll filter out all verbose displayers, then
+    | select the first valid displayer from the new list.
+    |
+    */
+
+    'displayers' => [
+        'GrahamCampbell\Exceptions\Displayers\DebugDisplayer',
+        'GrahamCampbell\Exceptions\Displayers\HtmlDisplayer',
+        'GrahamCampbell\Exceptions\Displayers\JsonDisplayer',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Displayer Filters
+    |--------------------------------------------------------------------------
+    |
+    | Here are each of the filters for the displayers.
+    |
+    | This allows you to apply filters to your displayers in order to work out
+    | which displayer to use for each exception. This includes things like
+    | content type negotiation.
+    |
+    */
+
+    'filters' => [
+        'GrahamCampbell\Exceptions\Filters\VerboseFilter',
+        'GrahamCampbell\Exceptions\Filters\CanDisplayFilter',
+        'GrahamCampbell\Exceptions\Filters\ContentTypeFilter',
+    ],
+
+];


### PR DESCRIPTION
Again, this is needed before I can upgrade us to L5.1. We need to be careful with this one, as this could be quite breaking. Do we have any "ajax" requests that are expecting json only. If so, we need to make sure we're setting the correct accept headers on those requests before continuing with this.