### PR TITLE
Always show vertical scrollbar

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -9,6 +9,9 @@ html {
     position: relative;
     min-height: 100%;
     -webkit-font-smoothing: antialiased;
+    // always show up-down scrollbar to prevent content from jumping left/right
+    // depending on whether the page is taller than 100% of viewport height
+    overflow-y: scroll;
 }
 
 body {


### PR DESCRIPTION
If you click from the home page to the subscribe page, the content shifts slightly to the right because the scrollbar is missing.