### PR TITLE
Completely remove the use of Redirect::back - closes #867

### DIFF
--- a/app/Handlers/Events/SendIncidentEmailNotificationHandler.php
+++ b/app/Handlers/Events/SendIncidentEmailNotificationHandler.php
@@ -73,7 +73,7 @@ class SendIncidentEmailNotificationHandler
                     'htmlContent'     => $data->formattedMessage,
                     'textContent'     => $data->message,
                     'token'           => $subscriber->token,
-                    'unsubscribeLink' => route('unsubscribe', ['code' => $subscriber->verify_code]),
+                    'unsubscribeLink' => route('subscribe.unsubscribe', ['code' => $subscriber->verify_code]),
                     'appUrl'          => env('APP_URL'),
                 ];
 

--- a/app/Handlers/Events/SendMaintenanceEmailNotificationHandler.php
+++ b/app/Handlers/Events/SendMaintenanceEmailNotificationHandler.php
@@ -71,7 +71,7 @@ class SendMaintenanceEmailNotificationHandler
                 'htmlContent'     => $data->formattedMessage,
                 'textContent'     => $data->message,
                 'token'           => $subscriber->token,
-                'unsubscribeLink' => route('unsubscribe', ['code' => $subscriber->verify_code]),
+                'unsubscribeLink' => route('subscribe.unsubscribe', ['code' => $subscriber->verify_code]),
                 'appUrl'          => env('APP_URL'),
             ];
 

--- a/app/Handlers/Events/SendSubscriberVerificationEmailHandler.php
+++ b/app/Handlers/Events/SendSubscriberVerificationEmailHandler.php
@@ -44,7 +44,7 @@ class SendSubscriberVerificationEmailHandler
         $mail = [
             'email'   => $event->subscriber->email,
             'subject' => 'Confirm your subscription.',
-            'link'    => route('subscribe-verify', ['code' => $event->subscriber->verify_code]),
+            'link'    => route('subscribe.verify', ['code' => $event->subscriber->verify_code]),
             'appUrl'  => env('APP_URL'),
         ];
 

