### PR TITLE
Fixed typo for unsubscribe

### DIFF
--- a/app/Http/Controllers/SubscribeController.php
+++ b/app/Http/Controllers/SubscribeController.php
@@ -109,6 +109,6 @@ class SubscribeController extends Controller
         $this->dispatch(new UnsubscribeSubscriberCommand($subscriber));
 
         return Redirect::route('status-page')
-            ->withSuccess(sprintf('<strong>%s</strong> %s', trans('dashboard.notifications.awesome'), trans('cachet.subscriber.email.unsuscribed')));
+            ->withSuccess(sprintf('<strong>%s</strong> %s', trans('dashboard.notifications.awesome'), trans('cachet.subscriber.email.unsubscribed')));
     }
 }

--- a/resources/lang/en/cachet.php
+++ b/resources/lang/en/cachet.php
@@ -66,7 +66,7 @@ return [
             'subscribe'    => 'Subscribe to email updates.',
             'subscribed'   => 'You\'ve been subscribed to email notifications, please check your email to confirm your subscription.',
             'verified'     => 'Your email subscription has been confirmed. Thank you!',
-            'unsubscribe'  => 'Unsuscribe from email updates.',
+            'unsubscribe'  => 'Unsubscribe from email updates.',
             'unsubscribed' => 'Your email subscription has been cancelled.',
             'failure'      => 'Something went wrong with the subscription.',
             'verify'       => [


### PR DESCRIPTION
Found a typo in the english language file for unsubscribe link. Also noticed the unsubscribed flash message was misspelled so it wasn't pulling in the string.