### PR TITLE
Require the ext-xml extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
+        "ext-xml": "*",
         "laravel/framework": "5.2.39",
         "alt-three/badger": "^3.1",
         "alt-three/bus": "^1.1",


### PR DESCRIPTION
Closes #2018

---

@CachetHQ/owners do you guys remember our discussion about parsing the blog and using a package? We're only using `simplexml_load_string` and not a package so there is nobody at fault but ourselves :trollface: