### PR TITLE
Revert travis build order changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-  - 7.0
-  - 5.6
-  - 5.5
   - 5.5.9
+  - 5.5
+  - 5.6
+  - 7.0
   - hhvm
 
 sudo: false


### PR DESCRIPTION
This is the way to get the fastest total build time out of travis, which is why we had it like this in the first place.