### PR TITLE
Fix crap login throttling

### DIFF
--- a/app/Foundation/Exceptions/Displayers/ThrottleDisplayer.php
+++ b/app/Foundation/Exceptions/Displayers/ThrottleDisplayer.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Foundation\Exceptions\Displayers;
+
+use Exception;
+use GrahamCampbell\Exceptions\Displayers\DisplayerInterface;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+
+class ThrottleDisplayer implements DisplayerInterface
+{
+    /**
+     * The request instance.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    protected $request;
+
+    /**
+     * Create a new redirect displayer instance.
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return void
+     */
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * Get the error response associated with the given exception.
+     *
+     * @param \Exception $exception
+     * @param string     $id
+     * @param int        $code
+     * @param string[]   $headers
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function display(Exception $exception, $id, $code, array $headers)
+    {
+        return redirect()->route('auth.login')->withError(trans('forms.login.rate-limit'));
+    }
+
+    /**
+     * Get the supported content type.
+     *
+     * @return string
+     */
+    public function contentType()
+    {
+        return 'text/html';
+    }
+
+    /**
+     * Can we display the exception?
+     *
+     * @param \Exception $original
+     * @param \Exception $transformed
+     * @param int        $code
+     *
+     * @return bool
+     */
+    public function canDisplay(Exception $original, Exception $transformed, $code)
+    {
+        return $transformed instanceof TooManyRequestsHttpException && $this->request->is('auth*');
+    }
+
+    /**
+     * Do we provide verbose information about the exception?
+     *
+     * @return bool
+     */
+    public function isVerbose()
+    {
+        return false;
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -59,6 +59,6 @@ class Kernel extends HttpKernel
         'ready'       => 'CachetHQ\Cachet\Http\Middleware\ReadyForUse',
         'setup'       => 'CachetHQ\Cachet\Http\Middleware\SetupAlreadyCompleted',
         'subscribers' => 'CachetHQ\Cachet\Http\Middleware\SubscribersConfigured',
-        'throttle'    => 'Illuminate\Routing\Middleware\ThrottleRequests',
+        'throttle'    => 'AltThree\Throttle\ThrottlingMiddleware',
     ];
 }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "alt-three/badger": "^3.1",
         "alt-three/bus": "^1.1",
         "alt-three/emoji": "^3.1",
+        "alt-three/throttle": "^1.0",
         "alt-three/validator": "^1.5",
         "backup-manager/laravel": "^1.1",
         "barryvdh/laravel-cors": "^0.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "20e1a31cd1a88b67ac946fb3c3453a11",
-    "content-hash": "ed5e328f5b020fdc07ee9bfb3c639d81",
+    "hash": "d58416fb0d16c8b7fc9b936b6f642c39",
+    "content-hash": "226b91629f9aa94bb32446a4e963600c",
     "packages": [
         {
             "name": "alt-three/badger",
@@ -200,6 +200,68 @@
                 "parser"
             ],
             "time": "2016-04-22 17:24:35"
+        },
+        {
+            "name": "alt-three/throttle",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/AltThree/Throttle.git",
+                "reference": "55738ea2e3900e9ba785aa8495c4a82cbb7eb998"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/AltThree/Throttle/zipball/55738ea2e3900e9ba785aa8495c4a82cbb7eb998",
+                "reference": "55738ea2e3900e9ba785aa8495c4a82cbb7eb998",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/cache": "5.2.*|5.3.*",
+                "illuminate/http": "5.2.*|5.3.*",
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "graham-campbell/testbench": "^3.1",
+                "phpunit/phpunit": "^4.8|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "AltThree\\Throttle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "James Brooks",
+                    "email": "james@alt-three.com"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com"
+                },
+                {
+                    "name": "Joseph Cohen",
+                    "email": "joe@alt-three.com"
+                }
+            ],
+            "description": "A request rate limiter for Laravel 5.2+",
+            "keywords": [
+                "Alt Three",
+                "http",
+                "rate limit",
+                "rate limiter",
+                "throttle"
+            ],
+            "time": "2016-05-28 14:23:19"
         },
         {
             "name": "alt-three/validator",

--- a/config/exceptions.php
+++ b/config/exceptions.php
@@ -49,6 +49,7 @@ return [
     'displayers' => [
         'CachetHQ\Cachet\Foundation\Exceptions\Displayers\JsonValidationDisplayer',
         'CachetHQ\Cachet\Foundation\Exceptions\Displayers\RedirectDisplayer',
+        'CachetHQ\Cachet\Foundation\Exceptions\Displayers\ThrottleDisplayer',
         'GrahamCampbell\Exceptions\Displayers\DebugDisplayer',
         'GrahamCampbell\Exceptions\Displayers\HtmlDisplayer',
         'GrahamCampbell\Exceptions\Displayers\JsonDisplayer',

--- a/resources/lang/en/forms.php
+++ b/resources/lang/en/forms.php
@@ -34,6 +34,7 @@ return [
         'invalid'       => 'Invalid username or password',
         'invalid-token' => 'Invalid token',
         'cookies'       => 'You must enable cookies to login.',
+        'rate-limit'    => 'Rate limit exceeded.',
     ],
 
     // Incidents form fields


### PR DESCRIPTION
Uses https://github.com/AltThree/Throttle, which still uses Laravel's rate limiter under the hood.

---

Closes #1849.