### PR TITLE
Change "order" condition when a component is edited

### DIFF
--- a/resources/views/dashboard/components/edit.blade.php
+++ b/resources/views/dashboard/components/edit.blade.php
@@ -66,7 +66,7 @@
                 </fieldset>
 
                 <input type="hidden" name="component[user_id]" value="{{ $component->agent_id || $current_user->id }}">
-                <input type="hidden" name="component[order]" value="{{ $component->order || 0 }}">
+                <input type="hidden" name="component[order]" value="{{ $component->order ?: 0 }}">
 
                 <div class="btn-group">
                     <button type="submit" class="btn btn-success">{{ trans('forms.save') }}</button>


### PR DESCRIPTION
It's just me, or when the component order is false, the condition returns an empty value breaking the site after the update is confirmed? I had to change the way the condition is formatted for fixing the problem. Now the 0 is placed if the component order checking is false.

If this is happening on my case only, please ignore the pull request.