### PR TITLE
Use pluck rather than lists

### DIFF
--- a/app/Presenters/ComponentPresenter.php
+++ b/app/Presenters/ComponentPresenter.php
@@ -53,7 +53,7 @@ class ComponentPresenter extends BasePresenter implements Arrayable
      */
     public function tags()
     {
-        return $this->wrappedObject->tags->lists('name', 'slug');
+        return $this->wrappedObject->tags->pluck('name', 'slug');
     }
 
     /**


### PR DESCRIPTION
`lists` is removed in 5.3, in favour of `pluck`.