### PR TITLE
Fixed wrong Locale on Settings form submit

### DIFF
--- a/app/Http/Controllers/Dashboard/SettingsController.php
+++ b/app/Http/Controllers/Dashboard/SettingsController.php
@@ -168,7 +168,9 @@ class SettingsController extends Controller
             return Redirect::route('dashboard.settings.setup')->withErrors(trans('dashboard.settings.edit.failure'));
         }
 
-        Lang::setLocale(Binput::get('app_locale'));
+        if (Binput::has('app_locale')) {
+            Lang::setLocale(Binput::get('app_locale'));
+        }
 
         return Redirect::route('dashboard.settings.setup')
             ->withSuccess(trans('dashboard.settings.edit.success'));


### PR DESCRIPTION
Except Setup section, when you submit a form, the Success message doesn't use your current locale but always English (that is the default language).