### PR TITLE
Make MetricPoint events consistent.

### DIFF
--- a/app/Events/Metric/MetricPointWasAddedEvent.php
+++ b/app/Events/Metric/MetricPointWasAddedEvent.php
@@ -20,17 +20,17 @@ class MetricPointWasAddedEvent implements MetricEventInterface
      *
      * @var \CachetHQ\Cachet\Models\MetricPoint
      */
-    public $metric;
+    public $metricPoint;
 
     /**
      * Create a new metric point was added event instance.
      *
-     * @param \CachetHQ\Cachet\Models\MetricPoint $metric
+     * @param \CachetHQ\Cachet\Models\MetricPoint $metricPoint
      *
      * @return void
      */
-    public function __construct(MetricPoint $metric)
+    public function __construct(MetricPoint $metricPoint)
     {
-        $this->metric = $metric;
+        $this->metricPoint = $metricPoint;
     }
 }

--- a/app/Events/Metric/MetricPointWasUpdatedEvent.php
+++ b/app/Events/Metric/MetricPointWasUpdatedEvent.php
@@ -20,17 +20,17 @@ class MetricPointWasUpdatedEvent implements MetricEventInterface
      *
      * @var \CachetHQ\Cachet\Models\MetricPoint
      */
-    public $point;
+    public $metricPoint;
 
     /**
      * Create a new metric point was updated event instance.
      *
-     * @param \CachetHQ\Cachet\Models\MetricPoint $point
+     * @param \CachetHQ\Cachet\Models\MetricPoint $metricPoint
      *
      * @return void
      */
-    public function __construct(MetricPoint $point)
+    public function __construct(MetricPoint $metricPoint)
     {
-        $this->point = $point;
+        $this->metricPoint = $metricPoint;
     }
 }


### PR DESCRIPTION
I noticed the properties were inconsistent during the documentation changes.
I've kept the original properties as well, for backwards compatibility although have marked these as deprecated.