### PR TITLE
fix hidden (overlayed) tooltip

### DIFF
--- a/resources/views/partials/component.blade.php
+++ b/resources/views/partials/component.blade.php
@@ -6,11 +6,11 @@
     @endif
 
     @if($component->description)
-    <i class="ion ion-ios-help-outline help-icon" data-toggle="tooltip" data-title="{{ $component->description }}"></i>
+    <i class="ion ion-ios-help-outline help-icon" data-toggle="tooltip" data-title="{{ $component->description }}" data-container="body"></i>
     @endif
 
     @if(subscribers_enabled())
-    <a href="#" data-toggle="modal" data-target="#subscribe-modal" data-component-id="{{ $component->id }}"><i class="ion ion-ios-email-outline" data-toggle="tooltip" data-title="{{ trans('cachet.subscriber.email.component.tooltip-title', ['component_name' => $component->name]) }}"></i></a>
+    <a href="#" data-toggle="modal" data-target="#subscribe-modal" data-component-id="{{ $component->id }}"><i class="ion ion-ios-email-outline" data-toggle="tooltip" data-title="{{ trans('cachet.subscriber.email.component.tooltip-title', ['component_name' => $component->name]) }}" data-container="body"></i></a>
     @endif
 
     <div class="pull-right">


### PR DESCRIPTION
moved component's icons tooltip to the right

before:
![2016-04-17 13 13 54](https://cloud.githubusercontent.com/assets/2950241/14586503/e9b87d74-04a2-11e6-8e7c-e26c1b0525a6.png)

after:
![2016-04-17 13 14 14](https://cloud.githubusercontent.com/assets/2950241/14586508/f4d519b0-04a2-11e6-90b7-ffcdcf188a03.png)
