### PR TITLE
Don't allow php 7 installs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
+        "php": "^5.5.9",
         "laravel/framework": "5.1.*",
         "cachethq/segment": "^2.1",
         "doctrine/dbal": "^2.5",


### PR DESCRIPTION
We can't support php5 and php7 at the same time due to the fact carbon doesn't work. We need to choose a time to drop php5 and move to php7 in the future. I suggest maybe 20 Jun 2016 is a good date to do this. That's when php 5.5 stops reviewing security updates, and php 7.0 should be available on ubuntu 16.04 LTS by then. :)

N.B. I haven't updated the lock file yet since this was done from github's gui.