### PR TITLE
Allow us to set better default settings

### DIFF
--- a/app/Foundation/Providers/ConfigServiceProvider.php
+++ b/app/Foundation/Providers/ConfigServiceProvider.php
@@ -16,6 +16,13 @@ use CachetHQ\Cachet\Models\Setting as SettingModel;
 use Exception;
 use Illuminate\Support\ServiceProvider;
 
+/**
+ * This is the config service provider class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ * @author Graham Campbell <graham@alt-three.com>
+ * @author Joe Cohen <joe@alt-three.com>
+ */
 class ConfigServiceProvider extends ServiceProvider
 {
     /**
@@ -26,7 +33,16 @@ class ConfigServiceProvider extends ServiceProvider
     public function boot()
     {
         try {
-            $this->app->config->set('setting', $this->app->setting->all());
+            // Get the default settings.
+            $defaultSettings = $this->app->config->get('setting');
+
+            // Get the configured settings.
+            $appSettings = $this->app->setting->all();
+
+            // Merge the settings
+            $settings = array_merge($defaultSettings, $appSettings);
+
+            $this->app->config->set('setting', $settings);
         } catch (Exception $e) {
             //
         }

--- a/config/setting.php
+++ b/config/setting.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Dashboard Login Link
+    |--------------------------------------------------------------------------
+    |
+    | Whether to show the dashboard link in the footer by default.
+    |
+    */
+
+    'dashboard_login_link' => true,
+];


### PR DESCRIPTION
Closes #1755 

---

Now we can set all of our default settings in `./config/setting.php`, we then apply the application settings on top.

Once this is merged in I'm going to go through all of our settings and move them into here, which means that our `cachet:seed` command can be reduced down too.