### PR TITLE
Removed Bold Text On Footer 'Subscriber' Button #1056

### DIFF
--- a/resources/views/partials/stylesheet.blade.php
+++ b/resources/views/partials/stylesheet.blade.php
@@ -67,7 +67,6 @@ body.status-page {
     background-color: transparent;
     border-color: {{ $theme_greens }};
     color: {{ $theme_greens }};
-    font-weight: bold;
 }
 .btn.btn-success.btn-outline:hover {
     background-color: {{ $theme_greens }};


### PR DESCRIPTION
I don't think that bold text for 'Subscribe' within the button in the footer is coherent with the styling of the rest of the footer, hence this pull request removes the bold styling within the button.