### PR TITLE
Api groups order

### DIFF
--- a/app/Http/Controllers/Api/ComponentGroupController.php
+++ b/app/Http/Controllers/Api/ComponentGroupController.php
@@ -62,7 +62,7 @@ class ComponentGroupController extends AbstractApiController
         $groups->search(Binput::except(['sort', 'order', 'per_page']));
 
         if ($sortBy = Binput::get('sort')) {
-            $direction = Binput::has('order') && Binput::get('order') == 'desc';
+            $direction = Binput::get('order', 'asc');
 
             $groups->sort($sortBy, $direction);
         }


### PR DESCRIPTION
Issue: if the request use “?sort=order” returns groups ordered by “order DESC”.

This is unexpected.
If I would a reversed order I have to use “sort=order&order=desc”