### PR TITLE
Use HTML version of incident message in atom feed

### DIFF
--- a/app/Http/Controllers/AtomController.php
+++ b/app/Http/Controllers/AtomController.php
@@ -14,9 +14,9 @@ namespace CachetHQ\Cachet\Http\Controllers;
 use CachetHQ\Cachet\Facades\Setting;
 use CachetHQ\Cachet\Models\ComponentGroup;
 use CachetHQ\Cachet\Models\Incident;
+use GrahamCampbell\Markdown\Facades\Markdown;
 use Illuminate\Support\Str;
 use Roumen\Feed\Facades\Feed;
-use GrahamCampbell\Markdown\Facades\Markdown;
 
 class AtomController extends AbstractController
 {

--- a/app/Http/Controllers/AtomController.php
+++ b/app/Http/Controllers/AtomController.php
@@ -16,6 +16,7 @@ use CachetHQ\Cachet\Models\ComponentGroup;
 use CachetHQ\Cachet\Models\Incident;
 use Illuminate\Support\Str;
 use Roumen\Feed\Facades\Feed;
+use GrahamCampbell\Markdown\Facades\Markdown;
 
 class AtomController extends AbstractController
 {
@@ -65,7 +66,7 @@ class AtomController extends AbstractController
             Setting::get('app_name'),
             Str::canonicalize(Setting::get('app_domain')).'#'.$incident->id,
             $incident->created_at->toAtomString(),
-            $incident->message
+            Markdown::convertToHtml($incident->message)
         );
     }
 }


### PR DESCRIPTION
Atom (not RSS) feeds are able to handle html in entry content, so it
makes sense to put HTML version of incident in it.