### PR TITLE
Remove someRandomString from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 APP_ENV=production
 APP_DEBUG=false
 APP_URL=http://localhost
-APP_KEY=SomeRandomString
+APP_KEY=
 
 DB_DRIVER=mysql
 DB_HOST=localhost


### PR DESCRIPTION
Remove someRandomString from .env.example

Removed someRandomString because it interferes with php artisan
key:generate

Resolves: #2222