### PR TITLE
Use HTTPS for Google Fonts

### DIFF
--- a/resources/views/layout/master.blade.php
+++ b/resources/views/layout/master.blade.php
@@ -37,7 +37,7 @@
 
     <title>{{ $page_title }}</title>
 
-    <link href="//fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet" type="text/css">
     <link rel="stylesheet" href="{{ elixir('dist/css/all.css') }}">
 
     @include('partials.stylesheet')


### PR DESCRIPTION
There's no reason to use a protocol-relative URL for loading Google Fonts - HTTP opens the door for MITM attacks, and the original proposer of the method has even recommended abandoning the practice (http://www.paulirish.com/2010/the-protocol-relative-url/).

This PR simply edits the `<link>` to Google Fonts to be HTTPS instead of HTTP.