--- a/app/Http/Controllers/Admin/ComponentController.php
+++ b/app/Http/Controllers/Admin/ComponentController.php
@@ -113,7 +113,7 @@ class ComponentController extends Controller
         try {
             $component->update($_component);
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.components.edit', ['id' => $component->id])
                 ->withInput(Binput::all())
                 ->withTitle(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.components.edit.failure')))
                 ->withErrors($e->getMessageBag());
@@ -129,7 +129,7 @@ class ComponentController extends Controller
 
         $component->tags()->sync($componentTags);
 
-        return Redirect::back()
+        return Redirect::route('dashboard.components.edit', ['id' => $component->id])
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.components.edit.success')));
     }
 
@@ -159,7 +159,7 @@ class ComponentController extends Controller
         try {
             $component = Component::create($_component);
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.components.add')
                 ->withInput(Binput::all())
                 ->withTitle(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.components.add.failure')))
                 ->withErrors($e->getMessageBag());
@@ -175,7 +175,7 @@ class ComponentController extends Controller
 
         $component->tags()->sync($componentTags);
 
-        return Redirect::back()
+        return Redirect::route('dashboard.components.add')
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.components.add.success')));
     }
 
@@ -190,7 +190,7 @@ class ComponentController extends Controller
     {
         $component->delete();
 
-        return Redirect::back();
+        return Redirect::route('dashboard.components.index');
     }
 
     /**
@@ -208,7 +208,7 @@ class ComponentController extends Controller
 
         $group->delete();
 
-        return Redirect::back();
+        return Redirect::route('dashboard.components.index');
     }
 
     /**
@@ -246,13 +246,13 @@ class ComponentController extends Controller
         try {
             $group = ComponentGroup::create(Binput::get('group'));
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.components.groups.add')
                 ->withInput(Binput::all())
                 ->withTitle(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.components.groups.add.failure')))
                 ->withErrors($e->getMessageBag());
         }
 
-        return Redirect::back()
+        return Redirect::route('dashboard.components.groups.add')
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.components.groups.add.success')));
     }
 
@@ -270,13 +270,13 @@ class ComponentController extends Controller
         try {
             $group->update($groupData);
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.components.group.edit', ['id' => $group->id])
                 ->withInput(Binput::all())
                 ->withTitle(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.components.groups.edit.failure')))
                 ->withErrors($e->getMessageBag());
         }
 
-        return Redirect::back()
+        return Redirect::route('dashboard.components.group.edit', ['id' => $group->id])
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.components.groups.edit.success')));
     }
 }

--- a/app/Http/Controllers/Admin/IncidentController.php
+++ b/app/Http/Controllers/Admin/IncidentController.php
@@ -121,7 +121,7 @@ class IncidentController extends Controller
         try {
             $incident = Incident::create($incidentData);
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.incidents.add')
                 ->withInput(Binput::all())
                 ->withTitle(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.incidents.add.failure')))
                 ->withErrors($e->getMessageBag());
@@ -136,7 +136,7 @@ class IncidentController extends Controller
             event(new IncidentHasReportedEvent($incident));
         }
 
-        return Redirect::back()
+        return Redirect::route('dashboard.incidents.add')
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.incidents.add.success')));
     }
 
@@ -176,7 +176,7 @@ class IncidentController extends Controller
     {
         $template->delete();
 
-        return Redirect::back();
+        return Redirect::route('dashboard.incidents.index');
     }
 
     /**
@@ -189,13 +189,13 @@ class IncidentController extends Controller
         try {
             IncidentTemplate::create(Binput::get('template'));
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.templates.add')
                 ->withInput(Binput::all())
                 ->withTitle(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.incidents.templates.add.failure')))
                 ->withErrors($e->getMessageBag());
         }
 
-        return Redirect::back()
+        return Redirect::route('dashboard.templates.add')
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.incidents.templates.add.success')));
     }
 
@@ -210,7 +210,7 @@ class IncidentController extends Controller
     {
         $incident->delete();
 
-        return Redirect::back();
+        return Redirect::route('dashboard.incidents.index');
     }
 
     /**
@@ -251,7 +251,7 @@ class IncidentController extends Controller
         try {
             $incident->update($incidentData);
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.incidents.edit', ['id' => $incident->id])
                 ->withInput(Binput::all())
                 ->withTitle(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.incidents.templates.edit.failure')))
                 ->withErrors($e->getMessageBag());
@@ -263,7 +263,7 @@ class IncidentController extends Controller
             $incident->component->update(['status' => $componentStatus]);
         }
 
-        return Redirect::to('dashboard/incidents')
+        return Redirect::route('dashboard.incidents.edit', ['id' => $incident->id])
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.incidents.edit.success')));
     }
 
@@ -279,12 +279,12 @@ class IncidentController extends Controller
         try {
             $template->update(Binput::get('template'));
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.templates.edit', ['id' => $template->id])
                 ->withUpdatedTemplate($template)
                 ->withTemplateErrors($e->getMessageBag()->getErrors());
         }
 
-        return Redirect::back()
+        return Redirect::route('dashboard.templates.edit', ['id' => $template->id])
             ->withUpdatedTemplate($template);
     }
 }

--- a/app/Http/Controllers/Admin/MetricController.php
+++ b/app/Http/Controllers/Admin/MetricController.php
@@ -68,13 +68,13 @@ class MetricController extends Controller
         try {
             Metric::create(Binput::get('metric'));
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.metrics.add')
                 ->withInput(Binput::all())
                 ->withTitle(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.metrics.add.failure')))
                 ->withErrors($e->getMessageBag());
         }
 
-        return Redirect::back()
+        return Redirect::route('dashboard.metrics.add')
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.metrics.add.success')));
     }
 
@@ -90,26 +90,6 @@ class MetricController extends Controller
     }
 
     /**
-     * Creates a new metric point.
-     *
-     * @return \Illuminate\Http\RedirectResponse
-     */
-    public function createMetricPointAction()
-    {
-        try {
-            MetricPoint::create(Binput::get('point', null, false));
-        } catch (ValidationException $e) {
-            return Redirect::back()
-                ->withInput(Binput::all())
-                ->withTitle(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.metrics.points.add.failure')))
-                ->withErrors($e->getMessageBag());
-        }
-
-        return Redirect::back()
-            ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.metrics.points.add.success')));
-    }
-
-    /**
      * Deletes a given metric.
      *
      * @param \CachetHQ\Cachet\Models\Metric $metric
@@ -120,7 +100,7 @@ class MetricController extends Controller
     {
         $metric->delete();
 
-        return Redirect::back();
+        return Redirect::route('dashboard.metrics.index');
     }
 
     /**
@@ -149,13 +129,13 @@ class MetricController extends Controller
         try {
             $metric->update(Binput::get('metric', null, false));
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.metrics.edit', ['id' => $metric->id])
                 ->withInput(Binput::all())
                 ->withTitle(sprintf('<strong>%s</strong>', trans('dashboard.notifications.whoops')))
                 ->withErrors($e->getMessageBag());
         }
 
-        return Redirect::to('dashboard/metrics')
+        return Redirect::route('dashboard.metrics.edit', ['id' => $metric->id])
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.metrics.edit.success')));
     }
 }

--- a/app/Http/Controllers/Admin/ScheduleController.php
+++ b/app/Http/Controllers/Admin/ScheduleController.php
@@ -44,13 +44,13 @@ class ScheduleController extends Controller
         $this->subMenu = [
             'incidents' => [
                 'title'  => trans('dashboard.incidents.incidents'),
-                'url'    => route('dashboard.incidents'),
+                'url'    => route('dashboard.incidents.index'),
                 'icon'   => 'ion-android-checkmark-circle',
                 'active' => false,
             ],
             'schedule' => [
                 'title'  => trans('dashboard.schedule.schedule'),
-                'url'    => route('dashboard.schedule'),
+                'url'    => route('dashboard.schedule.index'),
                 'icon'   => 'ion-android-calendar',
                 'active' => true,
             ],
@@ -101,7 +101,7 @@ class ScheduleController extends Controller
             $messageBag = new MessageBag();
             $messageBag->add('scheduled_at', trans('validation.date', ['attribute' => 'scheduled time you supplied']));
 
-            return Redirect::back()->withErrors($messageBag);
+            return Redirect::route('dashboard.schedule.add')->withErrors($messageBag);
         }
 
         $scheduleData['scheduled_at'] = $scheduledAt;
@@ -111,7 +111,7 @@ class ScheduleController extends Controller
         try {
             Incident::create($scheduleData);
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.schedule.add')
                 ->withInput(Binput::all())
                 ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.schedule.add.failure')))
                 ->withErrors($e->getMessageBag());
@@ -121,7 +121,7 @@ class ScheduleController extends Controller
             event(new MaintenanceHasScheduledEvent($incident));
         }
 
-        return Redirect::back()
+        return Redirect::route('dashboard.schedule.add')
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.schedule.add.success')));
     }
 
@@ -159,7 +159,7 @@ class ScheduleController extends Controller
             $messageBag = new MessageBag();
             $messageBag->add('scheduled_at', trans('validation.date', ['attribute' => 'scheduled time you supplied']));
 
-            return Redirect::back()->withErrors($messageBag);
+            return Redirect::route('dashboard.schedule.edit', ['id' => $schedule->id])->withErrors($messageBag);
         }
 
         $scheduleData['scheduled_at'] = $scheduledAt;
@@ -169,13 +169,13 @@ class ScheduleController extends Controller
         try {
             $schedule->update($scheduleData);
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.schedule.edit', ['id' => $schedule->id])
                 ->withInput(Binput::all())
                 ->withTitle(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.schedule.edit.failure')))
                 ->withErrors($e->getMessageBag());
         }
 
-        return Redirect::to('dashboard/schedule')
+        return Redirect::route('dashboard.schedule.edit', ['id' => $schedule->id])
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.schedule.edit.success')));
     }
 
@@ -190,7 +190,7 @@ class ScheduleController extends Controller
     {
         $schedule->delete();
 
-        return Redirect::back()
+        return Redirect::route('dashboard.schedule.index')
             ->withWarning(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.schedule.delete.failure')));
     }
 }

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -138,15 +138,15 @@ class SettingsController extends Controller
             $maxSize = $file->getMaxFilesize();
 
             if ($file->getSize() > $maxSize) {
-                return Redirect::back()->withErrors(trans('dashboard.settings.app-setup.too-big', ['size' => $maxSize]));
+                return Redirect::route('dashboard.settings.setup')->withErrors(trans('dashboard.settings.app-setup.too-big', ['size' => $maxSize]));
             }
 
             if (!$file->isValid() || $file->getError()) {
-                return Redirect::back()->withErrors($file->getErrorMessage());
+                return Redirect::route('dashboard.settings.setup')->withErrors($file->getErrorMessage());
             }
 
             if (strpos($file->getMimeType(), 'image/') !== 0) {
-                return Redirect::back()->withErrors(trans('dashboard.settings.app-setup.images-only'));
+                return Redirect::route('dashboard.settings.setup')->withErrors(trans('dashboard.settings.app-setup.images-only'));
             }
 
             // Store the banner.
@@ -165,12 +165,12 @@ class SettingsController extends Controller
                 Setting::firstOrCreate(['name' => $settingName])->update(['value' => $settingValue]);
             }
         } catch (Exception $e) {
-            return Redirect::back()->withErrors(trans('dashboard.settings.edit.failure'));
+            return Redirect::route('dashboard.settings.setup')->withErrors(trans('dashboard.settings.edit.failure'));
         }
 
         Lang::setLocale(Binput::get('app_locale'));
 
-        return Redirect::back()
+        return Redirect::route('dashboard.settings.setup')
             ->withSuccess(trans('dashboard.settings.edit.success'));
     }
 }

--- a/app/Http/Controllers/Admin/SubscriberController.php
+++ b/app/Http/Controllers/Admin/SubscriberController.php
@@ -58,7 +58,7 @@ class SubscriberController extends Controller
         try {
             $subscriber = Subscriber::create(['email' => $email]);
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.subscribers.add')
                 ->withInput(Binput::all())
                 ->withTitle(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.subscribers.add.failure')))
                 ->withErrors($e->getMessageBag());
@@ -66,7 +66,7 @@ class SubscriberController extends Controller
 
         event(new CustomerHasSubscribedEvent($subscriber));
 
-        return Redirect::back()
+        return Redirect::route('dashboard.subscribers.add')
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.subscribers.add.success')));
     }
 
@@ -83,6 +83,6 @@ class SubscriberController extends Controller
     {
         $subscriber->delete();
 
-        return Redirect::back();
+        return Redirect::route('dashboard.subscribers.index');
     }
 }

--- a/app/Http/Controllers/Admin/TeamController.php
+++ b/app/Http/Controllers/Admin/TeamController.php
@@ -67,13 +67,13 @@ class TeamController extends Controller
         try {
             User::create(Binput::all());
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.team.add')
                 ->withInput(Binput::except('password'))
                 ->withTitle(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.team.add.failure')))
                 ->withErrors($e->getMessageBag());
         }
 
-        return Redirect::back()
+        return Redirect::route('dashboard.team.add')
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.team.add.success')));
     }
 
@@ -97,13 +97,13 @@ class TeamController extends Controller
         try {
             $user->update($items);
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.team.edit', ['id' => $user->id])
                 ->withInput(Binput::except('password'))
                 ->withTitle(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.team.edit.failure')))
                 ->withErrors($e->getMessageBag());
         }
 
-        return Redirect::back()
+        return Redirect::route('dashboard.team.edit', ['id' => $user->id])
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.team.edit.success')));
     }
 
@@ -118,7 +118,7 @@ class TeamController extends Controller
     {
         $user->delete();
 
-        return Redirect::route('dashboard.team')
+        return Redirect::route('dashboard.team.index')
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.team.delete.success')));
     }
 }

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -59,13 +59,13 @@ class UserController extends Controller
         try {
             Auth::user()->update($items);
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('dashboard.user')
                 ->withInput(Binput::except('password'))
                 ->withTitle(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('dashboard.team.edit.failure')))
                 ->withErrors($e->getMessageBag());
         }
 
-        return Redirect::back()
+        return Redirect::route('dashboard.user')
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('dashboard.team.edit.success')));
     }
 
@@ -79,6 +79,6 @@ class UserController extends Controller
         $user->api_key = User::generateApiKey();
         $user->save();
 
-        return Redirect::back();
+        return Redirect::route('dashboard.user');
     }
 }

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -59,7 +59,7 @@ class AuthController extends Controller
             return Redirect::intended('dashboard');
         }
 
-        return Redirect::back()
+        return Redirect::route('auth.login')
             ->withInput(Binput::except('password'))
             ->withError(trans('forms.login.invalid'));
     }

--- a/app/Http/Controllers/SetupController.php
+++ b/app/Http/Controllers/SetupController.php
@@ -179,7 +179,7 @@ class SetupController extends Controller
             return Response::json(['errors' => $v->getMessageBag()], 400);
         }
 
-        return Redirect::back()->withInput()->withErrors($v->getMessageBag());
+        return Redirect::route('setup.index')->withInput()->withErrors($v->getMessageBag());
     }
 
     /**

--- a/app/Http/Controllers/SubscribeController.php
+++ b/app/Http/Controllers/SubscribeController.php
@@ -47,7 +47,7 @@ class SubscribeController extends Controller
         try {
             $subscriber = Subscriber::create(['email' => Binput::get('email')]);
         } catch (ValidationException $e) {
-            return Redirect::back()
+            return Redirect::route('subscribe.subscribe')
                 ->withInput(Binput::all())
                 ->withTitle(sprintf('<strong>%s</strong> %s', trans('dashboard.notifications.whoops'), trans('cachet.subscriber.email.failure')))
                 ->withErrors($e->getMessageBag());

--- a/app/Http/Routes/DashboardRoutes.php
+++ b/app/Http/Routes/DashboardRoutes.php
@@ -90,7 +90,10 @@ class DashboardRoutes
                     'uses' => 'IncidentController@showAddIncident',
                 ]);
                 $router->post('add', 'IncidentController@createIncidentAction');
-                $router->delete('{incident}/delete', 'IncidentController@deleteIncidentAction');
+                $router->delete('{incident}/delete', [
+                    'as'   => 'delete',
+                    'uses' => 'IncidentController@deleteIncidentAction',
+                ]);
                 $router->get('{incident}/edit', [
                     'as'   => 'edit',
                     'uses' => 'IncidentController@showEditIncidentAction',

--- a/app/Http/Routes/SubscribeRoutes.php
+++ b/app/Http/Routes/SubscribeRoutes.php
@@ -30,20 +30,20 @@ class SubscribeRoutes
         $router->group([
             'middleware' => 'app.hasSetting',
             'setting'    => 'app_name',
+            'as'         => 'subscribe.',
         ], function ($router) {
             $router->group(['middleware' => 'app.subscribers'], function ($router) {
                 $router->get('subscribe', [
-                    'as'   => 'subscribe-page',
+                    'as'   => 'subscribe',
                     'uses' => 'SubscribeController@showSubscribe',
                 ]);
 
                 $router->post('subscribe', [
-                    'as'   => 'subscribe',
                     'uses' => 'SubscribeController@postSubscribe',
                 ]);
 
                 $router->get('subscribe/verify/{code}', [
-                    'as'   => 'subscribe-verify',
+                    'as'   => 'verify',
                     'uses' => 'SubscribeController@getVerify',
                 ]);
 

--- a/resources/views/dashboard/components/edit.blade.php
+++ b/resources/views/dashboard/components/edit.blade.php
@@ -63,7 +63,7 @@
 
                     <div class="btn-group">
                         <button type="submit" class="btn btn-success">{{ trans('forms.save') }}</button>
-                        <a class="btn btn-default" href="{{ route('dashboard.components') }}">{{ trans('forms.cancel') }}</a>
+                        <a class="btn btn-default" href="{{ route('dashboard.components.index') }}">{{ trans('forms.cancel') }}</a>
                     </div>
                 </form>
             </div>

--- a/resources/views/dashboard/incidents/add.blade.php
+++ b/resources/views/dashboard/incidents/add.blade.php
@@ -118,7 +118,7 @@
                     <div class="form-group">
                         <div class="btn-group">
                             <button type="submit" class="btn btn-success">{{ trans('forms.add') }}</button>
-                            <a class="btn btn-default" href="{{ route('dashboard.incidents') }}">{{ trans('forms.cancel') }}</a>
+                            <a class="btn btn-default" href="{{ route('dashboard.incidents.index') }}">{{ trans('forms.cancel') }}</a>
                         </div>
                     </div>
                 </form>

--- a/resources/views/dashboard/incidents/edit.blade.php
+++ b/resources/views/dashboard/incidents/edit.blade.php
@@ -88,7 +88,7 @@
                     <div class="form-group">
                         <div class="btn-group">
                             <button type="submit" class="btn btn-success">{{ trans('forms.update') }}</button>
-                            <a class="btn btn-default" href="{{ route('dashboard.incidents') }}">{{ trans('forms.cancel') }}</a>
+                            <a class="btn btn-default" href="{{ route('dashboard.incidents.index') }}">{{ trans('forms.cancel') }}</a>
                         </div>
                     </div>
                 </form>

--- a/resources/views/dashboard/metrics/add.blade.php
+++ b/resources/views/dashboard/metrics/add.blade.php
@@ -51,7 +51,7 @@
                     <div class='form-group'>
                         <div class='btn-group'>
                             <button type="submit" class="btn btn-success">{{ trans('forms.add') }}</button>
-                            <a class="btn btn-default" href="{{ route('dashboard.metrics') }}">{{ trans('forms.cancel') }}</a>
+                            <a class="btn btn-default" href="{{ route('dashboard.metrics.index') }}">{{ trans('forms.cancel') }}</a>
                         </div>
                     </div>
                 </form>

--- a/resources/views/dashboard/metrics/edit.blade.php
+++ b/resources/views/dashboard/metrics/edit.blade.php
@@ -54,7 +54,7 @@
                     <div class='form-group'>
                         <div class='btn-group'>
                             <button type="submit" class="btn btn-success">{{ trans('forms.update') }}</button>
-                            <a class="btn btn-default" href="{{ route('dashboard.metrics') }}">{{ trans('forms.cancel') }}</a>
+                            <a class="btn btn-default" href="{{ route('dashboard.metrics.index') }}">{{ trans('forms.cancel') }}</a>
                         </div>
                     </div>
                 </form>

--- a/resources/views/dashboard/schedule/add.blade.php
+++ b/resources/views/dashboard/schedule/add.blade.php
@@ -53,7 +53,7 @@
                     <div class="form-group">
                         <div class="btn-group">
                             <button type="submit" class="btn btn-success">{{ trans('forms.add') }}</button>
-                            <a class="btn btn-default" href="{{ route('dashboard.schedule') }}">{{ trans('forms.cancel') }}</a>
+                            <a class="btn btn-default" href="{{ route('dashboard.schedule.index') }}">{{ trans('forms.cancel') }}</a>
                         </div>
                     </div>
                 </form>

--- a/resources/views/dashboard/schedule/edit.blade.php
+++ b/resources/views/dashboard/schedule/edit.blade.php
@@ -48,7 +48,7 @@
                     <div class="form-group">
                         <div class="btn-group">
                             <button type="submit" class="btn btn-success">{{ trans('forms.save') }}</button>
-                            <a class="btn btn-default" href="{{ route('dashboard.schedule') }}">{{ trans('forms.cancel') }}</a>
+                            <a class="btn btn-default" href="{{ route('dashboard.schedule.index') }}">{{ trans('forms.cancel') }}</a>
                         </div>
                     </div>
                 </form>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -3,7 +3,7 @@
 @section('content')
     @if($subscribersEnabled)
     <div class="pull-right">
-        <p><a class="btn btn-success btn-outline" href="{{ route('subscribe') }}">{{ trans('cachet.subscriber.button') }}</a></p>
+        <p><a class="btn btn-success btn-outline" href="{{ route('subscribe.subscribe') }}">{{ trans('cachet.subscriber.button') }}</a></p>
     </div>
     @endif
 

--- a/resources/views/partials/incidents.blade.php
+++ b/resources/views/partials/incidents.blade.php
@@ -14,8 +14,8 @@
                         <div class="panel-heading">
                             @if($current_user)
                             <div class="pull-right btn-group">
-                                <a href="/dashboard/incidents/{{ $incident->id }}/edit" class="btn btn-default">{{ trans('forms.edit') }}</a>
-                                <a href="/dashboard/incidents/{{ $incident->id }}/delete" class="btn btn-danger confirm-action" data-method='DELETE'>{{ trans('forms.delete') }}</a>
+                                <a href="{{ route('dashboard.incidents.edit', ['id' => $incident->id]) }}" class="btn btn-default">{{ trans('forms.edit') }}</a>
+                                <a href="{{ route('dashboard.incidents.delete', ['id' => $incident->id]) }}" class="btn btn-danger confirm-action" data-method='DELETE'>{{ trans('forms.delete') }}</a>
                             </div>
                             @endif
                             <strong>{{ $incident->name }}</strong>{{ $incident->isScheduled ? trans("cachet.incidents.scheduled_at", ["timestamp" => $incident->scheduled_at_diff]) : null }}


### PR DESCRIPTION
So since Cachet is used as a learning tool by many people, the reason we've done this is because `Redirect::back` uses the `referer` header, which can be hijacked to redirect you somewhere completely different.

By directing users back to the exact route we want, we can avoid this.