### PR TITLE
per_page attribute in API responses should be an integer

### DIFF
--- a/app/Http/Controllers/Api/AbstractApiController.php
+++ b/app/Http/Controllers/Api/AbstractApiController.php
@@ -147,11 +147,11 @@ abstract class AbstractApiController extends Controller
 
         $pagination = [
             'pagination' => [
-                'total'        => $paginator->total(),
+                'total'        => (int) $paginator->total(),
                 'count'        => count($paginator->items()),
-                'per_page'     => $paginator->perPage(),
-                'current_page' => $paginator->currentPage(),
-                'total_pages'  => $paginator->lastPage(),
+                'per_page'     => (int) $paginator->perPage(),
+                'current_page' => (int) $paginator->currentPage(),
+                'total_pages'  => (int) $paginator->lastPage(),
                 'links'        => [
                     'next_page'     => $paginator->nextPageUrl(),
                     'previous_page' => $paginator->previousPageUrl(),


### PR DESCRIPTION
It was previously a string because of `Binput::get`. I don't know how to reflect this in the API documentation