### PR TITLE
Add the /status endpoint

### DIFF
--- a/app/Composers/StatusPageComposer.php
+++ b/app/Composers/StatusPageComposer.php
@@ -11,10 +11,12 @@
 
 namespace CachetHQ\Cachet\Composers;
 
+use CachetHQ\Cachet\Foundation\ViewObjects\SystemStatusViewObject;
 use CachetHQ\Cachet\Models\Component;
 use CachetHQ\Cachet\Models\ComponentGroup;
 use CachetHQ\Cachet\Models\Incident;
 use Illuminate\Contracts\View\View;
+use CachetHQ\Cachet\Foundation\Queries\SystemStatusQuery;
 
 class StatusPageComposer
 {
@@ -27,41 +29,6 @@ class StatusPageComposer
      */
     public function compose(View $view)
     {
-        $totalComponents = Component::enabled()->count();
-        $majorOutages = Component::enabled()->status(4)->count();
-        $isMajorOutage = $totalComponents ? ($majorOutages / $totalComponents) >= 0.5 : false;
-
-        // Default data
-        $withData = [
-            'system_status'  => 'info',
-            'system_message' => trans_choice('cachet.service.bad', $totalComponents),
-            'favicon'        => 'favicon-high-alert',
-        ];
-
-        if ($isMajorOutage) {
-            $withData = [
-                'system_status'  => 'danger',
-                'system_message' => trans_choice('cachet.service.major', $totalComponents),
-                'favicon'        => 'favicon-high-alert',
-            ];
-        } elseif (Component::enabled()->notStatus(1)->count() === 0) {
-            // If all our components are ok, do we have any non-fixed incidents?
-            $incidents = Incident::notScheduled()->orderBy('created_at', 'desc')->get();
-            $incidentCount = $incidents->count();
-
-            if ($incidentCount === 0 || ($incidentCount >= 1 && (int) $incidents->first()->status === 4)) {
-                $withData = [
-                    'system_status'  => 'success',
-                    'system_message' => trans_choice('cachet.service.good', $totalComponents),
-                    'favicon'        => 'favicon',
-                ];
-            }
-        } else {
-            if (Component::enabled()->whereIn('status', [2, 3])->count() > 0) {
-                $withData['favicon'] = 'favicon-medium-alert';
-            }
-        }
-
         // Scheduled maintenance code.
         $scheduledMaintenance = Incident::scheduled()->orderBy('scheduled_at')->get();
 
@@ -70,7 +37,7 @@ class StatusPageComposer
         $componentGroups = ComponentGroup::whereIn('id', $usedComponentGroups)->orderBy('order')->get();
         $ungroupedComponents = Component::enabled()->where('group_id', 0)->orderBy('order')->orderBy('created_at')->get();
 
-        $view->with($withData)
+        $view->with((new SystemStatusViewObject(new SystemStatusQuery))->toArray())
             ->withComponentGroups($componentGroups)
             ->withUngroupedComponents($ungroupedComponents)
             ->withScheduledMaintenance($scheduledMaintenance);

--- a/app/Foundation/Policies/SystemStatus/MajorOutagePolicy.php
+++ b/app/Foundation/Policies/SystemStatus/MajorOutagePolicy.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Foundation\Policies\SystemStatus;
+
+class MajorOutagePolicy
+{
+    /**
+     * @var int
+     */
+    private $numOfMajorOutages;
+
+    /**
+     * @var int
+     */
+    private $numOfTotalEnabledComponents;
+
+    /**
+     * @param int $numOfMajorOutages
+     * @param int $numOfTotalEnabledComponents
+     */
+    public function __construct($numOfMajorOutages, $numOfTotalEnabledComponents)
+    {
+        $this->numOfMajorOutages            = $numOfMajorOutages;
+        $this->numOfTotalEnabledComponents  = $numOfTotalEnabledComponents;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isMajorOutaged()
+    {
+        return (
+            $this->numOfTotalEnabledComponents
+                ? ($this->numOfMajorOutages / $this->numOfTotalEnabledComponents) >= 0.5
+                : false
+        );
+    }
+}

--- a/app/Foundation/Queries/SystemStatusQuery.php
+++ b/app/Foundation/Queries/SystemStatusQuery.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Foundation\Queries;
+
+use Illuminate\Database\Eloquent;
+use CachetHQ\Cachet\Models\Incident;
+use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Foundation\Policies\SystemStatus\MajorOutagePolicy;
+
+class SystemStatusQuery
+{
+    /**
+     * @return string
+     */
+    public function getSystemStatus()
+    {
+        $systemStatus = 'info';
+
+        if ($this->isMajorOutaged()) {
+            $systemStatus = 'danger';
+        } elseif ($this->isAllTheEnabledComponentsWork() && $this->isAllTheIncidentsFixed()) {
+            $systemStatus = 'success';
+        }
+
+        return $systemStatus;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isMajorOutaged()
+    {
+        return
+            (new MajorOutagePolicy(Component::majorOutaged()->count(), Component::enabled()->count()))
+            ->isMajorOutaged();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAllTheEnabledComponentsWork()
+    {
+        return Component::notOperationaled()->count() === 0;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAllTheIncidentsFixed()
+    {
+        return Incident::isAllAreFixed();
+    }
+}

--- a/app/Foundation/ViewObjects/SystemStatusViewObject.php
+++ b/app/Foundation/ViewObjects/SystemStatusViewObject.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Foundation\ViewObjects;
+
+use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Foundation\Queries\SystemStatusQuery;
+
+class SystemStatusViewObject
+{
+    /**
+     * @var SystemStatusQuery
+     */
+    private $systemStatusQuery;
+
+    /**
+     * @param SystemStatusQuery $systemStatusQuery
+     */
+    public function __construct(SystemStatusQuery $systemStatusQuery) {
+        $this->systemStatusQuery = $systemStatusQuery;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        $systemStatus           = $this->systemStatusQuery->getSystemStatus();
+        $numOfEnabledComponents = Component::enabled()->count();
+        $viewData               = [
+            'system_status'  => $systemStatus,
+            'system_message' => trans_choice('cachet.service.bad', $numOfEnabledComponents),
+            'favicon'        => 'favicon-high-alert',
+        ];
+
+        if ($systemStatus === 'danger') {
+            $viewData['system_message'] = trans_choice('cachet.service.major', $numOfEnabledComponents);
+            $viewData['favicon']        = 'favicon-high-alert';
+        } elseif ($systemStatus === 'success') {
+            $viewData['system_message'] = trans_choice('cachet.service.major', $numOfEnabledComponents);
+            $viewData['favicon']        = 'favicon';
+        }
+
+        if ( ! $this->systemStatusQuery->isMajorOutaged()
+            && ! $this->systemStatusQuery->isAllTheEnabledComponentsWork()
+            && Component::enabled()->whereIn('status', [2, 3])->count() > 0) {
+            $viewData['favicon'] = 'favicon-medium-alert';
+        }
+
+        return $viewData;
+    }
+}

--- a/app/Http/Controllers/Api/GeneralController.php
+++ b/app/Http/Controllers/Api/GeneralController.php
@@ -12,6 +12,8 @@
 namespace CachetHQ\Cachet\Http\Controllers\Api;
 
 use CachetHQ\Cachet\Integrations\Releases;
+use CachetHQ\Cachet\Foundation\Queries\SystemStatusQuery;
+use CachetHQ\Cachet\Foundation\ViewObjects\SystemStatusViewObject;
 
 /**
  * This is the general api controller.
@@ -43,5 +45,20 @@ class GeneralController extends AbstractApiController
             'on_latest' => version_compare(CACHET_VERSION, $latest['tag_name']) === 1,
             'latest'    => $latest,
         ])->item(CACHET_VERSION);
+    }
+
+    /**
+     * Endpoint to show System status
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function status()
+    {
+        $systemStatusViewArray = (new SystemStatusViewObject(new SystemStatusQuery))->toArray();
+
+        return [
+            'system_status'     => $systemStatusViewArray['system_status'],
+            'system_message'    => $systemStatusViewArray['system_message']
+        ];
     }
 }

--- a/app/Http/Routes/ApiRoutes.php
+++ b/app/Http/Routes/ApiRoutes.php
@@ -33,6 +33,7 @@ class ApiRoutes
             $router->group(['middleware' => ['auth.api']], function (Registrar $router) {
                 $router->get('ping', 'GeneralController@ping');
                 $router->get('version', 'GeneralController@version');
+                $router->get('status', 'GeneralController@status');
 
                 $router->get('components', 'ComponentController@getComponents');
                 $router->get('components/groups', 'ComponentGroupController@getGroups');

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -187,6 +187,30 @@ class Component extends Model implements HasPresenter
     }
 
     /**
+     * Finds all components which have major outaged status.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeMajorOutaged(Builder $query)
+    {
+        return $query->enabled()->status(4);
+    }
+
+    /**
+     * Finds all components which are not operational ones.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeNotOperationaled(Builder $query)
+    {
+        return $this->enabled()->notStatus(1);
+    }
+
+    /**
      * Returns all of the tags on this component.
      *
      * @return string

--- a/app/Models/Incident.php
+++ b/app/Models/Incident.php
@@ -31,8 +31,9 @@ class Incident extends Model implements HasPresenter
      */
     protected $casts = [
         'visible'      => 'int',
+        'status'       => 'int',
         'scheduled_at' => 'date',
-        'deleted_at'   => 'date',
+        'deleted_at'   => 'date'
     ];
 
     /**
@@ -129,6 +130,22 @@ class Incident extends Model implements HasPresenter
     }
 
     /**
+     * Do we have any non-fixed incidents?
+     *
+     * @return bool
+     */
+    public static function isAllAreFixed()
+    {
+        $incidentsOrderedByCreation = static::notScheduled()->orderBy('created_at', 'desc')->get();
+        $incidentCount              = $incidentsOrderedByCreation->count();
+
+        return
+            $incidentCount === 0
+            ||
+            ($incidentCount >= 1 && (int) $incidentsOrderedByCreation->first()->hasFixedStatus());
+    }
+
+    /**
      * An incident belongs to a component.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
@@ -146,6 +163,14 @@ class Incident extends Model implements HasPresenter
     public function getIsScheduledAttribute()
     {
         return $this->getOriginal('scheduled_at') !== null;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasFixedStatus()
+    {
+        return $this->getAttribute('status') === 4;
     }
 
     /**


### PR DESCRIPTION
Closes #1936

---

The API endpoint is ```/status```for getting all kinds of status messages. Right now it looks like this:
```json
{
  "system_status": "danger",
  "system_message": "The service experiencing a major outage"
}
```

(It still needs unit tests.)