### PR TITLE
Fix piwik missing slash problem

### DIFF
--- a/resources/views/partials/analytics.blade.php
+++ b/resources/views/partials/analytics.blade.php
@@ -18,7 +18,7 @@
   _gs('{{ $gosquaredTracking }}');
 </script>
 @endif
-@if($piwikTracking = Setting::get('app_analytics_pi_url'))
+@if($piwikTracking = rtrim(Setting::get('app_analytics_pi_url'), '/'))
 <!-- Piwik -->
 <script type="text/javascript">
   var _paq = _paq || [];
@@ -26,10 +26,10 @@
   _paq.push(['enableLinkTracking']);
   (function() {
     var u="//{{ $piwikTracking }}";
-    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setTrackerUrl', u+'/piwik.php']);
     _paq.push(['setSiteId', {{ Setting::get('app_analytics_pi_siteid', 1) }}]);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'/piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
 <noscript><p><img src="//{{ $piwikTracking }}/piwik.php?idsite={{ Setting::get('app_analytics_pi_siteid', 1) }}" style="border:0;" alt="" /></p></noscript>


### PR DESCRIPTION
If there is no trailing slash in the Piwik URL, it won't load piwk.js or piwik.php. I added a slash in the view to fix it.