### PR TITLE
Tags API

### DIFF
--- a/app/Bus/Commands/ComponentTag/AddComponentTagCommand.php
+++ b/app/Bus/Commands/ComponentTag/AddComponentTagCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Commands\ComponentTag;
+
+use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\Tag;
+
+/**
+ * This is the add component tag command.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+final class AddComponentTagCommand
+{
+    /**
+     * The component to add the tag to.
+     *
+     * @var \CachetHQ\Cachet\Models\Component
+     */
+    public $component;
+
+    /**
+     * The tag to add to the component.
+     *
+     * @var \CachetHQ\Cachet\Models\Tag
+     */
+    public $tag;
+
+    /**
+     * The validation rules.
+     *
+     * @var string[]
+     */
+    public $rules = [
+        'component' => 'required',
+        'tag'       => 'required',
+    ];
+
+    /**
+     * Create a add component tag command instance.
+     *
+     * @param \CachetHQ\Cachet\Models\Component $component
+     * @param \CachetHQ\Cachet\Models\Tag       $tag
+     *
+     * @return void
+     */
+    public function __construct(Component $component, Tag $tag)
+    {
+        $this->component = $component;
+        $this->tag = $tag;
+    }
+}

--- a/app/Bus/Commands/ComponentTag/DeleteComponentTagCommand.php
+++ b/app/Bus/Commands/ComponentTag/DeleteComponentTagCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Commands\ComponentTag;
+
+use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\Tag;
+
+/**
+ * This is the delete component tag command.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+final class DeleteComponentTagCommand
+{
+    /**
+     * The component to delete the tag from.
+     *
+     * @var \CachetHQ\Cachet\Models\Component
+     */
+    public $component;
+
+    /**
+     * The tag to delete.
+     *
+     * @var \CachetHQ\Cachet\Models\Tag
+     */
+    public $tag;
+
+    /**
+     * The validation rules.
+     *
+     * @var string[]
+     */
+    public $rules = [
+        'component' => 'required',
+        'tag'       => 'required',
+    ];
+
+    /**
+     * Create a delete component tag command instance.
+     *
+     * @param \CachetHQ\Cachet\Models\Component $component
+     * @param \CachetHQ\Cachet\Models\Tag       $tag
+     *
+     * @return void
+     */
+    public function __construct(Component $component, Tag $tag)
+    {
+        $this->component = $component;
+        $this->tag = $tag;
+    }
+}

--- a/app/Bus/Commands/Tag/CreateTagCommand.php
+++ b/app/Bus/Commands/Tag/CreateTagCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Commands\Tag;
+
+/**
+ * This is the create tag command.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+final class CreateTagCommand
+{
+    /**
+     * The name.
+     *
+     * @var string
+     */
+    public $name;
+
+    /**
+     * The slug.
+     *
+     * @var string
+     */
+    public $slug;
+
+    /**
+     * The validation rules.
+     *
+     * @var array
+     */
+    public $rules = [
+        'name' => 'required|string',
+        'slug' => 'sometimes|string',
+    ];
+
+    /**
+     * Create a new create tag command instance.
+     *
+     * @param string $name
+     * @param string $slug
+     *
+     * @return void
+     */
+    public function __construct($name, $slug)
+    {
+        $this->name = $name;
+        $this->slug = $slug;
+    }
+}

--- a/app/Bus/Commands/Tag/DeleteTagCommand.php
+++ b/app/Bus/Commands/Tag/DeleteTagCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Commands\Tag;
+
+use CachetHQ\Cachet\Models\Tag;
+
+/**
+ * This is the delete tag command.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+final class DeleteTagCommand
+{
+    /**
+     * The tag.
+     *
+     * @var \CachetHQ\Cachet\Models\Tag
+     */
+    public $tag;
+
+    /**
+     * The validation rules.
+     *
+     * @var array
+     */
+    public $rules = [
+        'tag' => 'required',
+    ];
+
+    /**
+     * Create a new delete tag command instance.
+     *
+     * @param \CachetHQ\Cachet\Models\Tag $tag
+     *
+     * @return void
+     */
+    public function __construct(Tag $tag)
+    {
+        $this->tag = $tag;
+    }
+}

