### PR TITLE
Option to only show disrupted days

### DIFF
--- a/app/Composers/AppComposer.php
+++ b/app/Composers/AppComposer.php
@@ -78,5 +78,6 @@ class AppComposer
         $view->withTimezone($this->dates->getTimezone());
         $view->withSiteTitle($this->config->get('setting.app_name'));
         $view->withFontSubset($this->config->get('langs.'.$this->config->get('app.locale').'.subset', 'latin'));
+        $view->withOnlyDisruptedDays($this->config->get('setting.only_disrupted_days'));
     }
 }

--- a/app/Http/Controllers/StatusPageController.php
+++ b/app/Http/Controllers/StatusPageController.php
@@ -90,11 +90,13 @@ class StatusPageController extends AbstractApiController
         });
 
         // Add in days that have no incidents
-        foreach ($incidentDays as $i) {
-            $date = app(DateFactory::class)->make($startDate)->subDays($i);
+        if (Config::get('setting.only_disrupted_days') === false) {
+            foreach ($incidentDays as $i) {
+                $date = app(DateFactory::class)->make($startDate)->subDays($i);
 
-            if (!isset($allIncidents[$date->toDateString()])) {
-                $allIncidents[$date->toDateString()] = [];
+                if (!isset($allIncidents[$date->toDateString()])) {
+                    $allIncidents[$date->toDateString()] = [];
+                }
             }
         }
 

--- a/config/setting.php
+++ b/config/setting.php
@@ -88,4 +88,15 @@ return [
     */
 
     'skip_subscriber_verification' => false,
+
+   /*
+    |--------------------------------------------------------------------------
+    | Only disrupted days
+    |--------------------------------------------------------------------------
+    |
+    | Whether to only show days with incidents, or each day in the timeline.
+    |
+    */
+
+    'only_disrupted_days' => false,
 ];

--- a/resources/lang/en/forms.php
+++ b/resources/lang/en/forms.php
@@ -139,6 +139,7 @@ return [
             'automatic_localization'       => 'Automatically localise your status page to your visitor\'s language?',
             'enable_external_dependencies' => 'Enable Third Party Dependencies (Google Fonts, Trackers, etc...)',
             'show_timezone'                => 'Show the timezone the status page is running in.',
+            'only_disrupted_days'          => 'Only show days containing incidents in the timeline?',
         ],
         'analytics' => [
             'analytics_google'       => 'Google Analytics code',

--- a/resources/views/dashboard/settings/app-setup.blade.php
+++ b/resources/views/dashboard/settings/app-setup.blade.php
@@ -117,6 +117,17 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <div class="checkbox">
+                                    <label>
+                                        <input type="hidden" value="0" name="only_disrupted_days">
+                                        <input type="checkbox" value="1" name="only_disrupted_days" {{ $only_disrupted_days ? 'checked' : null }}>
+                                        {{ trans('forms.settings.app-setup.only_disrupted_days') }}
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
                     </fieldset>
 
                     <div class="row">


### PR DESCRIPTION
Closes #2088

---

The timeline can now *optionally* show only days which were disrupted — those that has an incident.

This setting continues to be `false` by default.