### PR TITLE
[WIP] Show the component status within a label

### DIFF
--- a/app/Presenters/ComponentPresenter.php
+++ b/app/Presenters/ComponentPresenter.php
@@ -35,6 +35,21 @@ class ComponentPresenter extends BasePresenter implements Arrayable
     }
 
     /**
+     * Return the color for the status label.
+     *
+     * @return string
+     */
+    public function label_color()
+    {
+        switch ($this->wrappedObject->status) {
+            case 1: return 'success';
+            case 2: return 'info';
+            case 3: return 'warning';
+            case 4: return 'danger';
+        }
+    }
+
+    /**
      * Looks up the human readable version of the status.
      *
      * @return string

--- a/resources/views/partials/component.blade.php
+++ b/resources/views/partials/component.blade.php
@@ -14,6 +14,6 @@
     @endif
 
     <div class="pull-right">
-        <small class="text-component-{{ $component->status }} {{ $component->status_color }}">{{ $component->human_status }}</small>
+        <span class="label label-{{ $component->label_color }} label-{{ $component->status_color }}">{{ $component->human_status }}</span>
     </div>
 </li>


### PR DESCRIPTION
Looks like this:

![image](https://cloud.githubusercontent.com/assets/246103/12942456/362b2b0c-cfd3-11e5-9db1-841df0efcc10.png)

A custom stylesheet can be applied to remove the colours though.