### PR TITLE
Fix piwik missing slash problem

### DIFF
--- a/resources/views/layout/master.blade.php
+++ b/resources/views/layout/master.blade.php
@@ -41,7 +41,7 @@
 
     @if($stylesheet = Setting::get('stylesheet'))
     <style type="text/css">
-    {{ $stylesheet }}
+    {!! $stylesheet !!}
     </style>
     @endif
 

--- a/resources/views/partials/analytics.blade.php
+++ b/resources/views/partials/analytics.blade.php
@@ -26,10 +26,10 @@
   _paq.push(['enableLinkTracking']);
   (function() {
     var u="//{{ $piwikTracking }}";
-    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setTrackerUrl', u+'/piwik.php']);
     _paq.push(['setSiteId', {{ Setting::get('app_analytics_pi_siteid', 1) }}]);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'/piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
 <noscript><p><img src="//{{ $piwikTracking }}/piwik.php?idsite={{ Setting::get('app_analytics_pi_siteid', 1) }}" style="border:0;" alt="" /></p></noscript>


### PR DESCRIPTION
If there is no trailing slash in the Piwik URL, it won't load piwk.js. I added a slash in the view to fix it.