### PR TITLE
Fix a division by zero error

### DIFF
--- a/app/Composers/StatusPageComposer.php
+++ b/app/Composers/StatusPageComposer.php
@@ -29,7 +29,11 @@ class StatusPageComposer
     {
         $totalComponents = Component::enabled()->count();
         $majorOutages = Component::enabled()->status(4)->count();
-        $isMajorOutage = ($majorOutages / $totalComponents) >= 0.5;
+        $isMajorOutage = false;
+
+        if ($totalComponents > 0) {
+            $isMajorOutage = ($majorOutages / $totalComponents) >= 0.5;
+        }
 
         // Default data
         $withData = [


### PR DESCRIPTION
On an installation with no components the status page will throw a 500 error.