### PR TITLE
Docker compose support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,23 @@ Now go to `http://<ipdockerisboundto>/setup` and have fun!
 Note: When running in production you should ensure that you enable SSL.
 This is commonly achieved by running Nginx with your certificates on your Docker host, service or load balancers in-front of the running container, or by adding your custom SSL certificates and configuration to the supplied Nginx configuration.
 
+### docker-compose
+Quickly launch Cachet and MySQL docker images with [docker-compose](https://docs.docker.com/compose/)
+
+```bash
+git clone https://github.com/cachethq/Cachet.git
+cd Cachet
+docker-compose build
+docker-compose up
+```
+
+To initialize the database, utilize [docker exec](https://docs.docker.com/reference/commandline/cli/#exec):
+```bash
+docker exec -it cachet_cachet_1 php artisan migrate --force
+```
+
+Continue to `http://<ipdockerisboundto>/setup` to configure Cachet.
+
 ## Addons
 
 - [cachet-monitor](https://github.com/castawaylabs/cachet-monitor) - For URL monitoring. Automatic incident updates.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+mysql:
+  image: mysql:5.6
+  environment:
+    - MYSQL_ROOT_PASSWORD=cachet
+    - MYSQL_DATABASE=cachet
+    - MYSQL_USER=cachet
+    - MYSQL_PASSWORD=cachet
+cachet:
+  build: . 
+  ports:
+    - 80:8000
+  links:
+    - mysql:mysql
+  environment:
+    - DB_HOST=mysql
+    - DB_DATABASE=cachet
+    - DB_USERNAME=cachet
+    - DB_PASSWORD=cachet


### PR DESCRIPTION
Adds a `docker-compose.yml` to quickly setup and link a set of mysql and Cachet containers for demo purposes.

I wasn't quite sure we wanted it to pull and user the cachet image from the docker hub, or have it do a build locally. (Currently it does the pull from docker hub)


