### PR TITLE
Removed HTTPS from Piwik JS

### DIFF
--- a/resources/views/partials/analytics.blade.php
+++ b/resources/views/partials/analytics.blade.php
@@ -24,13 +24,13 @@
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
     (function() {
-        var u="https://{{ $app_analytics_piwik_url }}";
+        var u="{{ $app_analytics_piwik_url }}";
         _paq.push(['setTrackerUrl', u+'/piwik.php']);
         _paq.push(['setSiteId', {{ $app_analytics_piwik_site_id }}]);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'/piwik.js'; s.parentNode.insertBefore(g,s);
     })();
 </script>
-<noscript><p><img src="https://{{ $app_analytics_piwik_url }}/piwik.php?idsite={{ $app_analytics_piwik_site_id }}" style="border:0;" alt="" /></p></noscript>
+<noscript><p><img src="{{ $app_analytics_piwik_url }}/piwik.php?idsite={{ $app_analytics_piwik_site_id }}" style="border:0;" alt="" /></p></noscript>
 @endif
 @endif


### PR DESCRIPTION
Piwik links will need to include HTTP/HTTPS

Reference Issue #2172 