--- a/app/Bus/Commands/Tag/UpdateTagCommand.php
+++ b/app/Bus/Commands/Tag/UpdateTagCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Commands\Tag;
+
+use CachetHQ\Cachet\Models\Tag;
+
+/**
+ * This is the update tag command.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+final class UpdateTagCommand
+{
+    /**
+     * The tag.
+     *
+     * @var \CachetHQ\Cachet\Models\Tag
+     */
+    public $tag;
+
+    /**
+     * The name.
+     *
+     * @var string
+     */
+    public $name;
+
+    /**
+     * The slug.
+     *
+     * @var string
+     */
+    public $slug;
+
+    /**
+     * The validation rules.
+     *
+     * @var array
+     */
+    public $rules = [
+        'tag'  => 'required',
+        'name' => 'sometimes|string',
+        'slug' => 'sometimes|string',
+    ];
+
+    /**
+     * Create a new update tag command instance.
+     *
+     * @param \CachetHQ\Cachet\Models\Tag $tag
+     * @param string                      $name
+     * @param string                      $slug
+     *
+     * @return void
+     */
+    public function __construct(Tag $tag, $name, $slug)
+    {
+        $this->tag = $tag;
+        $this->name = $name;
+        $this->slug = $slug;
+    }
+}

--- a/app/Bus/Exceptions/Tag/TagDoesNotExistOnComponentException.php
+++ b/app/Bus/Exceptions/Tag/TagDoesNotExistOnComponentException.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Exceptions\Tag;
+
+use Exception;
+
+/**
+ * This is the tag does not exist on component exception class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class TagDoesNotExistOnComponentException extends Exception implements TagExceptionInterface
+{
+    //
+}

--- a/app/Bus/Exceptions/Tag/TagExceptionInterface.php
+++ b/app/Bus/Exceptions/Tag/TagExceptionInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Exceptions\Tag;
+
+use CachetHQ\Cachet\Bus\Exceptions\ExceptionInterface;
+
+/**
+ * This is the tag exception interface.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+interface TagExceptionInterface extends ExceptionInterface
+{
+    //
+}

--- a/app/Bus/Handlers/Commands/ComponentTag/AddComponentTagCommandHandler.php
+++ b/app/Bus/Handlers/Commands/ComponentTag/AddComponentTagCommandHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Commands\ComponentTag;
+
+use CachetHQ\Cachet\Bus\Commands\ComponentTag\AddComponentTagCommand;
+use CachetHQ\Cachet\Models\ComponentTag;
+
+/**
+ * This is the add component tag command handler.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class AddComponentTagCommandHandler
+{
+    /**
+     * Handle the add component tag command.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\ComponentTag\AddComponentTagCommand $command
+     *
+     * @return \CachetHQ\Cachet\Models\ComponentTag
+     */
+    public function handle(AddComponentTagCommand $command)
+    {
+        $tag = ComponentTag::create([
+            'component_id' => $command->component->id,
+            'tag_id'       => $command->tag->id,
+        ]);
+
+        return $tag;
+    }
+}

--- a/app/Bus/Handlers/Commands/ComponentTag/DeleteComponentTagCommandHandler.php
+++ b/app/Bus/Handlers/Commands/ComponentTag/DeleteComponentTagCommandHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Commands\ComponentTag;
+
+use CachetHQ\Cachet\Bus\Commands\ComponentTag\DeleteComponentTagCommand;
+use CachetHQ\Cachet\Bus\Exceptions\Tag\TagDoesNotExistOnComponentException;
+use CachetHQ\Cachet\Models\ComponentTag;
+
+/**
+ * This is the delete component tag command handler.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class DeleteComponentTagCommandHandler
+{
+    /**
+     * Handle the add component tag command.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\ComponentTag\DeleteComponentTagCommand $command
+     *
+     * @return void
+     */
+    public function handle(DeleteComponentTagCommand $command)
+    {
+        // If the tag does not exist on the component, throw an exception.
+        if (!($componentTag = ComponentTag::tagForComponent($command->tag->id, $command->component->id))) {
+            throw new TagDoesNotExistOnComponentException('The given tag <'.$command->tag->id.'> does not exist on this component <'.$command->componnet->id.'>');
+        }
+
+        $componentTag->delete();
+    }
+}

--- a/app/Bus/Handlers/Commands/Tag/CreateTagCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Tag/CreateTagCommandHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Commands\Tag;
+
+use CachetHQ\Cachet\Bus\Commands\Tag\CreateTagCommand;
+use CachetHQ\Cachet\Models\Tag;
+
+class CreateTagCommandHandler
+{
+    /**
+     * Handle the create tag command.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\Tag\CreateTagCommand $command
+     *
+     * @return \CachetHQ\Cachet\Models\Tag
+     */
+    public function handle(CreateTagCommand $command)
+    {
+        $tag = Tag::create([
+            'name' => $command->name,
+            'slug' => $command->slug,
+        ]);
+
+        return $tag;
+    }
+}

