### PR TITLE
Dashboard - Active Menu Item CSS Fix

### DIFF
--- a/app/Http/helpers.php
+++ b/app/Http/helpers.php
@@ -34,7 +34,7 @@ if (!function_exists('set_active')) {
 
         $class = implode(' ', $classes);
 
-        return empty($classes) ? '' : "class=\"{$class}\"";
+        return empty($classes) ? '' : "class={$class}";
     }
 }
 


### PR DESCRIPTION
Very minor fix for the sidebar menu.

**Current behavior:** When clicking on an item in the sidebar, the page reloads and does not indicate which menu item is active in the dashboard sidebar.

**Expected behavior:** When clicking on an item in the sidebar, the page should reload and the sidebar menu should show the currently selected item.