### PR TITLE
Component groups sorted by status and order

### DIFF
--- a/app/Composers/Modules/ComponentsComposer.php
+++ b/app/Composers/Modules/ComponentsComposer.php
@@ -15,6 +15,7 @@ use CachetHQ\Cachet\Models\Component;
 use CachetHQ\Cachet\Models\ComponentGroup;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\View\View;
+use McCool\LaravelAutoPresenter\Facades\AutoPresenter;
 
 /**
  * This is the status page composer.
@@ -54,6 +55,9 @@ class ComponentsComposer
     {
         $componentGroups = $this->getVisibleGroupedComponents();
         $ungroupedComponents = Component::ungrouped()->get();
+
+        $componentGroups = AutoPresenter::decorate($componentGroups)
+            ->sortByDesc('lowest_status');
 
         $view->withComponentGroups($componentGroups)
             ->withUngroupedComponents($ungroupedComponents);


### PR DESCRIPTION
Related to https://github.com/CachetHQ/Cachet/issues/2100

Now groups are ordered by severity status and specified order.
