### PR TITLE
Don't HTML escape custom stylesheet

### DIFF
--- a/resources/views/layout/master.blade.php
+++ b/resources/views/layout/master.blade.php
@@ -41,7 +41,7 @@
 
     @if($stylesheet = Setting::get('stylesheet'))
     <style type="text/css">
-    {{ $stylesheet }}
+    {!! $stylesheet !!}
     </style>
     @endif
 


### PR DESCRIPTION
If you HTML escape the custom stylesheet, you can't have quotes in it.
You need quotes if you want to add something with url('foo') (in a
background-image by exemple).