### PR TITLE
Specify components to subscribe to via API

### DIFF
--- a/app/Bus/Commands/Subscriber/SubscribeSubscriberCommand.php
+++ b/app/Bus/Commands/Subscriber/SubscribeSubscriberCommand.php
@@ -33,6 +33,13 @@ final class SubscribeSubscriberCommand
     public $verified;
 
     /**
+     * The list of subscriptions to set the subscriber up with.
+     *
+     * @var array|null
+     */
+    public $subscriptions;
+
+    /**
      * The validation rules.
      *
      * @var array
@@ -44,14 +51,16 @@ final class SubscribeSubscriberCommand
     /**
      * Create a new subscribe subscriber command instance.
      *
-     * @param string $email
-     * @param bool   $verified
+     * @param string     $email
+     * @param bool       $verified
+     * @param array|null $subscriptions
      *
      * @return void
      */
-    public function __construct($email, $verified = false)
+    public function __construct($email, $verified = false, $subscriptions = null)
     {
         $this->email = $email;
         $this->verified = $verified;
+        $this->subscriptions = $subscriptions;
     }
 }

--- a/app/Bus/Handlers/Commands/Subscriber/SubscribeSubscriberCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Subscriber/SubscribeSubscriberCommandHandler.php
@@ -22,6 +22,8 @@ use CachetHQ\Cachet\Models\Subscription;
  * This is the subscribe subscriber command handler.
  *
  * @author James Brooks <james@alt-three.com>
+ * @author Joe Cohen <joe@alt-three.com>
+ * @author Graham Campbell <graham@alt-three.com>
  */
 class SubscribeSubscriberCommandHandler
 {
@@ -40,7 +42,14 @@ class SubscribeSubscriberCommandHandler
 
         $subscriber = Subscriber::firstOrCreate(['email' => $command->email]);
 
-        foreach (Component::all() as $component) {
+        // Decide what to subscribe the subscriber to.
+        if ($subscriptions = $command->subscriptions) {
+            $subscriptions = Component::whereIn('id', $subscriptions);
+        } else {
+            $subscriptions = Component::all();
+        }
+
+        foreach ($subscriptions as $component) {
             Subscription::create([
                 'subscriber_id' => $subscriber->id,
                 'component_id'  => $component->id,

--- a/app/Http/Controllers/Api/SubscriberController.php
+++ b/app/Http/Controllers/Api/SubscriberController.php
@@ -21,6 +21,12 @@ use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
+/**
+ * This is the subscriber controller class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ * @author Graham Campbell <graham@alt-three.com>
+ */
 class SubscriberController extends AbstractApiController
 {
     /**
@@ -43,7 +49,11 @@ class SubscriberController extends AbstractApiController
     public function postSubscribers()
     {
         try {
-            $subscriber = dispatch(new SubscribeSubscriberCommand(Binput::get('email'), Binput::get('verify', false), null));
+            $subscriber = dispatch(new SubscribeSubscriberCommand(
+                Binput::get('email'),
+                Binput::get('verify', false),
+                Binput::get('components', null)
+            ));
         } catch (QueryException $e) {
             throw new BadRequestHttpException();
         }

--- a/tests/Api/SubscriberTest.php
+++ b/tests/Api/SubscriberTest.php
@@ -44,11 +44,11 @@ class SubscriberTest extends AbstractApiTestCase
         $this->expectsEvents('CachetHQ\Cachet\Bus\Events\Subscriber\SubscriberHasSubscribedEvent');
 
         $this->post('/api/v1/subscribers', [
-            'email' => 'james@cachethq.io',
+            'email' => 'support@alt-three.com',
         ]);
         $this->assertResponseOk();
         $this->seeHeader('Content-Type', 'application/json');
-        $this->seeJson(['email' => 'james@cachethq.io']);
+        $this->seeJson(['email' => 'support@alt-three.com']);
     }
 
     public function testCreateSubscriberAutoVerified()
@@ -56,12 +56,32 @@ class SubscriberTest extends AbstractApiTestCase
         $this->beUser();
 
         $this->post('/api/v1/subscribers', [
-            'email'  => 'james@cachethq.io',
+            'email'  => 'support@alt-three.com',
             'verify' => true,
         ]);
         $this->assertResponseOk();
         $this->seeHeader('Content-Type', 'application/json');
-        $this->seeJson(['email' => 'james@cachethq.io']);
+        $this->seeJson(['email' => 'support@alt-three.com']);
+    }
+
+    public function testCreateSubscriberWithSubscriptions()
+    {
+        $this->beUser();
+
+        factory('CachetHQ\Cachet\Models\Component', 3)->create();
+
+        $this->post('/api/v1/subscribers', [
+            'email'         => 'support@alt-three.com',
+            'verify'        => true,
+            'subscriptions' => [
+                1,
+                2,
+                3,
+            ],
+        ]);
+        $this->assertResponseOk();
+        $this->seeHeader('Content-Type', 'application/json');
+        $this->seeJson(['email' => 'support@alt-three.com']);
     }
 
     public function testDeleteSubscriber()

--- a/tests/Bus/Commands/Subscriber/SubscribeSubscriberCommandTest.php
+++ b/tests/Bus/Commands/Subscriber/SubscribeSubscriberCommandTest.php
@@ -28,8 +28,8 @@ class SubscribeSubscriberCommandTest extends AbstractTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['email' => 'support@cachethq.io', 'verified' => true];
-        $object = new SubscribeSubscriberCommand($params['email'], $params['verified']);
+        $params = ['email' => 'support@cachethq.io', 'verified' => true, 'subscriptions' => null];
+        $object = new SubscribeSubscriberCommand($params['email'], $params['verified'], $params['subscriptions']);
 
         return compact('params', 'object');
     }


### PR DESCRIPTION
Closes #1685 

---

When subscribing a customer, you can supply a `components` parameter which is an array of component id's to subscribe to.