### PR TITLE
Add small note to README that a composer install needs to be executed before a vagrant up

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Here is a list of things that Cachet is not or does not do:
 
 If you would like to utilize [laravel homestead](http://laravel.com/docs/5.1/homestead), we have a per-project installation available to use for development purposes.
 
-First, modify Homestead.yaml to map your Cachet directory to the Vagrant VM properly. It looks like this by default:
+First, install dependencies by `composer install` and modify Homestead.yaml to map your Cachet directory to the Vagrant VM properly. It looks like this by default:
 
 ```yaml
 folders:


### PR DESCRIPTION
I wanted to try Cachet and thankful you provide a Vagrant machine.
I cloned the repo and fired a vagrant up. An error appears:

```
$ vagrant up
There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: /Users/agrunwald/Development/Cachet.git/Vagrantfile
Line number: 11
Message: LoadError: cannot load such file -- /Users/agrunwald/Development/Cachet.git/vendor/laravel/homestead/scripts/homestead.rb
```

After a `composer install` this problem was solved.
But maybe a small note about this step is useful.
This Pull Request is about adding this small note :)