### PR TITLE
Move packages to  devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "cachet",
-  "dependencies": {
+  "devDependencies": {
+    "gulp": "~3.9.1",
+    "laravel-elixir": "~5.0.0",
     "animate-sass": "git+https://github.com/tgdev/animate-sass.git",
     "autosize": "^3.0.15",
     "bootstrap-sass": "^3.3.6",
@@ -8,20 +10,16 @@
     "eonasdan-bootstrap-datetimepicker": "~3.1",
     "github-markdown-css": "^2.3.0",
     "ionicons": "~2.0",
-    "jquery": "~2.2",
     "jquery-minicolors": "^2.1.10",
     "jquery-serializeobject": "^1.0.0",
     "jquery-sparkline": "^2.3.2",
+    "jquery": "~2.2",
     "livestamp": "git+https://github.com/mattbradley/livestampjs.git#develop",
     "lodash": "^4.12.0",
     "messenger": "git+https://github.com/HubSpot/messenger.git",
     "moment": "^2.13.0",
     "sortablejs": "^1.4.2",
     "sweetalert": "^1.1.3"
-  },
-  "devDependencies": {
-    "gulp": "~3.9.1",
-    "laravel-elixir": "~5.0.0"
   },
   "private": true
 }


### PR DESCRIPTION
Since we build the asset files with gulp we can move them to devDependencies instead.