### PR TITLE
Disable xdebug when not running as PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ sudo: false
 install:
   - travis_retry composer install --no-interaction --no-scripts --prefer-source
 
+before_script:
+  - if [ "$TRAVIS_PHP_VERSION" != "5.6" ] || [ "$TRAVIS_PULL_REQUEST" != false ]; then phpenv config-rm xdebug.ini; fi
+
 script:
   - if [ "$TRAVIS_PHP_VERSION" != "5.6" ] || [ "$TRAVIS_PULL_REQUEST" != false ]; then vendor/bin/phpunit; fi
   - if [ "$TRAVIS_PHP_VERSION" == "5.6" ] && [ "$TRAVIS_PULL_REQUEST" == false ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; fi


### PR DESCRIPTION
Although @GrahamCampbell hasn't had much luck with this, we've at least tried to make Travis more efficient.