### PR TITLE
Do not prepend "Status" to the site name

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -112,7 +112,7 @@ class HomeController extends AbstractController
             'canPageBackward'      => $canPageBackward,
             'previousDate'         => $startDate->copy()->subDays($daysToShow)->toDateString(),
             'nextDate'             => $startDate->copy()->addDays($daysToShow)->toDateString(),
-            'page_title'           => Setting::get('app_name').' Status',
+            'page_title'           => Setting::get('app_name'),
         ]);
     }
 }


### PR DESCRIPTION
Currently the title of the index is the site name set in the settings is
prepended with "Status". This is confusing because the RSS feeds show
the site name without it (and you probably want to write "Status" in the site
name yourself anyway).