### PR TITLE
Add support for Vagrant/Homestead

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,10 @@ APP_DEBUG=true
 APP_URL=http://localhost
 APP_KEY=SomeRandomString
 
-DB_DRIVER=sqlite
+DB_DRIVER=mysql
 DB_HOST=localhost
 DB_DATABASE=cachet
-DB_USERNAME=user
+DB_USERNAME=homestead
 DB_PASSWORD=secret
 
 CACHE_DRIVER=file

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 phpunit.xml
 vendor
+.vagrant

--- a/Homestead.yaml
+++ b/Homestead.yaml
@@ -1,0 +1,40 @@
+---
+ip: "192.168.10.10"
+memory: 2048
+cpus: 1
+hostname: cachet
+name: cachet
+provider: virtualbox
+
+authorize: ~/.ssh/id_rsa.pub
+
+keys:
+    - ~/.ssh/id_rsa
+
+folders:
+    - map: "/srv/www/Cachet"
+      to: "/home/vagrant/Cachet"
+
+sites:
+    - map: homestead.app
+      to: "/home/vagrant/Cachet/public"
+
+databases:
+    - cachet
+
+variables:
+    - key: APP_ENV
+      value: local
+
+# blackfire:
+#     - id: foo
+#       token: bar
+#       client-id: foo
+#       client-token: bar
+
+# ports:
+#     - send: 93000
+#       to: 9300
+#     - send: 7777
+#       to: 777
+#       protocol: udp

--- a/README.md
+++ b/README.md
@@ -55,6 +55,39 @@ Here is a list of things that Cachet is not or does not do:
 2. It does not work on a plugin system. There are no monitoring services to extend.
 3. It's not a Twitter clone.
 
