### PR TITLE
Restored Status Page localization

### DIFF
--- a/app/Http/Routes/StatusPageRoutes.php
+++ b/app/Http/Routes/StatusPageRoutes.php
@@ -28,7 +28,7 @@ class StatusPageRoutes
     public function map(Registrar $router)
     {
         $router->group([
-            'middleware' => 'app.hasSetting',
+            'middleware' => ['app.hasSetting', 'localize'],
             'setting'    => 'app_name',
         ], function ($router) {
             $router->get('/', [


### PR DESCRIPTION
Has been removed here: https://github.com/cachethq/Cachet/commit/c2c815ab14a7664fb7e56e4319377a175fd878cf#diff-d02b216c1d1bdf67feaa85180f7b2a84L30

But I think it's been removed by mistake