### PR TITLE
Display a status circle next to component groups. Closes #1317

### DIFF
--- a/app/Models/ComponentGroup.php
+++ b/app/Models/ComponentGroup.php
@@ -12,9 +12,11 @@
 namespace CachetHQ\Cachet\Models;
 
 use AltThree\Validator\ValidatingTrait;
+use CachetHQ\Cachet\Presenters\ComponentGroupPresenter;
 use Illuminate\Database\Eloquent\Model;
+use McCool\LaravelAutoPresenter\HasPresenter;
 
-class ComponentGroup extends Model
+class ComponentGroup extends Model implements HasPresenter
 {
     use ValidatingTrait;
 
@@ -47,6 +49,13 @@ class ComponentGroup extends Model
     ];
 
     /**
+     * The relations to eager load on every query.
+     *
+     * @var string[]
+     */
+    protected $with = ['enabled_components'];
+
+    /**
      * A group can have many components.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
@@ -54,5 +63,25 @@ class ComponentGroup extends Model
     public function components()
     {
         return $this->hasMany(Component::class, 'group_id', 'id');
+    }
+
+    /**
+     * Return all of the enabled components.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function enabled_components()
+    {
+        return $this->components()->enabled();
+    }
+
+    /**
+     * Get the presenter class.
+     *
+     * @return string
+     */
+    public function getPresenterClass()
+    {
+        return ComponentGroupPresenter::class;
     }
 }

--- a/app/Presenters/ComponentGroupPresenter.php
+++ b/app/Presenters/ComponentGroupPresenter.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Presenters;
+
+use CachetHQ\Cachet\Presenters\Traits\TimestampsTrait;
+
+class ComponentGroupPresenter extends AbstractPresenter
+{
+    use TimestampsTrait;
+
+    /**
+     * Returns the lowest component status.
+     *
+     * @return string
+     */
+    public function lowest_status()
+    {
+        return $this->wrappedObject->enabled_components->first()->human_status;
+    }
+
+    /**
+     * Returns the lowest component status, readable by humans.
+     *
+     * @return string
+     */
+    public function lowest_human_status()
+    {
+        return $this->wrappedObject->enabled_components->first()->human_status;
+    }
+
+    /**
+     * Returns the lowest component status color.
+     *
+     * @return string
+     */
+    public function lowest_status_color()
+    {
+        return $this->wrappedObject->enabled_components->first()->status_color;
+    }
+
+    /**
+     * Convert the presenter instance to an array.
+     *
+     * @return string[]
+     */
+    public function toArray()
+    {
+        return array_merge($this->wrappedObject->toArray(), [
+            'created_at'          => $this->created_at(),
+            'updated_at'          => $this->updated_at(),
+            'lowest_human_status' => $this->lowest_human_status(),
+        ]);
+    }
+}

--- a/app/Presenters/ComponentGroupPresenter.php
+++ b/app/Presenters/ComponentGroupPresenter.php
@@ -20,31 +20,37 @@ class ComponentGroupPresenter extends AbstractPresenter
     /**
      * Returns the lowest component status.
      *
-     * @return string
+     * @return string|null
      */
     public function lowest_status()
     {
-        return $this->wrappedObject->enabled_components->first()->human_status;
+        if ($enabledComponents = $this->wrappedObject->enabled_components()->orderBy('status', 'desc')->first()) {
+            return $enabledComponents->status;
+        }
     }
 
     /**
      * Returns the lowest component status, readable by humans.
      *
-     * @return string
+     * @return string|null
      */
     public function lowest_human_status()
     {
-        return $this->wrappedObject->enabled_components->first()->human_status;
+        if ($enabledComponents = $this->wrappedObject->enabled_components()->orderBy('status', 'desc')->first()) {
+            return $enabledComponents->human_status;
+        }
     }
 
     /**
      * Returns the lowest component status color.
      *
-     * @return string
+     * @return string|null
      */
     public function lowest_status_color()
     {
-        return $this->wrappedObject->enabled_components->first()->status_color;
+        if ($enabledComponents = $this->wrappedObject->enabled_components()->orderBy('status', 'desc')->first()) {
+            return $enabledComponents->status_color;
+        }
     }
 
     /**

--- a/resources/views/partials/components.blade.php
+++ b/resources/views/partials/components.blade.php
@@ -5,6 +5,10 @@
     <li class="list-group-item group-name">
         <i class="ion-ios-minus-outline group-toggle"></i>
         <strong>{{ $componentGroup->name }}</strong>
+
+        <div class="pull-right">
+            <i class="ion-ios-circle-filled text-component-{{ $componentGroup->lowest_status }} {{ $componentGroup->lowest_status_color }}" data-toggle="tooltip" title="{{ $componentGroup->lowest_human_status }}"></i>
+        </div>
     </li>
 
     <div class="group-items">

--- a/resources/views/partials/components.blade.php
+++ b/resources/views/partials/components.blade.php
@@ -1,7 +1,7 @@
 <ul class="list-group components">
     @if($component_groups->count() > 0)
     @foreach($component_groups as $componentGroup)
-    @if($componentGroup->components()->enabled()->count() > 0)
+    @if($componentGroup->enabled_components->count() > 0)
     <li class="list-group-item group-name">
         <i class="ion-ios-minus-outline group-toggle"></i>
         <strong>{{ $componentGroup->name }}</strong>
@@ -12,7 +12,7 @@
     </li>
 
     <div class="group-items">
-    @foreach($componentGroup->components()->enabled()->orderBy('order')->get() as $component)
+    @foreach($componentGroup->enabled_components()->orderBy('order')->get() as $component)
     @include('partials.component', compact($component))
     @endforeach
     </div>


### PR DESCRIPTION
Looks like this:

![image](https://cloud.githubusercontent.com/assets/246103/12078590/fce67602-b20f-11e5-967c-ae67caf8ee02.png)
