### PR TITLE
Fixes #1147, also see #1145

### DIFF
--- a/app/Http/Controllers/SetupController.php
+++ b/app/Http/Controllers/SetupController.php
@@ -65,6 +65,8 @@ class SetupController extends Controller
         return View::make('setup')
             ->withPageTitle(trans('setup.setup'))
             ->withCacheDrivers($this->cacheDrivers)
+            ->withAppTimezone(Config::get('cachet.timezone'))
+            ->withAppLocale(getenv('APP_LOCALE'))
             ->withAppUrl(Request::root());
     }
 

--- a/resources/views/setup.blade.php
+++ b/resources/views/setup.blade.php
@@ -85,7 +85,7 @@
                                 @foreach($timezones as $region => $list)
                                 <optgroup label="{{ $region }}">
                                 @foreach($list as $timezone => $name)
-                                <option value="{{ $timezone }}" @if(Input::old('settins.app_timezone') == $timezone) selected @endif>
+                                <option value="{{ $timezone }}" @if(Input::old('settins.app_timezone', $app_timezone) == $timezone) selected @endif>
                                     {{ $name }}
                                 </option>
                                 @endforeach
@@ -101,7 +101,7 @@
                             <select name="settings[app_locale]" class="form-control" required>
                                 <option value="">Select Language</option>
                                 @foreach($langs as $lang => $name)
-                                <option value="{{ $lang }}" @if(Input::old('settins.app_locale') == $timezone) selected @endif>
+                                <option value="{{ $lang }}" @if(Input::old('settins.app_locale', $app_locale) == $lang) selected @endif>
                                     {{ $name }}
                                 </option>
                                 @endforeach


### PR DESCRIPTION
## Changes

* SetupController
```PHP
public function getIndex()
    {
        // If we've copied the .env.example file, then we should try and reset it.
        if (getenv('APP_KEY') === 'SomeRandomString') {
            $this->keyGenerate();
        }

        return View::make('setup')
            ->withPageTitle(trans('setup.setup'))
            ->withCacheDrivers($this->cacheDrivers)
            ->withAppTimezone(Config::get('cachet.timezone'))
            ->withAppLocale(getenv('APP_LOCALE'))
            ->withAppUrl(Request::root());
    }
```
* setup.blade.php
```HTML
<option value="{{ $timezone }}" @if(Input::old('settins.app_timezone', $app_timezone) == $timezone) selected @endif>
......
<option value="{{ $lang }}" @if(Input::old('settins.app_locale', $app_locale) == $lang) selected @endif>
                                    {{ $name }}

```

## Why
If we set the value of APP_LOCAL in .env,  change the default value of timezone in config/cachet.php,
setup wizard pages will automatically select the default value.