--- a/app/Bus/Handlers/Commands/Tag/DeleteTagCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Tag/DeleteTagCommandHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Commands\Tag;
+
+use CachetHQ\Cachet\Bus\Commands\Tag\DeleteTagCommand;
+use CachetHQ\Cachet\Models\Tag;
+
+class DeleteTagCommandHandler
+{
+    /**
+     * Handle the delete tag command.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\Tag\DeleteTagCommand $command
+     *
+     * @return void
+     */
+    public function handle(DeleteTagCommand $command)
+    {
+        $command->tag->delete();
+    }
+}

--- a/app/Bus/Handlers/Commands/Tag/UpdateTagCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Tag/UpdateTagCommandHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Commands\Tag;
+
+use CachetHQ\Cachet\Bus\Commands\Tag\UpdateTagCommand;
+use CachetHQ\Cachet\Models\Tag;
+
+class UpdateTagCommandHandler
+{
+    /**
+     * Handle the update tag command.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\Tag\UpdateTagCommand $command
+     *
+     * @return \CachetHQ\Cachet\Models\Tag
+     */
+    public function handle(UpdateTagCommand $command)
+    {
+        $command->tag->update($this->filter($command));
+
+        return $command->tag;
+    }
+
+    /**
+     * Filter the command data.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\Tag\UpdateTagCommand $command
+     *
+     * @return array
+     */
+    protected function filter(UpdateTagCommand $command)
+    {
+        $params = [
+            'name' => $command->name,
+            'slug' => $command->slug,
+        ];
+
+        return array_filter($params, function ($val) {
+            return $val !== null;
+        });
+    }
+}

--- a/app/Foundation/Providers/RouteServiceProvider.php
+++ b/app/Foundation/Providers/RouteServiceProvider.php
@@ -48,6 +48,7 @@ class RouteServiceProvider extends ServiceProvider
     {
         $this->app->router->model('component', 'CachetHQ\Cachet\Models\Component');
         $this->app->router->model('component_group', 'CachetHQ\Cachet\Models\ComponentGroup');
+        $this->app->router->model('component_tag', 'CachetHQ\Cachet\Models\ComponentTag');
         $this->app->router->model('incident', 'CachetHQ\Cachet\Models\Incident');
         $this->app->router->model('incident_template', 'CachetHQ\Cachet\Models\IncidentTemplate');
         $this->app->router->model('metric', 'CachetHQ\Cachet\Models\Metric');
@@ -55,6 +56,7 @@ class RouteServiceProvider extends ServiceProvider
         $this->app->router->model('setting', 'CachetHQ\Cachet\Models\Setting');
         $this->app->router->model('subscriber', 'CachetHQ\Cachet\Models\Subscriber');
         $this->app->router->model('subscription', 'CachetHQ\Cachet\Models\Subscription');
+        $this->app->router->model('tag', 'CachetHQ\Cachet\Models\Tag');
         $this->app->router->model('user', 'CachetHQ\Cachet\Models\User');
     }
 