+## Quickstart with Vagrant
+
+If you would like to utilize [laravel homestead](http://laravel.com/docs/5.1/homestead), we have a per-project installation available to use for development purposes.
+
+First, modify Homestead.yaml to map your Cachet directory to the Vagrant VM properly. It looks like this by default:
+
+```yaml
+folders:
+    - map: "/srv/www/Cachet"
+      to: "/home/vagrant/Cachet"
+```
+
+Change the map key to the location of your Cachet installation and follow the instructions below.
+
+```bash
+# Copy over your environment variables
+$ cp .env.example .env
+
+# Initiate VM
+$ vagrant up
+
+# Generate application key
+$ php artisan key:generate
+
+# SSH into your machine
+$ vagrant ssh
+
+# Run migrations
+$ cd Cachet && php artisan migrate
+```
+
+Navigate to http://192.168.10.10 and begin using Cachet!
+
 ## Quickstart with Docker
 
 Run a DB container (you can either pass in environment variables for the DB, or mount a config with `-v /my/database.php:/var/www/html/app/config/database.php`):

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+require 'json'
+require 'yaml'
+
+VAGRANTFILE_API_VERSION = "2"
+confDir = $confDir ||= File.expand_path("vendor/laravel/homestead")
+
+homesteadYamlPath = "Homestead.yaml"
+afterScriptPath = "after.sh"
+aliasesPath = "aliases"
+
+require File.expand_path(confDir + '/scripts/homestead.rb')
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+	if File.exists? aliasesPath then
+		config.vm.provision "file", source: aliasesPath, destination: "~/.bash_aliases"
+	end
+
+	Homestead.configure(config, YAML::load(File.read(homesteadYamlPath)))
+
+	if File.exists? afterScriptPath then
+		config.vm.provision "shell", path: afterScriptPath
+	end
+end

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
     "require-dev": {
         "fzaninotto/faker": "^1.5",
         "graham-campbell/testbench-core": "^1.0",
-        "phpunit/phpunit": "^4.7.6"
+	"phpunit/phpunit": "^4.7.6",
+	"laravel/homestead": "dev-master"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,8 @@
     "require-dev": {
         "fzaninotto/faker": "^1.5",
         "graham-campbell/testbench-core": "^1.0",
-	"phpunit/phpunit": "^4.7.6",
-	"laravel/homestead": "dev-master"
+        "phpunit/phpunit": "^4.7.6",
+        "laravel/homestead": "^2.1"
     },
     "autoload": {
         "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "687f3b651fc7e102f31fd6cc34bd2020",
+    "hash": "52170701af5a0e6e40fbc59832487b3e",
     "packages": [
         {
             "name": "alt-three/segment",
@@ -3436,6 +3436,47 @@
             "time": "2015-06-26 16:35:19"
         },
         {
+	    "name": "laravel/homestead",
+	    "version": "dev-master",
+	    "source": {
+		"type": "git",
+		"url": "https://github.com/laravel/homestead.git",
+		"reference": "835d8f223a95fd763f6fc7c4ee119692893af3a1"
+	    },
+	    "dist": {
+		"type": "zip",
+		"url": "https://api.github.com/repos/laravel/homestead/zipball/835d8f223a95fd763f6fc7c4ee119692893af3a1",
+		"reference": "835d8f223a95fd763f6fc7c4ee119692893af3a1",
+		"shasum": ""
+	    },
+	    "require": {
+		"php": ">=5.4",
+		"symfony/console": "~2.0",
+		"symfony/process": "~2.0"
+	    },
+	    "bin": [
+		"homestead"
+	    ],
+	    "type": "library",
+	    "autoload": {
+		"psr-4": {
+		    "Laravel\\Homestead\\": "src/"
+		}
+	    },
+	    "notification-url": "https://packagist.org/downloads/",
+	    "license": [
+		"MIT"
+	    ],
+	    "authors": [
+		{
+		    "name": "Taylor Otwell",
+		    "email": "taylorotwell@gmail.com"
+		}
+	    ],
+	    "description": "A virtual machine for web artisans.",
+	    "time": "2015-06-29 21:00:49"
+	},
+	{
             "name": "phpdocumentor/reflection-docblock",
             "version": "2.0.4",
             "source": {
@@ -4334,7 +4375,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+	"laravel/homestead": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "52170701af5a0e6e40fbc59832487b3e",
+    "hash": "9efc83056d64e48063ebb42f1f7dc337",
     "packages": [
         {
             "name": "alt-three/segment",
@@ -3436,47 +3436,47 @@
             "time": "2015-06-26 16:35:19"
         },
         {
-	    "name": "laravel/homestead",
-	    "version": "dev-master",
-	    "source": {
-		"type": "git",
-		"url": "https://github.com/laravel/homestead.git",
-		"reference": "835d8f223a95fd763f6fc7c4ee119692893af3a1"
-	    },
-	    "dist": {
-		"type": "zip",
-		"url": "https://api.github.com/repos/laravel/homestead/zipball/835d8f223a95fd763f6fc7c4ee119692893af3a1",
-		"reference": "835d8f223a95fd763f6fc7c4ee119692893af3a1",
-		"shasum": ""
-	    },
-	    "require": {
-		"php": ">=5.4",
-		"symfony/console": "~2.0",
-		"symfony/process": "~2.0"
-	    },
-	    "bin": [
-		"homestead"
-	    ],
-	    "type": "library",
-	    "autoload": {
-		"psr-4": {
-		    "Laravel\\Homestead\\": "src/"
-		}
-	    },
-	    "notification-url": "https://packagist.org/downloads/",
-	    "license": [
-		"MIT"
-	    ],
-	    "authors": [
-		{
-		    "name": "Taylor Otwell",
-		    "email": "taylorotwell@gmail.com"
-		}
-	    ],
-	    "description": "A virtual machine for web artisans.",
-	    "time": "2015-06-29 21:00:49"
-	},
-	{
+            "name": "laravel/homestead",
+            "version": "v2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/homestead.git",
+                "reference": "ffab9eac576906fc1ba76c2e50050cc36f381195"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/homestead/zipball/ffab9eac576906fc1ba76c2e50050cc36f381195",
+                "reference": "ffab9eac576906fc1ba76c2e50050cc36f381195",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "symfony/console": "~2.0",
+                "symfony/process": "~2.0"
+            },
+            "bin": [
+                "homestead"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Homestead\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylorotwell@gmail.com"
+                }
+            ],
+            "description": "A virtual machine for web artisans.",
+            "time": "2015-06-24 19:39:40"
+        },
+        {
             "name": "phpdocumentor/reflection-docblock",
             "version": "2.0.4",
             "source": {
@@ -4375,9 +4375,6 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-	"laravel/homestead": 20
-    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
Given the [new changes to Laravel Homestead](http://laravel.com/docs/5.1/homestead#per-project-installation), I thought it might be appropriate to setup a per-project Vagrant environment for out-of-the-box development usage.

Overview of Changes:
* Added new requirement for dev-dependencies (laravel/homestead)
* Modified .env.example to default to mysql and use the built in Homestead mysql database and user information
* Added Homestead-related files
* Modified gitignore to account for vagrant
* Updated README information for Vagrant setup.

I know that there is already a docker setup for the project, but I figure another configuration option wouldn't be a bad thing. I was already using homestead to develop with, and thought I would go ahead and see if y'all might want to go ahead and just add the per-project support.

Let me know if you see a need for any changes.