### PR TITLE
Set default database engine in migrations

### DIFF
--- a/database/migrations/2015_01_05_201324_CreateComponentGroupsTable.php
+++ b/database/migrations/2015_01_05_201324_CreateComponentGroupsTable.php
@@ -22,7 +22,7 @@ class CreateComponentGroupsTable extends Migration
     {
         Schema::create('component_groups', function (Blueprint $table) {
             $table->engine = 'InnoDB';
-            
+
             $table->increments('id');
             $table->string('name');
             $table->timestamps();

--- a/database/migrations/2015_01_05_201324_CreateComponentGroupsTable.php
+++ b/database/migrations/2015_01_05_201324_CreateComponentGroupsTable.php
@@ -21,6 +21,8 @@ class CreateComponentGroupsTable extends Migration
     public function up()
     {
         Schema::create('component_groups', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->string('name');
             $table->timestamps();

--- a/database/migrations/2015_01_05_201444_CreateComponentsTable.php
+++ b/database/migrations/2015_01_05_201444_CreateComponentsTable.php
@@ -22,7 +22,7 @@ class CreateComponentsTable extends Migration
     {
         Schema::create('components', function (Blueprint $table) {
             $table->engine = 'InnoDB';
-            
+
             $table->increments('id');
             $table->string('name');
             $table->text('description');

--- a/database/migrations/2015_01_05_201444_CreateComponentsTable.php
+++ b/database/migrations/2015_01_05_201444_CreateComponentsTable.php
@@ -21,6 +21,8 @@ class CreateComponentsTable extends Migration
     public function up()
     {
         Schema::create('components', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->string('name');
             $table->text('description');

--- a/database/migrations/2015_01_05_202446_CreateIncidentTemplatesTable.php
+++ b/database/migrations/2015_01_05_202446_CreateIncidentTemplatesTable.php
@@ -21,6 +21,8 @@ class CreateIncidentTemplatesTable extends Migration
     public function up()
     {
         Schema::create('incident_templates', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->string('name');
             $table->string('slug');

--- a/database/migrations/2015_01_05_202446_CreateIncidentTemplatesTable.php
+++ b/database/migrations/2015_01_05_202446_CreateIncidentTemplatesTable.php
@@ -22,7 +22,7 @@ class CreateIncidentTemplatesTable extends Migration
     {
         Schema::create('incident_templates', function (Blueprint $table) {
             $table->engine = 'InnoDB';
-            
+
             $table->increments('id');
             $table->string('name');
             $table->string('slug');

--- a/database/migrations/2015_01_05_202609_CreateIncidentsTable.php
+++ b/database/migrations/2015_01_05_202609_CreateIncidentsTable.php
@@ -21,6 +21,8 @@ class CreateIncidentsTable extends Migration
     public function up()
     {
         Schema::create('incidents', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->integer('component_id')->default(0);
             $table->string('name');

--- a/database/migrations/2015_01_05_202609_CreateIncidentsTable.php
+++ b/database/migrations/2015_01_05_202609_CreateIncidentsTable.php
@@ -22,7 +22,7 @@ class CreateIncidentsTable extends Migration
     {
         Schema::create('incidents', function (Blueprint $table) {
             $table->engine = 'InnoDB';
-            
+
             $table->increments('id');
             $table->integer('component_id')->default(0);
             $table->string('name');

--- a/database/migrations/2015_01_05_202730_CreateMetricPointsTable.php
+++ b/database/migrations/2015_01_05_202730_CreateMetricPointsTable.php
@@ -22,7 +22,7 @@ class CreateMetricPointsTable extends Migration
     {
         Schema::create('metric_points', function (Blueprint $table) {
             $table->engine = 'InnoDB';
-            
+
             $table->increments('id');
             $table->integer('metric_id');
             $table->decimal('value', 10, 3);

--- a/database/migrations/2015_01_05_202730_CreateMetricPointsTable.php
+++ b/database/migrations/2015_01_05_202730_CreateMetricPointsTable.php
@@ -21,6 +21,8 @@ class CreateMetricPointsTable extends Migration
     public function up()
     {
         Schema::create('metric_points', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->integer('metric_id');
             $table->decimal('value', 10, 3);

--- a/database/migrations/2015_01_05_202826_CreateMetricsTable.php
+++ b/database/migrations/2015_01_05_202826_CreateMetricsTable.php
@@ -21,6 +21,8 @@ class CreateMetricsTable extends Migration
     public function up()
     {
         Schema::create('metrics', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->string('name');
             $table->string('suffix');

--- a/database/migrations/2015_01_05_202826_CreateMetricsTable.php
+++ b/database/migrations/2015_01_05_202826_CreateMetricsTable.php
@@ -22,7 +22,7 @@ class CreateMetricsTable extends Migration
     {
         Schema::create('metrics', function (Blueprint $table) {
             $table->engine = 'InnoDB';
-            
+
             $table->increments('id');
             $table->string('name');
             $table->string('suffix');

--- a/database/migrations/2015_01_05_203014_CreateSettingsTable.php
+++ b/database/migrations/2015_01_05_203014_CreateSettingsTable.php
@@ -21,6 +21,8 @@ class CreateSettingsTable extends Migration
     public function up()
     {
         Schema::create('settings', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->string('name');
             $table->longText('value');

--- a/database/migrations/2015_01_05_203014_CreateSettingsTable.php
+++ b/database/migrations/2015_01_05_203014_CreateSettingsTable.php
@@ -22,7 +22,7 @@ class CreateSettingsTable extends Migration
     {
         Schema::create('settings', function (Blueprint $table) {
             $table->engine = 'InnoDB';
-            
+
             $table->increments('id');
             $table->string('name');
             $table->longText('value');

--- a/database/migrations/2015_01_05_203235_CreateSubscribersTable.php
+++ b/database/migrations/2015_01_05_203235_CreateSubscribersTable.php
@@ -22,7 +22,7 @@ class CreateSubscribersTable extends Migration
     {
         Schema::create('subscribers', function (Blueprint $table) {
             $table->engine = 'InnoDB';
-            
+
             $table->increments('id');
             $table->string('email');
             $table->string('verify_code');

--- a/database/migrations/2015_01_05_203235_CreateSubscribersTable.php
+++ b/database/migrations/2015_01_05_203235_CreateSubscribersTable.php
@@ -21,6 +21,8 @@ class CreateSubscribersTable extends Migration
     public function up()
     {
         Schema::create('subscribers', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->string('email');
             $table->string('verify_code');

--- a/database/migrations/2015_01_05_203341_CreateUsersTable.php
+++ b/database/migrations/2015_01_05_203341_CreateUsersTable.php
@@ -21,6 +21,8 @@ class CreateUsersTable extends Migration
     public function up()
     {
         Schema::create('users', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->string('username');
             $table->string('password');

--- a/database/migrations/2015_01_05_203341_CreateUsersTable.php
+++ b/database/migrations/2015_01_05_203341_CreateUsersTable.php
@@ -22,7 +22,7 @@ class CreateUsersTable extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->engine = 'InnoDB';
-            
+
             $table->increments('id');
             $table->string('username');
             $table->string('password');

--- a/database/migrations/2015_01_16_083825_CreateTagsTable.php
+++ b/database/migrations/2015_01_16_083825_CreateTagsTable.php
@@ -22,7 +22,7 @@ class CreateTagsTable extends Migration
     {
         Schema::create('tags', function (Blueprint $table) {
             $table->engine = 'InnoDB';
-            
+
             $table->increments('id');
             $table->string('name');
             $table->string('slug');

--- a/database/migrations/2015_01_16_083825_CreateTagsTable.php
+++ b/database/migrations/2015_01_16_083825_CreateTagsTable.php
@@ -21,6 +21,8 @@ class CreateTagsTable extends Migration
     public function up()
     {
         Schema::create('tags', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->string('name');
             $table->string('slug');

--- a/database/migrations/2015_01_16_084030_CreateComponentTagTable.php
+++ b/database/migrations/2015_01_16_084030_CreateComponentTagTable.php
@@ -21,6 +21,8 @@ class CreateComponentTagTable extends Migration
     public function up()
     {
         Schema::create('component_tag', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->integer('component_id');
             $table->integer('tag_id');

--- a/database/migrations/2015_01_16_084030_CreateComponentTagTable.php
+++ b/database/migrations/2015_01_16_084030_CreateComponentTagTable.php
@@ -22,7 +22,7 @@ class CreateComponentTagTable extends Migration
     {
         Schema::create('component_tag', function (Blueprint $table) {
             $table->engine = 'InnoDB';
-            
+
             $table->increments('id');
             $table->integer('component_id');
             $table->integer('tag_id');

--- a/database/migrations/2015_05_24_210939_create_jobs_table.php
+++ b/database/migrations/2015_05_24_210939_create_jobs_table.php
@@ -21,7 +21,7 @@ class CreateJobsTable extends Migration
     {
         Schema::create('jobs', function (Blueprint $table) {
             $table->engine = 'InnoDB';
-            
+
             $table->bigIncrements('id');
             $table->string('queue');
             $table->text('payload');

--- a/database/migrations/2015_05_24_210939_create_jobs_table.php
+++ b/database/migrations/2015_05_24_210939_create_jobs_table.php
@@ -20,6 +20,8 @@ class CreateJobsTable extends Migration
     public function up()
     {
         Schema::create('jobs', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            
             $table->bigIncrements('id');
             $table->string('queue');
             $table->text('payload');

--- a/database/migrations/2015_05_24_210948_create_failed_jobs_table.php
+++ b/database/migrations/2015_05_24_210948_create_failed_jobs_table.php
@@ -20,6 +20,8 @@ class CreateFailedJobsTable extends Migration
     public function up()
     {
         Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->text('connection');
             $table->text('queue');

--- a/database/migrations/2015_05_24_210948_create_failed_jobs_table.php
+++ b/database/migrations/2015_05_24_210948_create_failed_jobs_table.php
@@ -21,7 +21,7 @@ class CreateFailedJobsTable extends Migration
     {
         Schema::create('failed_jobs', function (Blueprint $table) {
             $table->engine = 'InnoDB';
-            
+
             $table->increments('id');
             $table->text('connection');
             $table->text('queue');


### PR DESCRIPTION
Fixes #768. 

`php artisan migrate` will work regardless of mysql version or default_database_engine.