### PR TITLE
Add the /api/v1/status endpoint

### DIFF
--- a/app/Http/Controllers/Api/GeneralController.php
+++ b/app/Http/Controllers/Api/GeneralController.php
@@ -12,6 +12,8 @@
 namespace CachetHQ\Cachet\Http\Controllers\Api;
 
 use CachetHQ\Cachet\Integrations\Releases;
+use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\Incident;
 
 /**
  * This is the general api controller.
@@ -43,5 +45,49 @@ class GeneralController extends AbstractApiController
             'on_latest' => version_compare(CACHET_VERSION, $latest['tag_name']) === 1,
             'latest'    => $latest,
         ])->item(CACHET_VERSION);
+    }
+
+    /**
+     * Show the general system status.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function status()
+    {
+        $totalComponents = Component::enabled()->count();
+        $majorOutages = Component::enabled()->status(4)->count();
+        $isMajorOutage = $totalComponents ? ($majorOutages / $totalComponents) >= 0.5 : false;
+
+        $withData = [
+            'system_status'  => 'info',
+            'system_message' => trans_choice('cachet.service.bad', $totalComponents),
+            'favicon'        => 'favicon-high-alert',
+        ];
+
+        if ($isMajorOutage) {
+            $withData = [
+                'system_status'  => 'danger',
+                'system_message' => trans_choice('cachet.service.major', $totalComponents),
+                'favicon'        => 'favicon-high-alert',
+            ];
+        } elseif (Component::enabled()->notStatus(1)->count() === 0) {
+            // If all our components are ok, do we have any non-fixed incidents?
+            $incidents = Incident::notScheduled()->orderBy('created_at', 'desc')->get();
+            $incidentCount = $incidents->count();
+
+            if ($incidentCount === 0 || ($incidentCount >= 1 && (int) $incidents->first()->status === 4)) {
+                $withData = [
+                    'system_status'  => 'success',
+                    'system_message' => trans_choice('cachet.service.good', $totalComponents),
+                    'favicon'        => 'favicon',
+                ];
+            }
+        } else {
+            if (Component::enabled()->whereIn('status', [2, 3])->count() > 0) {
+                $withData['favicon'] = 'favicon-medium-alert';
+            }
+        }
+
+        return $this->item($withData);
     }
 }

--- a/app/Http/Routes/ApiRoutes.php
+++ b/app/Http/Routes/ApiRoutes.php
@@ -33,6 +33,7 @@ class ApiRoutes
             $router->group(['middleware' => ['auth.api']], function (Registrar $router) {
                 $router->get('ping', 'GeneralController@ping');
                 $router->get('version', 'GeneralController@version');
+                $router->get('status', 'GeneralController@status');
 
                 $router->get('components', 'ComponentController@getComponents');
                 $router->get('components/groups', 'ComponentGroupController@getGroups');

--- a/tests/Api/GeneralTest.php
+++ b/tests/Api/GeneralTest.php
@@ -41,4 +41,12 @@ class GeneralTest extends AbstractApiTestCase
 
         $this->assertResponseStatus(406);
     }
+
+    public function testGetSystemStatus()
+    {
+        $this->get('/api/v1/status');
+
+        $this->assertResponseOk();
+        $this->seeHeader('Content-Type', 'application/json');
+    }
 }


### PR DESCRIPTION
To get the system status all you need to do now is:
`/api/v1/status`

And it'll return:

```json
{
  "data": {
    "system_status": "success",
    "system_message": "System operational",
    "favicon": "favicon"
  }
}
```