### PR TITLE
Use warning rather than error

### DIFF
--- a/app/Composers/StatusPageComposer.php
+++ b/app/Composers/StatusPageComposer.php
@@ -30,7 +30,7 @@ class StatusPageComposer
     {
         // Default data
         $withData = [
-            'systemStatus'  => 'danger',
+            'systemStatus'  => 'warning',
             'systemMessage' => trans('cachet.service.bad'),
             'favicon'       => 'favicon-high-alert',
         ];

--- a/app/Composers/StatusPageComposer.php
+++ b/app/Composers/StatusPageComposer.php
@@ -30,7 +30,7 @@ class StatusPageComposer
     {
         // Default data
         $withData = [
-            'systemStatus'  => 'warning',
+            'systemStatus'  => 'info',
             'systemMessage' => trans('cachet.service.bad'),
             'favicon'       => 'favicon-high-alert',
         ];


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/246103/10416367/4be5127c-700c-11e5-9c3a-5f1ff171f2b3.png)

Red is quite serious, maybe we could make it yellow? Also it matches the favicon when there is an issue.