### PR TITLE
Help password managers

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -41,11 +41,11 @@ class AuthController extends Controller
      */
     public function postLogin()
     {
-        $loginData = Binput::only(['login', 'password']);
+        $loginData = Binput::only(['username', 'password']);
 
         // Login with username or email.
-        $loginKey = Str::contains($loginData['login'], '@') ? 'email' : 'username';
-        $loginData[$loginKey] = array_pull($loginData, 'login');
+        $loginKey = Str::contains($loginData['username'], '@') ? 'email' : 'username';
+        $loginData[$loginKey] = array_pull($loginData, 'username');
 
         // Validate login credentials.
         if (Auth::validate($loginData)) {

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -21,7 +21,7 @@
 
                 <div class="form-group">
                     <label class="sr-only">{{ trans('forms.login.login') }}</label>
-                    <input autocomplete="off" class="form-control login-input" placeholder="{{ trans('forms.login.login') }}" required="required" name="login" type="text" value="{{ Binput::old('login') }}" autofocus>
+                    <input autocomplete="off" class="form-control login-input" placeholder="{{ trans('forms.login.login') }}" required="required" name="username" type="text" value="{{ Binput::old('username') }}" autofocus>
                 </div>
                 <div class="form-group">
                     <label class="sr-only">{{ trans('forms.login.password') }}</label>


### PR DESCRIPTION
Fixes #1910 

---

LastPass struggles with the field name `login`. Let's change this to `username`, which makes more sense.