### PR TITLE
Template overview broken when templates exists

### DIFF
--- a/app/Http/Routes/Dashboard/TemplateRoutes.php
+++ b/app/Http/Routes/Dashboard/TemplateRoutes.php
@@ -58,7 +58,7 @@ class TemplateRoutes
                 'uses' => 'IncidentController@editTemplateAction',
             ]);
             $router->delete('{incident_template}', [
-                'as'   => 'delete::dashboard.templates.delete',
+                'as'   => 'delete:dashboard.templates.delete',
                 'uses' => 'IncidentController@deleteTemplateAction',
             ]);
         });


### PR DESCRIPTION
Due to a typo in the routing table the dashboard/templates page breaks once there are
templates available. Once the typo is resolved everything works as
expected