### PR TITLE
Make the Y axis start at zero

### DIFF
--- a/resources/views/partials/metrics.blade.php
+++ b/resources/views/partials/metrics.blade.php
@@ -39,6 +39,7 @@
 <script>
 (function () {
     Chart.defaults.global.pointHitDetectionRadius = 1;
+    Chart.defaults.global.scaleBeginAtZero = true;
 
     var charts = JSON.parse(document.getElementById('metricData').text);
 


### PR DESCRIPTION
Because tiny changes in, say, response time (210ms -> 219ms -> 208ms) on the non-zero Y scale (200ms to 220ms) might look like really big scary peaks or dips even if they are actually not.