### PR TITLE
Improved human_status of ComponentPresenter

### DIFF
--- a/app/Presenters/IncidentPresenter.php
+++ b/app/Presenters/IncidentPresenter.php
@@ -187,9 +187,7 @@ class IncidentPresenter extends AbstractPresenter
      */
     public function human_status()
     {
-        $statuses = trans('cachet.incidents.status');
-
-        return $statuses[$this->wrappedObject->status];
+        return trans('cachet.incidents.status.'.$this->wrappedObject->status);
     }
 
     /**


### PR DESCRIPTION
Why are there two different implementations of the same functionality?

compare human_status in IncidentPresenter and ComponentPresenter.
