### PR TITLE
Fixed Component Group’s order

### DIFF
--- a/app/Http/Controllers/Dashboard/ApiController.php
+++ b/app/Http/Controllers/Dashboard/ApiController.php
@@ -100,7 +100,8 @@ class ApiController extends AbstractApiController
                 $group,
                 $group->name,
                 $order + 1,
-                $group->collapsed
+                $group->collapsed,
+                $group->visible
             ));
         }
 


### PR DESCRIPTION
500 error after a reorder caused by a missing parameter on UpdateComponentGroupCommand instance