### PR TITLE
Adjust the orders of php compiler for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
 
 php:
+  - 7.0
+  - hhvm
   - 5.5.9
   - 5.5
   - 5.6
-  - 7.0
-  - hhvm
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: php
 
 php:
   - 7.0
-  - hhvm
-  - 5.5.9
-  - 5.5
   - 5.6
+  - 5.5
+  - 5.5.9
+  - hhvm
 
 sudo: false
 


### PR DESCRIPTION
PHP 7 is up to twice as fast as PHP 5.x. 
So php unit test under PHP7 cost less time.We can get the response immediately if the travis unit test unpassed.