### PR TITLE
Use Collection on API Paginator presenter

### DIFF
--- a/app/Http/Controllers/Api/AbstractApiController.php
+++ b/app/Http/Controllers/Api/AbstractApiController.php
@@ -167,7 +167,7 @@ abstract class AbstractApiController extends Controller
             $items = $items->sortBy($sortBy, SORT_REGULAR, $direction);
         }
 
-        return $this->setMetaData($pagination)->setData(AutoPresenter::decorate($items->values()->all()))->respond();
+        return $this->setMetaData($pagination)->setData(AutoPresenter::decorate($items->values()))->respond();
     }
 
     /**


### PR DESCRIPTION
This allows to decorate all model's attributes inside the Collection.

This is the difference with and without ->all():

![schermata 2015-10-07 alle 15 26 43](https://cloud.githubusercontent.com/assets/779534/10338878/b38875a6-6d08-11e5-9280-b6723035e967.png)

The CollectionDecorator of AutoPresenter check that subject is a Collection and, if not, it doesn't decorate model's attributes:

https://github.com/laravel-auto-presenter/laravel-auto-presenter/blob/42c1dac02ac88a21cdd015cdf6d940898b4b7b97/src/PresenterDecorator.php#L44

https://github.com/laravel-auto-presenter/laravel-auto-presenter/blob/42c1dac02ac88a21cdd015cdf6d940898b4b7b97/src/Decorators/CollectionDecorator.php#L18