### PR TITLE
Set Date locale

### DIFF
--- a/app/Foundation/Providers/ConfigServiceProvider.php
+++ b/app/Foundation/Providers/ConfigServiceProvider.php
@@ -16,6 +16,7 @@ use CachetHQ\Cachet\Settings\Cache;
 use CachetHQ\Cachet\Settings\Repository;
 use Exception;
 use Illuminate\Support\ServiceProvider;
+use Jenssegers\Date\Date;
 
 /**
  * This is the config service provider class.
@@ -64,6 +65,7 @@ class ConfigServiceProvider extends ServiceProvider
         if ($appLocale = $this->app->config->get('setting.app_locale')) {
             $this->app->config->set('app.locale', $appLocale);
             $this->app->translator->setLocale($appLocale);
+            Date::setLocale($appLocale);
         }
 
         if ($appTimezone = $this->app->config->get('setting.app_timezone')) {


### PR DESCRIPTION
Fixes #1727 

---

I think this is all that we need to do? By default we're overriding the `Date` locale, but then the `Localize` middleware is free to change it again to the visitors locale, if the setting is enabled.

@CachetHQ/owners agree?