### PR TITLE
Eager load tags on components

### DIFF
--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -107,6 +107,13 @@ class Component extends Model implements HasPresenter
     ];
 
     /**
+     * The relations to eager load on every query.
+     *
+     * @var string[]
+     */
+    protected $with = ['tags'];
+
+    /**
      * Components can belong to a group.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo


### PR DESCRIPTION
Closes #1697 

---

The output for the Component API now looks like this:

```json
{
  "meta":{
    "pagination":{
      "total":5,
      "count":5,
      "per_page":20,
      "current_page":1,
      "total_pages":1,
      "links":{
        "next_page":null,
        "previous_page":null
      }
    }
  },
  "data":[
    {
      "id":1,
      "name":"API",
      "description":"Used by third-parties to connect to us",
      "link":"",
      "status":1,
      "order":0,
      "group_id":0,
      "enabled":true,
      "created_at":"2016-04-06 20:11:52",
      "updated_at":"2016-04-06 20:11:52",
      "deleted_at":null,
      "tags":[
        {
          "id":1,
          "name":"API",
          "slug":"api",
          "created_at":"2016-04-16 08:28:21",
          "updated_at":"2016-04-16 08:28:21",
          "pivot":{
            "component_id":1,
            "tag_id":1
          }
        },
        {
          "id":2,
          "name":"Foo",
          "slug":"foo",
          "created_at":"2016-04-16 08:28:26",
          "updated_at":"2016-04-16 08:28:26",
          "pivot":{
            "component_id":1,
            "tag_id":2
          }
        }
      ],
      "status_name":"Operational"
    },
    {
      "id":2,
      "name":"Documentation",
      "description":"Kindly powered by Readme.io",
      "link":"https:\/\/docs.cachethq.io",
      "status":1,
      "order":0,
      "group_id":1,
      "enabled":true,
      "created_at":"2016-04-06 20:11:52",
      "updated_at":"2016-04-06 20:11:52",
      "deleted_at":null,
      "tags":[
        {
          "id":1,
          "name":"API",
          "slug":"api",
          "created_at":"2016-04-16 08:28:21",
          "updated_at":"2016-04-16 08:28:21",
          "pivot":{
            "component_id":2,
            "tag_id":1
          }
        }
      ],
      "status_name":"Operational"
    },
    {
      "id":3,
      "name":"Website",
      "description":"",
      "link":"https:\/\/cachethq.io",
      "status":1,
      "order":0,
      "group_id":1,
      "enabled":true,
      "created_at":"2016-04-06 20:11:52",
      "updated_at":"2016-04-06 20:11:52",
      "deleted_at":null,
      "tags":[

      ],
      "status_name":"Operational"
    },
    {
      "id":4,
      "name":"Blog",
      "description":"The Alt Three Blog.",
      "link":"https:\/\/blog.alt-three.com",
      "status":1,
      "order":0,
      "group_id":2,
      "enabled":true,
      "created_at":"2016-04-06 20:11:52",
      "updated_at":"2016-04-06 20:11:52",
      "deleted_at":null,
      "tags":[

      ],
      "status_name":"Operational"
    },
    {
      "id":5,
      "name":"StyleCI",
      "description":"The PHP Coding Style Service.",
      "link":"https:\/\/styleci.io",
      "status":1,
      "order":1,
      "group_id":2,
      "enabled":true,
      "created_at":"2016-04-06 20:11:52",
      "updated_at":"2016-04-06 20:11:52",
      "deleted_at":null,
      "tags":[

      ],
      "status_name":"Operational"
    }
  ]
}
```