--- a/app/Http/Controllers/Api/ComponentTagController.php
+++ b/app/Http/Controllers/Api/ComponentTagController.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Http\Controllers\Api;
+
+use CachetHQ\Cachet\Bus\Commands\ComponentTag\AddComponentTagCommand;
+use CachetHQ\Cachet\Bus\Commands\ComponentTag\DeleteComponentTagCommand;
+use CachetHQ\Cachet\Bus\Exceptions\Tag\TagDoesNotExistOnComponentException;
+use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\ComponentTag;
+use CachetHQ\Cachet\Models\Tag;
+use GrahamCampbell\Binput\Facades\Binput;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * This is the component tag controller class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class ComponentTagController extends AbstractApiController
+{
+    /**
+     * Get all tags.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getTags()
+    {
+        $tags = Tag::query();
+
+        $tags->search(Binput::except(['sort', 'order', 'per_page']));
+
+        if ($sortBy = Binput::get('sort')) {
+            $direction = Binput::has('order') && Binput::get('order') == 'desc';
+
+            $tags->sort($sortBy, $direction);
+        }
+
+        $tags = $tags->paginate(Binput::get('per_page', 20));
+
+        return $this->paginator($tags, Request::instance());
+    }
+
+    /**
+     * Get a single component tag.
+     *
+     * @param \CachetHQ\Cachet\Models\ComponentTag $componentTag
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getTag(ComponentTag $componentTag)
+    {
+        return $this->item($componentTag);
+    }
+
+    /**
+     * Create a new component tag.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function postTags()
+    {
+        $component = Component::find(Binput::get('component_id'));
+        $tag = Tag::find(Binput::get('tag_id'));
+
+        if (!($component && $tag)) {
+            throw new BadRequestHttpException();
+        }
+
+        try {
+            $tag = dispatch(new AddComponentTagCommand(
+                $component,
+                $tag
+            ));
+        } catch (QueryException $e) {
+            throw new BadRequestHttpException();
+        }
+
+        return $this->item($tag);
+    }
+
+    /**
+     * Delete an existing tag.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function deleteTag()
+    {
+        $component = Component::find(Binput::get('component_id'));
+        $tag = Tag::find(Binput::get('tag_id'));
+
+        if (!($component && $tag)) {
+            throw new BadRequestHttpException();
+        }
+
+        try {
+            dispatch(new DeleteComponentTagCommand(
+                $component,
+                $tag
+            ));
+        } catch (TagDoesNotExistOnComponentException $e) {
+            throw new BadRequestHttpException();
+        }
+
+        return $this->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/TagController.php
+++ b/app/Http/Controllers/Api/TagController.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Http\Controllers\Api;
+
+use CachetHQ\Cachet\Bus\Commands\Tag\CreateTagCommand;
+use CachetHQ\Cachet\Bus\Commands\Tag\DeleteTagCommand;
+use CachetHQ\Cachet\Bus\Commands\Tag\UpdateTagCommand;
+use CachetHQ\Cachet\Models\Tag;
+use GrahamCampbell\Binput\Facades\Binput;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class TagController extends AbstractApiController
+{
+    /**
+     * Get all tags.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getTags()
+    {
+        $tags = Tag::query();
+
+        $tags->search(Binput::except(['sort', 'order', 'per_page']));
+
+        if ($sortBy = Binput::get('sort')) {
+            $direction = Binput::has('order') && Binput::get('order') == 'desc';
+
+            $tags->sort($sortBy, $direction);
+        }
+
+        $tags = $tags->paginate(Binput::get('per_page', 20));
+
+        return $this->paginator($tags, Request::instance());
+    }
+
+    /**
+     * Get a single tag.
+     *
+     * @param \CachetHQ\Cachet\Models\Tag $tag
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getTag(Tag $tag)
+    {
+        return $this->item($tag);
+    }
+
+    /**
+     * Create a new tag.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function postTags()
+    {
+        try {
+            $tag = dispatch(new CreateTagCommand(
+                Binput::get('name'),
+                Binput::get('slug')
+            ));
+        } catch (QueryException $e) {
+            throw new BadRequestHttpException();
+        }
+
+        return $this->item($tag);
+    }
+
+    /**
+     * Update an existing tag.
+     *
+     * @param \CachetHQ\Cachet\Models\Tag $tag
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function putTag(Tag $tag)
+    {
+        try {
+            $tag = dispatch(new UpdateTagCommand(
+                $tag,
+                Binput::get('name'),
+                Binput::get('slug')
+            ));
+        } catch (QueryException $e) {
+            throw new BadRequestHttpException();
+        }
+
+        return $this->item($tag);
+    }
+
+    /**
+     * Delete an existing tag.
+     *
+     * @param \CachetHQ\Cachet\Models\Tag $tag
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function deleteTag(Tag $tag)
+    {
+        dispatch(new DeleteTagCommand($tag));
+
+        return $this->noContent();
+    }
+}

--- a/app/Http/Routes/ApiRoutes.php
+++ b/app/Http/Routes/ApiRoutes.php
@@ -37,6 +37,8 @@ class ApiRoutes
                 $router->get('components', 'ComponentController@getComponents');
                 $router->get('components/groups', 'ComponentGroupController@getGroups');
                 $router->get('components/groups/{component_group}', 'ComponentGroupController@getGroup');
+                $router->get('components/tags', 'ComponentTagController@getTags');
+                $router->get('components/tags/{component_tag}', 'ComponentTagController@getTag');
                 $router->get('components/{component}', 'ComponentController@getComponent');
 
                 $router->get('incidents', 'IncidentController@getIncidents');
@@ -58,6 +60,7 @@ class ApiRoutes
 
                 $router->post('components', 'ComponentController@postComponents');
                 $router->post('components/groups', 'ComponentGroupController@postGroups');
+                $router->post('components/tags', 'ComponentTagController@postTags');
                 $router->post('incidents', 'IncidentController@postIncidents');
                 $router->post('incidents/{incident}/updates', 'IncidentUpdateController@postIncidentUpdate');
                 $router->post('metrics', 'MetricController@postMetrics');
@@ -74,6 +77,7 @@ class ApiRoutes
                 $router->put('tags/{tag}', 'TagController@putTag');
 
                 $router->delete('components/groups/{component_group}', 'ComponentGroupController@deleteGroup');
+                $router->delete('components/tags', 'ComponentTagController@deleteTag');
                 $router->delete('components/{component}', 'ComponentController@deleteComponent');
                 $router->delete('incidents/{incident}', 'IncidentController@deleteIncident');
                 $router->delete('incidents/{incident}/updates/{update}', 'IncidentUpdateController@deleteIncidentUpdate');

--- a/app/Http/Routes/ApiRoutes.php
+++ b/app/Http/Routes/ApiRoutes.php
@@ -48,6 +48,9 @@ class ApiRoutes
                 $router->get('metrics', 'MetricController@getMetrics');
                 $router->get('metrics/{metric}', 'MetricController@getMetric');
                 $router->get('metrics/{metric}/points', 'MetricController@getMetricPoints');
+
+                $router->get('tags', 'TagController@getTags');
+                $router->get('tags/{tag}', 'TagController@getTag');
             });
 
             $router->group(['middleware' => ['auth.api:true']], function (Registrar $router) {
@@ -60,6 +63,7 @@ class ApiRoutes
                 $router->post('metrics', 'MetricController@postMetrics');
                 $router->post('metrics/{metric}/points', 'MetricPointController@postMetricPoints');
                 $router->post('subscribers', 'SubscriberController@postSubscribers');
+                $router->post('tags', 'TagController@postTags');
 
                 $router->put('components/groups/{component_group}', 'ComponentGroupController@putGroup');
                 $router->put('components/{component}', 'ComponentController@putComponent');
@@ -67,6 +71,7 @@ class ApiRoutes
                 $router->put('incidents/{incident}/updates/{update}', 'IncidentUpdateController@putIncidentUpdate');
                 $router->put('metrics/{metric}', 'MetricController@putMetric');
                 $router->put('metrics/{metric}/points/{metric_point}', 'MetricPointController@putMetricPoint');
+                $router->put('tags/{tag}', 'TagController@putTag');
 
                 $router->delete('components/groups/{component_group}', 'ComponentGroupController@deleteGroup');
                 $router->delete('components/{component}', 'ComponentController@deleteComponent');
@@ -76,6 +81,7 @@ class ApiRoutes
                 $router->delete('metrics/{metric}/points/{metric_point}', 'MetricPointController@deleteMetricPoint');
                 $router->delete('subscribers/{subscriber}', 'SubscriberController@deleteSubscriber');
                 $router->delete('subscriptions/{subscription}', 'SubscriberController@deleteSubscription');
+                $router->delete('tags/{tag}', 'TagController@deleteTag');
             });
         });
     }

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -129,11 +129,11 @@ class Component extends Model implements HasPresenter
     /**
      * Components can have many tags.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
      */
     public function tags()
     {
-        return $this->belongsToMany(Tag::class);
+        return $this->hasManyThrough(Tag::class, ComponentTag::class, 'tag_id', 'id');
     }
 
     /**

--- a/app/Models/ComponentTag.php
+++ b/app/Models/ComponentTag.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * This is the component tag class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class ComponentTag extends Model
+{
+    /**
+     * The attributes that should be casted to native types.
+     *
+     * @var string[]
+     */
+    protected $casts = [
+        'component_id' => 'int',
+        'tag_id'       => 'int',
+    ];
+
+    /**
+     * The fillable properties.
+     *
+     * @var string[]
+     */
+    protected $fillable = ['component_id', 'tag_id'];
+
+    /**
+     * Get the component relation.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function component()
+    {
+        return $this->belongsTo(Component::class, 'component_id', 'id');
+    }
+
+    /**
+     * Get the tag relation.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function tag()
+    {
+        return $this->belongsTo(Tag::class, 'tag_id', 'id');
+    }
+
+    /**
+     * Find a given tag for a component.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param int                                   $tagId
+     * @param int                                   $componentId
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeTagForComponent(Builder $query, $tagId, $componentId)
+    {
+        return $query->where('component_id', $componentId)->where('tag_id', $tagId);
+    }
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -11,11 +11,14 @@
 
 namespace CachetHQ\Cachet\Models;
 
+use CachetHQ\Cachet\Models\Traits\SearchableTrait;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
 class Tag extends Model
 {
+    use SearchableTrait;
+
     /**
      * The attributes that should be casted to native types.
      *
@@ -31,6 +34,28 @@ class Tag extends Model
      * @var string[]
      */
     protected $fillable = ['name'];
+
+    /**
+     * The searchable fields.
+     *
+     * @var string[]
+     */
+    protected $searchable = [
+        'id',
+        'name',
+        'slug',
+    ];
+
+    /**
+     * The sortable fields.
+     *
+     * @var string[]
+     */
+    protected $sortable = [
+        'id',
+        'name',
+        'slug',
+    ];
 
     /**
      * Overrides the models boot method.

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -12,12 +12,13 @@
 namespace CachetHQ\Cachet\Models;
 
 use CachetHQ\Cachet\Models\Traits\SearchableTrait;
+use CachetHQ\Cachet\Models\Traits\SortableTrait;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
 class Tag extends Model
 {
-    use SearchableTrait;
+    use SearchableTrait, SortableTrait;
 
     /**
      * The attributes that should be casted to native types.

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -11,6 +11,7 @@
 
 use CachetHQ\Cachet\Models\Component;
 use CachetHQ\Cachet\Models\ComponentGroup;
+use CachetHQ\Cachet\Models\ComponentTag;
 use CachetHQ\Cachet\Models\Incident;
 use CachetHQ\Cachet\Models\IncidentTemplate;
 use CachetHQ\Cachet\Models\IncidentUpdate;
@@ -38,6 +39,13 @@ $factory->define(ComponentGroup::class, function ($faker) {
         'name'      => $faker->words(2, true),
         'order'     => 0,
         'collapsed' => random_int(0, 3),
+    ];
+});
+
+$factory->define(ComponentTag::class, function ($faker) {
+    return [
+        'component_id' => factory(Component::class)->create()->id,
+        'tag_id'       => factory(Tag::class)->create()->id,
     ];
 });
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -18,8 +18,10 @@ use CachetHQ\Cachet\Models\Metric;
 use CachetHQ\Cachet\Models\MetricPoint;
 use CachetHQ\Cachet\Models\Subscriber;
 use CachetHQ\Cachet\Models\Subscription;
+use CachetHQ\Cachet\Models\Tag;
 use CachetHQ\Cachet\Models\User;
 use Carbon\Carbon;
+use Illuminate\Support\Str;
 
 $factory->define(Component::class, function ($faker) {
     return [
@@ -98,6 +100,15 @@ $factory->define(Subscription::class, function ($faker) {
     return [
         'subscriber_id' => factory(Subscriber::class)->create()->id,
         'component_id'  => factory(Component::class)->create()->id,
+    ];
+});
+
+$factory->define(Tag::class, function ($faker) {
+    $name = $faker->sentence();
+
+    return [
+        'name' => $name,
+        'slug' => Str::slug($name),
     ];
 });
 

--- a/database/migrations/2016_04_21_150021_RenameComponentTagTable.php
+++ b/database/migrations/2016_04_21_150021_RenameComponentTagTable.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+class RenameComponentTagTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename('component_tag', 'component_tags');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::rename('component_tags', 'component_tag');
+    }
+}

--- a/database/migrations/2016_04_21_153227_AlterTableComponentTagsAddTimestamps.php
+++ b/database/migrations/2016_04_21_153227_AlterTableComponentTagsAddTimestamps.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterTableComponentTagsAddTimestamps extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('component_tags', function (Blueprint $table) {
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('component_tags', function (Blueprint $table) {
+            $table->dropTimestamps();
+        });
+    }
+}

--- a/tests/Api/ComponentTagTest.php
+++ b/tests/Api/ComponentTagTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Api;
+
+/**
+ * This is the component tag test class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class ComponentTagTest extends AbstractApiTestCase
+{
+    public function testGetTags()
+    {
+        $tags = factory('CachetHQ\Cachet\Models\ComponentTag', 3)->create();
+
+        $this->get('/api/v1/components/tags');
+        $this->seeJson(['id' => $tags[0]->id]);
+        $this->seeJson(['id' => $tags[1]->id]);
+        $this->seeJson(['id' => $tags[2]->id]);
+        $this->assertResponseOk();
+    }
+
+    public function testGetInvalidTag()
+    {
+        $this->get('/api/v1/components/tags/1');
+        $this->assertResponseStatus(404);
+    }
+
+    public function testPostTagUnauthorized()
+    {
+        $this->post('/api/v1/components/tags');
+
+        $this->assertResponseStatus(401);
+    }
+
+    public function testPostTagNoData()
+    {
+        $this->beUser();
+
+        $this->post('/api/v1/components/tags');
+        $this->assertResponseStatus(400);
+    }
+
+    public function testPostTag()
+    {
+        $this->beUser();
+
+        $component = factory('CachetHQ\Cachet\Models\Component')->create();
+        $tag = factory('CachetHQ\Cachet\Models\Tag')->create();
+
+        $this->post('/api/v1/components/tags', [
+            'component_id' => $component->id,
+            'tag_id'       => $tag->id,
+        ]);
+        $this->seeJson(['component_id' => $component->id, 'tag_id' => $tag->id]);
+        $this->assertResponseOk();
+    }
+
+    public function testGetNewTag()
+    {
+        $tag = factory('CachetHQ\Cachet\Models\ComponentTag')->create();
+
+        $this->get('/api/v1/components/tags/1');
+        $this->seeJson(['tag_id' => $tag->id]);
+        $this->assertResponseOk();
+    }
+
+    public function testDeleteTag()
+    {
+        $this->beUser();
+        $tag = factory('CachetHQ\Cachet\Models\ComponentTag')->create();
+
+        $this->delete('/api/v1/components/tags', [
+            'component_id' => $tag->component_id,
+            'tag_id'       => $tag->tag_id,
+        ]);
+        $this->assertResponseStatus(204);
+    }
+}

--- a/tests/Api/TagTest.php
+++ b/tests/Api/TagTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Api;
+
+/**
+ * This is the tag test class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class TagTest extends AbstractApiTestCase
+{
+    public function testGetTags()
+    {
+        $tags = factory('CachetHQ\Cachet\Models\Tag', 3)->create();
+
+        $this->get('/api/v1/tags');
+        $this->seeJson(['id' => $tags[0]->id]);
+        $this->seeJson(['id' => $tags[1]->id]);
+        $this->seeJson(['id' => $tags[2]->id]);
+        $this->assertResponseOk();
+    }
+
+    public function testGetInvalidTag()
+    {
+        $this->get('/api/v1/tags/1');
+        $this->assertResponseStatus(404);
+    }
+
+    public function testPostTagUnauthorized()
+    {
+        $this->post('/api/v1/tags');
+
+        $this->assertResponseStatus(401);
+    }
+
+    public function testPostTagNoData()
+    {
+        $this->beUser();
+
+        $this->post('/api/v1/tags');
+        $this->assertResponseStatus(400);
+    }
+
+    public function testPostTag()
+    {
+        $this->beUser();
+
+        $this->post('/api/v1/tags', [
+            'name' => 'Foo',
+            'slug' => 'foo',
+        ]);
+        $this->seeJson(['name' => 'Foo', 'slug' => 'foo']);
+        $this->assertResponseOk();
+    }
+
+    public function testGetNewTag()
+    {
+        $tag = factory('CachetHQ\Cachet\Models\Tag')->create();
+
+        $this->get('/api/v1/tags/1');
+        $this->seeJson(['name' => $tag->name]);
+        $this->assertResponseOk();
+    }
+
+    public function testPutTag()
+    {
+        $this->beUser();
+        $tag = factory('CachetHQ\Cachet\Models\Tag')->create();
+
+        $this->put('/api/v1/tags/1', [
+            'name' => 'Lorem Ipsum Tagous',
+        ]);
+        $this->seeJson(['name' => 'Lorem Ipsum Tagous']);
+        $this->assertResponseOk();
+    }
+
+    public function testDeleteTag()
+    {
+        $this->beUser();
+        $tag = factory('CachetHQ\Cachet\Models\Tag')->create();
+
+        $this->delete('/api/v1/tags/1');
+        $this->assertResponseStatus(204);
+    }
+}

--- a/tests/Bus/Commands/ComponentTag/AddComponentTagCommandTest.php
+++ b/tests/Bus/Commands/ComponentTag/AddComponentTagCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Bus\Commands\ComponentTag;
+
+use AltThree\TestBench\CommandTrait;
+use CachetHQ\Cachet\Bus\Commands\ComponentTag\AddComponentTagCommand;
+use CachetHQ\Cachet\Bus\Handlers\Commands\ComponentTag\AddComponentTagCommandHandler;
+use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\Tag;
+use CachetHQ\Tests\Cachet\AbstractTestCase;
+
+/**
+ * This is the add component tag command test class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class AddComponentTagCommandTest extends AbstractTestCase
+{
+    use CommandTrait;
+
+    protected function getObjectAndParams()
+    {
+        $params = ['component' => new Component(), 'tag' => new Tag()];
+
+        $object = new AddComponentTagCommand($params['component'], $params['tag']);
+
+        return compact('params', 'object');
+    }
+
+    protected function objectHasRules()
+    {
+        return true;
+    }
+
+    protected function getHandlerClass()
+    {
+        return AddComponentTagCommandHandler::class;
+    }
+}

--- a/tests/Bus/Commands/ComponentTag/DeleteComponentTagCommandTest.php
+++ b/tests/Bus/Commands/ComponentTag/DeleteComponentTagCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Bus\Commands\ComponentTag;
+
+use AltThree\TestBench\CommandTrait;
+use CachetHQ\Cachet\Bus\Commands\ComponentTag\DeleteComponentTagCommand;
+use CachetHQ\Cachet\Bus\Handlers\Commands\ComponentTag\DeleteComponentTagCommandHandler;
+use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\Tag;
+use CachetHQ\Tests\Cachet\AbstractTestCase;
+
+/**
+ * This is the delete component tag command test class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class DeleteComponentTagCommandTest extends AbstractTestCase
+{
+    use CommandTrait;
+
+    protected function getObjectAndParams()
+    {
+        $params = ['component' => new Component(), 'tag' => new Tag()];
+
+        $object = new DeleteComponentTagCommand($params['component'], $params['tag']);
+
+        return compact('params', 'object');
+    }
+
+    protected function objectHasRules()
+    {
+        return true;
+    }
+
+    protected function getHandlerClass()
+    {
+        return DeleteComponentTagCommandHandler::class;
+    }
+}

--- a/tests/Bus/Commands/Tag/CreateTagCommandTest.php
+++ b/tests/Bus/Commands/Tag/CreateTagCommandTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Bus\Commands\Tag;
+
+use AltThree\TestBench\CommandTrait;
+use CachetHQ\Cachet\Bus\Commands\Tag\CreateTagCommand;
+use CachetHQ\Cachet\Bus\Handlers\Commands\Tag\CreateTagCommandHandler;
+use CachetHQ\Tests\Cachet\AbstractTestCase;
+
+/**
+ * This is the create tag command test class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class CreateTagCommandTest extends AbstractTestCase
+{
+    use CommandTrait;
+
+    protected function getObjectAndParams()
+    {
+        $params = ['name' => 'Hello World', 'slug' => 'hello-world'];
+        $object = new CreateTagCommand($params['name'], $params['slug']);
+
+        return compact('params', 'object');
+    }
+
+    protected function objectHasRules()
+    {
+        return true;
+    }
+
+    protected function getHandlerClass()
+    {
+        return CreateTagCommandHandler::class;
+    }
+}

--- a/tests/Bus/Commands/Tag/DeleteTagCommandTest.php
+++ b/tests/Bus/Commands/Tag/DeleteTagCommandTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Bus\Commands\Tag;
+
+use AltThree\TestBench\CommandTrait;
+use CachetHQ\Cachet\Bus\Commands\Tag\DeleteTagCommand;
+use CachetHQ\Cachet\Bus\Handlers\Commands\Tag\DeleteTagCommandHandler;
+use CachetHQ\Cachet\Models\Tag;
+use CachetHQ\Tests\Cachet\AbstractTestCase;
+
+/**
+ * This is the delete tag command test class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class DeleteTagCommandTest extends AbstractTestCase
+{
+    use CommandTrait;
+
+    protected function getObjectAndParams()
+    {
+        $params = ['tag' => new Tag()];
+        $object = new DeleteTagCommand($params['tag']);
+
+        return compact('params', 'object');
+    }
+
+    protected function objectHasRules()
+    {
+        return true;
+    }
+
+    protected function getHandlerClass()
+    {
+        return DeleteTagCommandHandler::class;
+    }
+}

--- a/tests/Bus/Commands/Tag/UpdateTagCommandTest.php
+++ b/tests/Bus/Commands/Tag/UpdateTagCommandTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Bus\Commands\Tag;
+
+use AltThree\TestBench\CommandTrait;
+use CachetHQ\Cachet\Bus\Commands\Tag\UpdateTagCommand;
+use CachetHQ\Cachet\Bus\Handlers\Commands\Tag\UpdateTagCommandHandler;
+use CachetHQ\Cachet\Models\Tag;
+use CachetHQ\Tests\Cachet\AbstractTestCase;
+
+/**
+ * This is the update tag command test class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class UpdateTagCommandTest extends AbstractTestCase
+{
+    use CommandTrait;
+
+    protected function getObjectAndParams()
+    {
+        $params = ['tag' => new Tag(), 'name' => 'Hello World', 'slug' => 'hello-world'];
+        $object = new UpdateTagCommand($params['tag'], $params['name'], $params['slug']);
+
+        return compact('params', 'object');
+    }
+
+    protected function objectHasRules()
+    {
+        return true;
+    }
+
+    protected function getHandlerClass()
+    {
+        return UpdateTagCommandHandler::class;
+    }
+}


### PR DESCRIPTION
Closes #1700.

- [x] Commands for creating tags.
- [x] Commands for creating relations between tags and components

---

This adds two new API's:

1. Tags - for actually managing tags themselves.
2. Component Tags - for adding and deleting tags on a component. This is API differs from the others a little, as we don't use model bindings. This will be explained in the documentation.

It turns out that we were never using the `component_tag` table, so that's been fixed.

- It's now renamed to `component_tags`.
- It contains the usual timestamp columns.

Aside from that:

- The `Component` model now has many `tags` through the `component_tags` table.
- We're now starting to use "Bus Exceptions", which aims to make a start on #1205.
- The dashboard remains the same. In the future the tags field will be a taggable list of some sort for cleaner UX.

All that is left is to implement the new commands into the dashboard code.