### PR TITLE
Add `composer test` script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,6 +81,9 @@
         "post-create-project-cmd": [
             "php -r \"copy('.env.example', '.env');\"",
             "php artisan key:generate"
+        ],
+        "test": [
+            "phpunit"
         ]
     },
     "config": {


### PR DESCRIPTION
Composer supports defining custom scripts. Major PHP projects started adapting this and are now all defining their own `test` scripts. Here are some examples:

- https://github.com/composer/composer/blob/master/composer.json#L63-L65
- https://github.com/Seldaek/monolog/blob/master/composer.json#L60-L63

The advantage of this is pretty obvious; you don't have to have a global phpunit/whatever setup and can just run `composer test` for each library that you want to start working with.