### PR TITLE
Fix language name.

### DIFF
--- a/config/langs.php
+++ b/config/langs.php
@@ -100,11 +100,11 @@ return [
         'subset' => 'latin,latin-ext',
     ],
     'pt-BR' => [
-        'name'   => 'Portuguese',
+        'name'   => 'Portuguese, Brazilian',
         'subset' => 'latin,latin-ext',
     ],
     'pt-PT' => [
-        'name'   => 'Portuguese, Brazilian',
+        'name'   => 'Portuguese, Portugal',
         'subset' => 'latin,latin-ext',
     ],
     'ro'    => [


### PR DESCRIPTION
Correct name of slugs portuguese.