### PR TITLE
Add component/group filter & historical status transitions

### DIFF
--- a/app/Bus/Commands/ComponentStatusTransition/RemoveComponentStatusTransitionCommand.php
+++ b/app/Bus/Commands/ComponentStatusTransition/RemoveComponentStatusTransitionCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Commands\ComponentStatusTransition;
+
+use CachetHQ\Cachet\Models\ComponentStatusTransition;
+
+/**
+ * This is the remove component status transition command.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+final class RemoveComponentStatusTransitionCommand
+{
+    /**
+     * The status transition to remove.
+     *
+     * @var \CachetHQ\Cachet\Models\ComponentStatusTransition
+     */
+    public $componentStatusTransition;
+
+    /**
+     * Create a new remove status transition command instance.
+     *
+     * @param \CachetHQ\Cachet\Models\ComponentStatusTransition $componentStatusTransition
+     *
+     * @return void
+     */
+    public function __construct(ComponentStatusTransition $componentStatusTransition)
+    {
+        $this->componentStatusTransition = $componentStatusTransition;
+    }
+}

--- a/app/Bus/Commands/ComponentStatusTransition/ReportComponentStatusTransitionCommand.php
+++ b/app/Bus/Commands/ComponentStatusTransition/ReportComponentStatusTransitionCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Commands\ComponentStatusTransition;
+
+/**
+ * This is the report component status transition command.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+final class ReportComponentStatusTransitionCommand
+{
+    /**
+     * The component.
+     *
+     * @var int
+     */
+    public $component_id;
+
+    /**
+     * The command status.
+     *
+     * @var int
+     */
+    public $status;
+
+    /**
+     * The validation rules.
+     *
+     * @var string[]
+     */
+    public $rules = [
+        'component_id' => 'required|int',
+        'status'       => 'required|int|min:0|max:4',
+    ];
+
+    /**
+     * Create a new report status transition command instance.
+     *
+     * @param int $component_id
+     * @param int $status
+     *
+     * @return void
+     */
+    public function __construct($component_id, $status)
+    {
+        $this->component_id = $component_id;
+        $this->status = $status;
+    }
+}

--- a/app/Bus/Commands/ComponentStatusTransition/UpdateComponentStatusTransitionCommand.php
+++ b/app/Bus/Commands/ComponentStatusTransition/UpdateComponentStatusTransitionCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Commands\ComponentStatusTransition;
+
+use CachetHQ\Cachet\Models\ComponentStatusTransition;
+
+/**
+ * This is the update status transition command.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+final class UpdateComponentStatusTransitionCommand
+{
+    /**
+     * The component status transition.
+     *
+     * @var \CachetHQ\Cachet\Models\ComponentStatusTransition
+     */
+    public $componentStatusTransition;
+
+    /**
+     * The component.
+     *
+     * @var int
+     */
+    public $component_id;
+
+    /**
+     * The command status.
+     *
+     * @var int
+     */
+    public $status;
+
+    /**
+     * The validation rules.
+     *
+     * @var string[]
+     */
+    public $rules = [
+        'component_id' => 'required|int',
+        'status'       => 'required|int|min:0|max:4',
+    ];
+
+    /**
+     * Create a new report status transition command instance.
+     *
+     * @param \CachetHQ\Cachet\Models\ComponentStatusTransition $componentStatusTransition
+     * @param int                                               $component_id
+     * @param int                                               $status
+     *
+     * @return void
+     */
+    public function __construct(ComponentStatusTransition $componentStatusTransition, $component_id, $status)
+    {
+        $this->componentStatusTransition = $componentStatusTransition;
+        $this->component_id = $component_id;
+        $this->status = $status;
+    }
+}

--- a/app/Bus/Commands/GroupStatusTransition/RemoveGroupStatusTransitionCommand.php
+++ b/app/Bus/Commands/GroupStatusTransition/RemoveGroupStatusTransitionCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Commands\GroupStatusTransition;
+
+use CachetHQ\Cachet\Models\GroupStatusTransition;
+
+/**
+ * This is the remove component group status transition command.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+final class RemoveGroupStatusTransitionCommand
+{
+    /**
+     * The status transition to remove.
+     *
+     * @var \CachetHQ\Cachet\Models\GroupStatusTransition
+     */
+    public $groupStatusTransition;
+
+    /**
+     * Create a new remove status transition command instance.
+     *
+     * @param \CachetHQ\Cachet\Models\GroupStatusTransition $groupStatusTransition
+     *
+     * @return void
+     */
+    public function __construct(GroupStatusTransition $groupStatusTransition)
+    {
+        $this->groupStatusTransition = $groupStatusTransition;
+    }
+}

--- a/app/Bus/Commands/GroupStatusTransition/ReportGroupStatusTransitionCommand.php
+++ b/app/Bus/Commands/GroupStatusTransition/ReportGroupStatusTransitionCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Commands\GroupStatusTransition;
+
+/**
+ * This is the report component group status transition command.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+final class ReportGroupStatusTransitionCommand
+{
+    /**
+     * The component.
+     *
+     * @var int
+     */
+    public $component_group_id;
+
+    /**
+     * The component group status.
+     *
+     * @var int
+     */
+    public $status;
+
+    /**
+     * The statuses of the components that are part of the component group.
+     *
+     * @var string
+     */
+    public $offending_components;
+
+    /**
+     * The validation rules.
+     *
+     * @var string[]
+     */
+    public $rules = [
+        'component_group_id'   => 'required|int',
+        'status'               => 'required|int|min:0|max:4',
+        'offending_components' => 'nullable|string',
+    ];
+
+    /**
+     * Create a new report status transition command instance.
+     *
+     * @param int    $component_group_id
+     * @param int    $status
+     * @param string $offending_components
+     *
+     * @return void
+     */
+    public function __construct($component_group_id, $status, $offending_components = null)
+    {
+        $this->component_group_id = $component_group_id;
+        $this->status = $status;
+        $this->offending_components = $offending_components;
+    }
+}

--- a/app/Bus/Commands/GroupStatusTransition/UpdateGroupStatusTransitionCommand.php
+++ b/app/Bus/Commands/GroupStatusTransition/UpdateGroupStatusTransitionCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Commands\GroupStatusTransition;
+
+use CachetHQ\Cachet\Models\GroupStatusTransition;
+
+/**
+ * This is the update component group status transition command.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+final class UpdateGroupStatusTransitionCommand
+{
+    /**
+     * The component group status transition.
+     *
+     * @var \CachetHQ\Cachet\Models\GroupStatusTransition
+     */
+    public $groupStatusTransition;
+
+    /**
+     * The component group id.
+     *
+     * @var int
+     */
+    public $component_group_id;
+
+    /**
+     * The component group status.
+     *
+     * @var int
+     */
+    public $status;
+
+    /**
+     * The statuses of the components that are part of the component group.
+     *
+     * @var string
+     */
+    public $offending_components;
+
+    /**
+     * The validation rules.
+     *
+     * @var string[]
+     */
+    public $rules = [
+        'component_group_id'   => 'required|int',
+        'status'               => 'required|int|min:0|max:4',
+        'offending_components' => 'nullable|string',
+    ];
+
+    /**
+     * Create a new report status transition command instance.
+     *
+     * @param \CachetHQ\Cachet\Models\GroupStatusTransition $groupStatusTransition
+     * @param int                                           $component_group_id
+     * @param int                                           $status
+     * @param string                                        $offending_components
+     *
+     * @return void
+     */
+    public function __construct(GroupStatusTransition $groupStatusTransition, $component_group_id, $status, $offending_components)
+    {
+        $this->groupStatusTransition = $groupStatusTransition;
+        $this->component_group_id = $component_group_id;
+        $this->status = $status;
+        $this->offending_components = $offending_components;
+    }
+}

--- a/app/Bus/Commands/Metric/AddMetricCommand.php
+++ b/app/Bus/Commands/Metric/AddMetricCommand.php
@@ -77,6 +77,13 @@ final class AddMetricCommand
     public $threshold;
 
     /**
+     * The component id the metric belongs to.
+     *
+     * @var int
+     */
+    public $component_id;
+
+    /**
      * The order of which to place the metric in.
      *
      * @var int
@@ -99,6 +106,7 @@ final class AddMetricCommand
         'places'        => 'nullable|int|between:0,4',
         'default_view'  => 'required|int|between:0,3',
         'threshold'     => 'nullable|numeric|between:0,10',
+        'component_id'  => 'required|int',
         'order'         => 'nullable|int',
     ];
 
@@ -114,11 +122,12 @@ final class AddMetricCommand
      * @param int    $places
      * @param int    $default_view
      * @param int    $threshold
+     * @param int    $component_id
      * @param int    $order
      *
      * @return void
      */
-    public function __construct($name, $suffix, $description, $default_value, $calc_type, $display_chart, $places, $default_view, $threshold, $order = 0)
+    public function __construct($name, $suffix, $description, $default_value, $calc_type, $display_chart, $places, $default_view, $threshold, $component_id, $order = 0)
     {
         $this->name = $name;
         $this->suffix = $suffix;
@@ -129,6 +138,7 @@ final class AddMetricCommand
         $this->places = $places;
         $this->default_view = $default_view;
         $this->threshold = $threshold;
+        $this->component_id = $component_id;
         $this->order = $order;
     }
 }

--- a/app/Bus/Commands/Metric/UpdateMetricCommand.php
+++ b/app/Bus/Commands/Metric/UpdateMetricCommand.php
@@ -86,6 +86,13 @@ final class UpdateMetricCommand
     public $threshold;
 
     /**
+     * The component id the metric belongs to.
+     *
+     * @var int
+     */
+    public $component_id;
+
+    /**
      * The order of which to place the metric in.
      *
      * @var int|null
@@ -108,6 +115,7 @@ final class UpdateMetricCommand
         'places'        => 'nullable|numeric|between:0,4',
         'default_view'  => 'nullable|numeric|between:0,4',
         'threshold'     => 'nullable|numeric|between:0,10',
+        'component_id'  => 'required|int',
         'order'         => 'nullable|int',
     ];
 
@@ -124,11 +132,12 @@ final class UpdateMetricCommand
      * @param int                            $places
      * @param int                            $default_view
      * @param int                            $threshold
+     * @param int                            $component_id
      * @param int|null                       $order
      *
      * @return void
      */
-    public function __construct(Metric $metric, $name, $suffix, $description, $default_value, $calc_type, $display_chart, $places, $default_view, $threshold, $order = null)
+    public function __construct(Metric $metric, $name, $suffix, $description, $default_value, $calc_type, $display_chart, $places, $default_view, $threshold, $component_id, $order = null)
     {
         $this->metric = $metric;
         $this->name = $name;
@@ -140,6 +149,7 @@ final class UpdateMetricCommand
         $this->places = $places;
         $this->default_view = $default_view;
         $this->threshold = $threshold;
+        $this->component_id = $component_id;
         $this->order = $order;
     }
 }

--- a/app/Bus/Events/ComponentGroup/ComponentGroupStatusWasUpdatedEvent.php
+++ b/app/Bus/Events/ComponentGroup/ComponentGroupStatusWasUpdatedEvent.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Events\ComponentGroup;
+
+use CachetHQ\Cachet\Models\ComponentGroup;
+
+/**
+ * This is the component status was updated event.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+final class ComponentGroupStatusWasUpdatedEvent implements ComponentGroupEventInterface
+{
+    /**
+     * The component group that was updated.
+     *
+     * @var \CachetHQ\Cachet\Models\ComponentGroup
+     */
+    public $group;
+
+    /**
+     * Create a new component group was updated event instance.
+     *
+     * @param \CachetHQ\Cachet\Models\ComponentGroup $group
+     *
+     * @return void
+     */
+    public function __construct(ComponentGroup $group)
+    {
+        $this->group = $group;
+    }
+}

--- a/app/Bus/Handlers/Commands/Component/AddComponentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Component/AddComponentCommandHandler.php
@@ -13,7 +13,9 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\Component;
 
 use CachetHQ\Cachet\Bus\Commands\Component\AddComponentCommand;
 use CachetHQ\Cachet\Bus\Events\Component\ComponentWasAddedEvent;
+use CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupStatusWasUpdatedEvent;
 use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\ComponentGroup;
 
 class AddComponentCommandHandler
 {
@@ -30,13 +32,18 @@ class AddComponentCommandHandler
 
         event(new ComponentWasAddedEvent($component));
 
+        // Trigger the event for when the component group status is updated.
+        if ($command->group_id) {
+            event(new ComponentGroupStatusWasUpdatedEvent((new ComponentGroup())->find($command->group_id)));
+        }
+
         return $component;
     }
 
     /**
      * Filter the command data.
      *
-     * @param \CachetHQ\Cachet\Bus\Commands\Incident\AddComponentCommand $command
+     * @param \CachetHQ\Cachet\Bus\Commands\Component\AddComponentCommand $command
      *
      * @return array
      */

--- a/app/Bus/Handlers/Commands/Component/RemoveComponentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Component/RemoveComponentCommandHandler.php
@@ -13,6 +13,8 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\Component;
 
 use CachetHQ\Cachet\Bus\Commands\Component\RemoveComponentCommand;
 use CachetHQ\Cachet\Bus\Events\Component\ComponentWasRemovedEvent;
+use CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupStatusWasUpdatedEvent;
+use CachetHQ\Cachet\Models\ComponentGroup;
 
 class RemoveComponentCommandHandler
 {
@@ -30,5 +32,10 @@ class RemoveComponentCommandHandler
         event(new ComponentWasRemovedEvent($component));
 
         $component->delete();
+
+        // Trigger the event for when the component is deleted.
+        if ($component->group_id) {
+            event(new ComponentGroupStatusWasUpdatedEvent((new ComponentGroup())->find($component->group_id)));
+        }
     }
 }

--- a/app/Bus/Handlers/Commands/ComponentStatusTransition/RemoveComponentStatusTransitionCommandHandler.php
+++ b/app/Bus/Handlers/Commands/ComponentStatusTransition/RemoveComponentStatusTransitionCommandHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Commands\ComponentStatusTransition;
+
+use CachetHQ\Cachet\Bus\Commands\ComponentStatusTransition\RemoveComponentStatusTransitionCommand;
+
+/**
+ * This is the remove status transition command handler.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+class RemoveComponentStatusTransitionCommandHandler
+{
+    /**
+     * Handle the remove status transition command.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\ComponentStatusTransition\RemoveComponentStatusTransitionCommand $command
+     *
+     * @return void
+     */
+    public function handle(RemoveComponentStatusTransitionCommand $command)
+    {
+        $componentStatusTransition = $command->componentStatusTransition;
+        $componentStatusTransition->delete();
+    }
+}

--- a/app/Bus/Handlers/Commands/ComponentStatusTransition/ReportComponentStatusTransitionCommandHandler.php
+++ b/app/Bus/Handlers/Commands/ComponentStatusTransition/ReportComponentStatusTransitionCommandHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Commands\ComponentStatusTransition;
+
+use CachetHQ\Cachet\Bus\Commands\ComponentStatusTransition\ReportComponentStatusTransitionCommand;
+use CachetHQ\Cachet\Models\ComponentStatusTransition;
+
+/**
+ * This is the report status transition command handler.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+class ReportComponentStatusTransitionCommandHandler
+{
+    /**
+     * Handle the report status transition command.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\ComponentStatusTransition\ReportComponentStatusTransitionCommand $command
+     *
+     * @return \CachetHQ\Cachet\Models\ComponentStatusTransition
+     */
+    public function handle(ReportComponentStatusTransitionCommand $command)
+    {
+        $data = [
+            'component_id' => $command->component_id,
+            'status'       => $command->status,
+        ];
+
+        // Create the status transition.
+        $componentStatusTransition = ComponentStatusTransition::create($data);
+
+        return $componentStatusTransition;
+    }
+}

--- a/app/Bus/Handlers/Commands/ComponentStatusTransition/UpdateComponentStatusTransitionCommandHandler.php
+++ b/app/Bus/Handlers/Commands/ComponentStatusTransition/UpdateComponentStatusTransitionCommandHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Commands\ComponentStatusTransition;
+
+use CachetHQ\Cachet\Bus\Commands\ComponentStatusTransition\UpdateComponentStatusTransitionCommand;
+
+/**
+ * This is the component status transition update command handler.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+class UpdateComponentStatusTransitionCommandHandler
+{
+    /**
+     * Handle the update status transition command.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\ComponentStatusTransition\UpdateComponentStatusTransitionCommand $command
+     *
+     * @return \CachetHQ\Cachet\Models\ComponentStatusTransition
+     */
+    public function handle(UpdateComponentStatusTransitionCommand $command)
+    {
+        $componentStatusTransition = $command->componentStatusTransition;
+
+        $componentStatusTransition->update($this->filter($command));
+
+        return $componentStatusTransition;
+    }
+
+    /**
+     * Filter the command data.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\ComponentStatusTransition\UpdateComponentStatusTransitionCommand $command
+     *
+     * @return array
+     */
+    protected function filter(UpdateComponentStatusTransitionCommand $command)
+    {
+        $params = [
+            'component_id' => $command->component_id,
+            'status'       => $command->status,
+        ];
+
+        return array_filter($params, function ($val) {
+            return $val !== null;
+        });
+    }
+}

--- a/app/Bus/Handlers/Commands/GroupStatusTransition/RemoveGroupStatusTransitionCommandHandler.php
+++ b/app/Bus/Handlers/Commands/GroupStatusTransition/RemoveGroupStatusTransitionCommandHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Commands\GroupStatusTransition;
+
+use CachetHQ\Cachet\Bus\Commands\GroupStatusTransition\RemoveGroupStatusTransitionCommand;
+
+/**
+ * This is the remove component group status transition command handler.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+class RemoveGroupStatusTransitionCommandHandler
+{
+    /**
+     * Handle the remove status transition command.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\GroupStatusTransition\RemoveGroupStatusTransitionCommand $command
+     *
+     * @return void
+     */
+    public function handle(RemoveGroupStatusTransitionCommand $command)
+    {
+        $groupStatusTransition = $command->groupStatusTransition;
+        $groupStatusTransition->delete();
+    }
+}

--- a/app/Bus/Handlers/Commands/GroupStatusTransition/ReportGroupStatusTransitionCommandHandler.php
+++ b/app/Bus/Handlers/Commands/GroupStatusTransition/ReportGroupStatusTransitionCommandHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Commands\GroupStatusTransition;
+
+use CachetHQ\Cachet\Bus\Commands\GroupStatusTransition\ReportGroupStatusTransitionCommand;
+use CachetHQ\Cachet\Models\GroupStatusTransition;
+
+/**
+ * This is the report component group status transition command handler.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+class ReportGroupStatusTransitionCommandHandler
+{
+    /**
+     * Handle the report status transition command.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\GroupStatusTransition\ReportGroupStatusTransitionCommand $command
+     *
+     * @return \CachetHQ\Cachet\Models\ComponentStatusTransition
+     */
+    public function handle(ReportGroupStatusTransitionCommand $command)
+    {
+        $data = [
+            'component_group_id'   => $command->component_group_id,
+            'status'               => $command->status,
+            'offending_components' => $command->offending_components,
+        ];
+
+        // Create the status transition.
+        $groupStatusTransition = GroupStatusTransition::create($data);
+
+        return $groupStatusTransition;
+    }
+}

--- a/app/Bus/Handlers/Commands/GroupStatusTransition/UpdateGroupStatusTransitionCommandHandler.php
+++ b/app/Bus/Handlers/Commands/GroupStatusTransition/UpdateGroupStatusTransitionCommandHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Commands\GroupStatusTransition;
+
+use CachetHQ\Cachet\Bus\Commands\GroupStatusTransition\UpdateGroupStatusTransitionCommand;
+
+/**
+ * This is the component group status transition update command handler.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+class UpdateGroupStatusTransitionCommandHandler
+{
+    /**
+     * Handle the update status transition command.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\GroupStatusTransition\UpdateGroupStatusTransitionCommand $command
+     *
+     * @return \CachetHQ\Cachet\Models\GroupStatusTransition
+     */
+    public function handle(UpdateGroupStatusTransitionCommand $command)
+    {
+        $groupStatusTransition = $command->groupStatusTransition;
+
+        $groupStatusTransition->update($this->filter($command));
+
+        return $groupStatusTransition;
+    }
+
+    /**
+     * Filter the command data.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\GroupStatusTransition\UpdateGroupStatusTransitionCommand $command
+     *
+     * @return array
+     */
+    protected function filter(UpdateGroupStatusTransitionCommand $command)
+    {
+        $params = [
+            'component_group_id'   => $command->component_group_id,
+            'status'               => $command->status,
+            'offending_components' => $command->offending_components,
+        ];
+
+        return array_filter($params, function ($val) {
+            return $val !== null;
+        });
+    }
+}

--- a/app/Bus/Handlers/Commands/Metric/AddMetricCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Metric/AddMetricCommandHandler.php
@@ -36,6 +36,7 @@ class AddMetricCommandHandler
             'places'        => $command->places,
             'default_view'  => $command->default_view,
             'threshold'     => $command->threshold,
+            'component_id'  => $command->component_id,
             'order'         => $command->order,
         ]);
 

--- a/app/Bus/Handlers/Commands/Metric/UpdateMetricCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Metric/UpdateMetricCommandHandler.php
@@ -54,6 +54,7 @@ class UpdateMetricCommandHandler
             'places'        => $command->places,
             'default_view'  => $command->default_view,
             'threshold'     => $command->threshold,
+            'component_id'  => $command->component_id,
             'order'         => $command->order,
         ];
 

--- a/app/Bus/Handlers/Events/ComponentStatusTransition/ReportComponentStatusTransitionHandler.php
+++ b/app/Bus/Handlers/Events/ComponentStatusTransition/ReportComponentStatusTransitionHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Events\ComponentStatusTransition;
+
+use CachetHQ\Cachet\Bus\Commands\ComponentStatusTransition\ReportComponentStatusTransitionCommand;
+use CachetHQ\Cachet\Bus\Events\Component\ComponentStatusWasUpdatedEvent;
+
+/**
+ * This is the report component status transition handler.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+class ReportComponentStatusTransitionHandler
+{
+    /**
+     * Handle the event.
+     *
+     * @param \CachetHQ\Cachet\Bus\Events\Component\ComponentStatusWasUpdatedEvent $event
+     *
+     * @return void
+     */
+    public function handle(ComponentStatusWasUpdatedEvent $event)
+    {
+        $component = $event->component;
+
+        // Don't create the state transition if the status hasn't changed.
+        if ($event->original_status === $event->new_status) {
+            return;
+        }
+
+        // Create the status transition.
+        dispatch(new ReportComponentStatusTransitionCommand(
+            $component->id,
+            $event->new_status
+        ));
+    }
+}

--- a/app/Bus/Handlers/Events/ComponentStatusTransition/StartComponentStatusTransitionHandler.php
+++ b/app/Bus/Handlers/Events/ComponentStatusTransition/StartComponentStatusTransitionHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Events\ComponentStatusTransition;
+
+use CachetHQ\Cachet\Bus\Commands\ComponentStatusTransition\ReportComponentStatusTransitionCommand;
+use CachetHQ\Cachet\Bus\Events\Component\ComponentWasAddedEvent;
+
+/**
+ * This is the handler for the first status transition.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+class StartComponentStatusTransitionHandler
+{
+    /**
+     * Handle the event.
+     *
+     * @param \CachetHQ\Cachet\Bus\Events\Component\ComponentWasAddedEvent $event
+     *
+     * @return void
+     */
+    public function handle(ComponentWasAddedEvent $event)
+    {
+        $component = $event->component;
+
+        // Create the status transition.
+        dispatch(new ReportComponentStatusTransitionCommand(
+            $component->id,
+            $component->status
+        ));
+    }
+}

--- a/app/Bus/Handlers/Events/GroupStatusTransition/ReportGroupStatusTransitionHandler.php
+++ b/app/Bus/Handlers/Events/GroupStatusTransition/ReportGroupStatusTransitionHandler.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Events\GroupStatusTransition;
+
+use CachetHQ\Cachet\Bus\Commands\GroupStatusTransition\ReportGroupStatusTransitionCommand;
+use CachetHQ\Cachet\Bus\Commands\GroupStatusTransition\UpdateGroupStatusTransitionCommand;
+use CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupStatusWasUpdatedEvent;
+use CachetHQ\Cachet\Models\GroupStatusTransition;
+
+/**
+ * This is the report status transition handler for component groups.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+class ReportGroupStatusTransitionHandler
+{
+    /**
+     * Handle the event.
+     *
+     * @param \CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupStatusWasUpdatedEvent $event
+     *
+     * @return void
+     */
+    public function handle(ComponentGroupStatusWasUpdatedEvent $event)
+    {
+        $componentGroup = $event->group;
+        $newGroupStatus = $componentGroup->enabled_components_lowest()->first() ? $componentGroup->enabled_components_lowest()->first()->status : 0;
+
+        $lastStatusTransitions = GroupStatusTransition::where('component_group_id', '=', $componentGroup->id)
+            ->orderBy('created_at', 'desc')
+            ->first();
+
+        // Get the components statuses that belongs to the component group.
+        $componentsStatuses = [];
+        foreach ($componentGroup->enabled_components_lowest()->get() as $cg) {
+            $componentsStatuses[] = [
+                'name'   => $cg->name,
+                'status' => $cg->status,
+            ];
+        }
+
+        // Update the offending components if the component group status hasn't changed.
+        if ($lastStatusTransitions->status === $newGroupStatus) {
+            dispatch(new UpdateGroupStatusTransitionCommand(
+                $lastStatusTransitions,
+                $componentGroup->id,
+                $componentGroup->status,
+                $this->mergeOffendingComponents(json_decode($lastStatusTransitions->offending_components, true), $componentsStatuses)
+            ));
+
+        // Create the component group status transition.
+        } else {
+            dispatch(new ReportGroupStatusTransitionCommand(
+                $componentGroup->id,
+                $newGroupStatus,
+                json_encode($componentsStatuses)
+            ));
+        }
+    }
+
+    /**
+     * Merge the two offending components arrays into one single array with the highest values for each component.
+     *
+     * @param array $originalComponents
+     * @param array $newComponents
+     *
+     * @return string
+     */
+    private function mergeOffendingComponents($originalComponents, $newComponents)
+    {
+        foreach ($newComponents as $new) {
+            $newComponentAdded = false;
+
+            foreach ($originalComponents as $originalKey => $original) {
+                if ($original['name'] == $new['name']) {
+                    $originalComponents[$originalKey]['status'] = $original['status'] < $new['status'] ? $new['status'] : $original['status'];
+                    $newComponentAdded = true;
+                }
+            }
+
+            if (!$newComponentAdded) {
+                $originalComponents[] = $new;
+            }
+        }
+
+        return json_encode($originalComponents);
+    }
+}

--- a/app/Bus/Handlers/Events/GroupStatusTransition/StartGroupStatusTransitionHandler.php
+++ b/app/Bus/Handlers/Events/GroupStatusTransition/StartGroupStatusTransitionHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Events\GroupStatusTransition;
+
+use CachetHQ\Cachet\Bus\Commands\GroupStatusTransition\ReportGroupStatusTransitionCommand;
+use CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupWasAddedEvent;
+
+/**
+ * This is the handler for the first status transition.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+class StartGroupStatusTransitionHandler
+{
+    /**
+     * Handle the event.
+     *
+     * @param \CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupWasAddedEvent $event
+     *
+     * @return void
+     */
+    public function handle(ComponentGroupWasAddedEvent $event)
+    {
+        $componentGroup = $event->group;
+
+        // Create the component group status transition.
+        dispatch(new ReportGroupStatusTransitionCommand(
+            $componentGroup->id,
+            0,
+            json_encode([])
+        ));
+    }
+}

--- a/app/Composers/Modules/MetricsComposer.php
+++ b/app/Composers/Modules/MetricsComposer.php
@@ -51,9 +51,20 @@ class MetricsComposer
      */
     public function compose(View $view)
     {
+        // Get the component/group if it's defined.
+        $viewdata = $view->getData();
+        $component = $viewdata['component'];
+        $componentGroup = $viewdata['componentGroup'];
+
         $metrics = null;
         if ($displayMetrics = $this->config->get('setting.display_graphs')) {
-            $metrics = Metric::displayable()->orderBy('order')->orderBy('id')->get();
+            if ($component->exists) {
+                $metrics = Metric::displayable()->where('component_id', '=', $component->id)->orderBy('order')->orderBy('id')->get();
+            } elseif ($componentGroup->exists) {
+                $metrics = Metric::displayable()->whereIn('component_id', $componentGroup->components()->pluck('id'))->orderBy('order')->orderBy('id')->get();
+            } else {
+                $metrics = Metric::displayable()->orderBy('order')->orderBy('id')->get();
+            }
         }
 
         $view->withDisplayMetrics($displayMetrics)

--- a/app/Foundation/Providers/EventServiceProvider.php
+++ b/app/Foundation/Providers/EventServiceProvider.php
@@ -28,7 +28,7 @@ class EventServiceProvider extends ServiceProvider
             //
         ],
         'CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupWasAddedEvent' => [
-            //
+            'CachetHQ\Cachet\Bus\Handlers\Events\GroupStatusTransition\StartGroupStatusTransitionHandler',
         ],
         'CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupWasRemovedEvent' => [
             //
@@ -36,11 +36,15 @@ class EventServiceProvider extends ServiceProvider
         'CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupWasUpdatedEvent' => [
             //
         ],
+        'CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupStatusWasUpdatedEvent' => [
+            'CachetHQ\Cachet\Bus\Handlers\Events\GroupStatusTransition\ReportGroupStatusTransitionHandler',
+        ],
         'CachetHQ\Cachet\Bus\Events\Component\ComponentStatusWasUpdatedEvent' => [
             'CachetHQ\Cachet\Bus\Handlers\Events\Component\SendComponentUpdateEmailNotificationHandler',
+            'CachetHQ\Cachet\Bus\Handlers\Events\ComponentStatusTransition\ReportComponentStatusTransitionHandler',
         ],
         'CachetHQ\Cachet\Bus\Events\Component\ComponentWasAddedEvent' => [
-            //
+            'CachetHQ\Cachet\Bus\Handlers\Events\ComponentStatusTransition\StartComponentStatusTransitionHandler',
         ],
         'CachetHQ\Cachet\Bus\Events\Component\ComponentWasRemovedEvent' => [
             'CachetHQ\Cachet\Bus\Handlers\Events\Component\CleanupComponentSubscriptionsHandler',
@@ -64,9 +68,6 @@ class EventServiceProvider extends ServiceProvider
             'CachetHQ\Cachet\Bus\Handlers\Events\Incident\SendIncidentEmailNotificationHandler',
         ],
         'CachetHQ\Cachet\Bus\Events\Incident\IncidentWasUpdatedEvent' => [
-            //
-        ],
-        'CachetHQ\Cachet\Bus\Events\Incident\IncidentWasRemovedEvent' => [
             //
         ],
         'CachetHQ\Cachet\Bus\Events\Invite\InviteWasClaimedEvent' => [

--- a/app/Http/Controllers/Api/MetricController.php
+++ b/app/Http/Controllers/Api/MetricController.php
@@ -86,6 +86,7 @@ class MetricController extends AbstractApiController
                 Binput::get('places', 2),
                 Binput::get('default_view', Binput::get('view', 1)),
                 Binput::get('threshold', 5),
+                Binput::get('component_id', 0),
                 Binput::get('order', 0)
             ));
         } catch (QueryException $e) {
@@ -116,6 +117,7 @@ class MetricController extends AbstractApiController
                 Binput::get('places'),
                 Binput::get('default_view', Binput::get('view')),
                 Binput::get('threshold'),
+                Binput::get('component_id'),
                 Binput::get('order')
             ));
         } catch (QueryException $e) {

--- a/app/Http/Controllers/Dashboard/MetricController.php
+++ b/app/Http/Controllers/Dashboard/MetricController.php
@@ -15,6 +15,8 @@ use AltThree\Validator\ValidationException;
 use CachetHQ\Cachet\Bus\Commands\Metric\AddMetricCommand;
 use CachetHQ\Cachet\Bus\Commands\Metric\RemoveMetricCommand;
 use CachetHQ\Cachet\Bus\Commands\Metric\UpdateMetricCommand;
+use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\ComponentGroup;
 use CachetHQ\Cachet\Models\Metric;
 use CachetHQ\Cachet\Models\MetricPoint;
 use GrahamCampbell\Binput\Facades\Binput;
@@ -45,6 +47,8 @@ class MetricController extends Controller
     public function showAddMetric()
     {
         return View::make('dashboard.metrics.add')
+            ->withComponentsInGroups(ComponentGroup::with('components')->get())
+            ->withComponentsOutGroups(Component::where('group_id', 0)->get())
             ->withPageTitle(trans('dashboard.metrics.add.title').' - '.trans('dashboard.dashboard'));
     }
 
@@ -79,7 +83,8 @@ class MetricController extends Controller
                 $metricData['display_chart'],
                 $metricData['places'],
                 $metricData['default_view'],
-                $metricData['threshold']
+                $metricData['threshold'],
+                $metricData['component_id']
             ));
         } catch (ValidationException $e) {
             return cachet_redirect('dashboard.metrics.create')
@@ -152,7 +157,8 @@ class MetricController extends Controller
                 Binput::get('display_chart', null, false),
                 Binput::get('places', null, false),
                 Binput::get('default_view', null, false),
-                Binput::get('threshold', null, false)
+                Binput::get('threshold', null, false),
+                Binput::get('component_id', null, false)
             ));
         } catch (ValidationException $e) {
             return cachet_redirect('dashboard.metrics.edit', [$metric->id])

--- a/app/Http/Routes/StatusPageRoutes.php
+++ b/app/Http/Routes/StatusPageRoutes.php
@@ -59,6 +59,26 @@ class StatusPageRoutes
                 'uses' => 'StatusPageController@getMetrics',
             ]);
 
+            $router->get('group/{componentGroup}', [
+                'as'   => 'get:group-status-page',
+                'uses' => 'StatusPageController@showIndex',
+            ]);
+
+            $router->get('component/{component}', [
+                'as'   => 'get:component-status-page',
+                'uses' => 'StatusPageController@showIndex',
+            ]);
+
+            $router->get('status/transitions/component/{component}', [
+                'as'   => 'get:component_status_transition',
+                'uses' => 'StatusPageController@getComponentStatusTransitions',
+            ]);
+
+            $router->get('status/transitions/group/{componentGroup}', [
+                'as'   => 'get:group_status_transition',
+                'uses' => 'StatusPageController@getComponentGroupStatusTransitions',
+            ]);
+
             $router->get('component/{component}/shield', [
                 'as'   => 'get:component_shield',
                 'uses' => 'StatusPageController@showComponentBadge',

--- a/app/Models/ComponentStatusTransition.php
+++ b/app/Models/ComponentStatusTransition.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Models;
+
+use AltThree\Validator\ValidatingTrait;
+use CachetHQ\Cachet\Models\Traits\SortableTrait;
+use CachetHQ\Cachet\Presenters\ComponentStatusTransitionPresenter;
+use Illuminate\Database\Eloquent\Model;
+use McCool\LaravelAutoPresenter\HasPresenter;
+
+/**
+ * This is the component status transition class.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+class ComponentStatusTransition extends Model implements HasPresenter
+{
+    use SortableTrait, ValidatingTrait;
+
+    /**
+     * The attributes that should be casted to native types.
+     *
+     * @var string[]
+     */
+    protected $casts = [
+        'component_id' => 'int',
+        'status'       => 'int',
+    ];
+
+    /**
+     * The fillable properties.
+     *
+     * @var string[]
+     */
+    protected $fillable = [
+        'component_id',
+        'status',
+    ];
+
+    /**
+     * The validation rules.
+     *
+     * @var string[]
+     */
+    public $rules = [
+        'component_id' => 'required|int',
+        'status'       => 'required|int',
+    ];
+
+    /**
+     * The sortable fields.
+     *
+     * @var string[]
+     */
+    protected $sortable = [
+        'id',
+        'component_id',
+        'status',
+    ];
+
+    /**
+     * Get the presenter class.
+     *
+     * @return string
+     */
+    public function getPresenterClass()
+    {
+        return ComponentStatusTransitionPresenter::class;
+    }
+}

--- a/app/Models/GroupStatusTransition.php
+++ b/app/Models/GroupStatusTransition.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Models;
+
+use AltThree\Validator\ValidatingTrait;
+use CachetHQ\Cachet\Models\Traits\SortableTrait;
+use CachetHQ\Cachet\Presenters\GroupStatusTransitionPresenter;
+use Illuminate\Database\Eloquent\Model;
+use McCool\LaravelAutoPresenter\HasPresenter;
+
+/**
+ * This is the component group status transition class.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+class GroupStatusTransition extends Model implements HasPresenter
+{
+    use SortableTrait, ValidatingTrait;
+
+    /**
+     * The attributes that should be casted to native types.
+     *
+     * @var string[]
+     */
+    protected $casts = [
+        'component_group_id'   => 'int',
+        'status'               => 'int',
+        'offending_components' => 'string',
+    ];
+
+    /**
+     * The fillable properties.
+     *
+     * @var string[]
+     */
+    protected $fillable = [
+        'component_group_id',
+        'status',
+        'offending_components',
+    ];
+
+    /**
+     * The validation rules.
+     *
+     * @var string[]
+     */
+    public $rules = [
+        'component_group_id'   => 'required|int',
+        'status'               => 'required|int',
+        'offending_components' => 'nullable|string',
+    ];
+
+    /**
+     * The sortable fields.
+     *
+     * @var string[]
+     */
+    protected $sortable = [
+        'id',
+        'component_group_id',
+        'status',
+    ];
+
+    /**
+     * Get the presenter class.
+     *
+     * @return string
+     */
+    public function getPresenterClass()
+    {
+        return GroupStatusTransitionPresenter::class;
+    }
+}

--- a/app/Models/Metric.php
+++ b/app/Models/Metric.php
@@ -49,6 +49,7 @@ class Metric extends Model implements HasPresenter
         'places'        => 2,
         'default_view'  => 1,
         'threshold'     => 5,
+        'component_id'  => 0,
         'order'         => 0,
     ];
 
@@ -65,6 +66,7 @@ class Metric extends Model implements HasPresenter
         'places'        => 'int',
         'default_view'  => 'int',
         'threshold'     => 'int',
+        'component_id'  => 'int',
         'order'         => 'int',
     ];
 
@@ -83,6 +85,7 @@ class Metric extends Model implements HasPresenter
         'places',
         'default_view',
         'threshold',
+        'component_id',
         'order',
     ];
 
@@ -98,6 +101,7 @@ class Metric extends Model implements HasPresenter
         'default_value' => 'required|numeric',
         'places'        => 'required|numeric|between:0,4',
         'default_view'  => 'required|numeric|between:0,3',
+        'component_id'  => 'required|int',
         'threshold'     => 'required|numeric|between:0,10',
     ];
 
@@ -112,8 +116,19 @@ class Metric extends Model implements HasPresenter
         'display_chart',
         'default_value',
         'calc_type',
+        'component_id',
         'order',
     ];
+
+    /**
+     * Get the component relation.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function component()
+    {
+        return $this->belongsTo(Component::class, 'component_id', 'id');
+    }
 
     /**
      * Get the points relation.

--- a/app/Presenters/ComponentStatusTransitionPresenter.php
+++ b/app/Presenters/ComponentStatusTransitionPresenter.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Presenters;
+
+use CachetHQ\Cachet\Dates\DateFactory;
+use CachetHQ\Cachet\Presenters\Traits\TimestampsTrait;
+use Illuminate\Contracts\Support\Arrayable;
+use McCool\LaravelAutoPresenter\BasePresenter;
+
+/**
+ * This is the component status transition presenter.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+class ComponentStatusTransitionPresenter extends BasePresenter implements Arrayable
+{
+    use TimestampsTrait;
+
+    /**
+     * Present formatted date time.
+     *
+     * @return string
+     */
+    public function created_at_iso()
+    {
+        return app(DateFactory::class)->make($this->wrappedObject->created_at)->toISO8601String();
+    }
+
+    /**
+     * Present formatted date time.
+     *
+     * @return string
+     */
+    public function updated_at_iso()
+    {
+        return app(DateFactory::class)->make($this->wrappedObject->updated_at)->toISO8601String();
+    }
+
+    /**
+     * Returns a human readable version of the status.
+     *
+     * @return string
+     */
+    public function human_status()
+    {
+        return trans('cachet.components.status.'.$this->wrappedObject->status);
+    }
+
+    /**
+     * Convert the presenter status transition to an array.
+     *
+     * @return string[]
+     */
+    public function toArray()
+    {
+        return array_merge($this->wrappedObject->toArray(), [
+            'human_status'   => $this->human_status(),
+            'utc_created_at' => $this->created_at_iso(),
+            'utc_updated_at' => $this->updated_at_iso(),
+        ]);
+    }
+}

--- a/app/Presenters/GroupStatusTransitionPresenter.php
+++ b/app/Presenters/GroupStatusTransitionPresenter.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Presenters;
+
+use CachetHQ\Cachet\Dates\DateFactory;
+use CachetHQ\Cachet\Presenters\Traits\TimestampsTrait;
+use Illuminate\Contracts\Support\Arrayable;
+use McCool\LaravelAutoPresenter\BasePresenter;
+
+/**
+ * This is the component group status transition presenter.
+ *
+ * @author Nicolas Fagotti <nicolasfagotti@gmail.com>
+ */
+class GroupStatusTransitionPresenter extends BasePresenter implements Arrayable
+{
+    use TimestampsTrait;
+
+    /**
+     * Present formatted date time.
+     *
+     * @return string
+     */
+    public function created_at_iso()
+    {
+        return app(DateFactory::class)->make($this->wrappedObject->created_at)->toISO8601String();
+    }
+
+    /**
+     * Present formatted date time.
+     *
+     * @return string
+     */
+    public function updated_at_iso()
+    {
+        return app(DateFactory::class)->make($this->wrappedObject->updated_at)->toISO8601String();
+    }
+
+    /**
+     * Returns a human readable version of the next status.
+     *
+     * @return string
+     */
+    public function human_status()
+    {
+        return trans('cachet.components.status.'.$this->wrappedObject->status);
+    }
+
+    /**
+     * Returns a human readable version of the offending components.
+     *
+     * @return array
+     */
+    public function human_offending_components()
+    {
+        $offendingComponents = json_decode($this->wrappedObject->offending_components, true);
+
+        foreach ($offendingComponents as $key => $component) {
+            $offendingComponents[$key]['status'] = trans('cachet.components.status.'.$offendingComponents[$key]['status']);
+        }
+
+        return $offendingComponents;
+    }
+
+    /**
+     * Convert the presenter status transition to an array.
+     *
+     * @return string[]
+     */
+    public function toArray()
+    {
+        return array_merge($this->wrappedObject->toArray(), [
+            'human_status'         => $this->human_status(),
+            'offending_components' => $this->human_offending_components(),
+            'utc_created_at'       => $this->created_at_iso(),
+            'utc_updated_at'       => $this->updated_at_iso(),
+        ]);
+    }
+}

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -79,6 +79,7 @@ $factory->define(Metric::class, function ($faker) {
         'calc_type'     => $faker->boolean(),
         'display_chart' => $faker->boolean(),
         'threshold'     => 5,
+        'component_id'  => 0,
     ];
 });
 

--- a/database/migrations/2016_11_10_150000_AlterTableMetricsAddComponentRelation.php
+++ b/database/migrations/2016_11_10_150000_AlterTableMetricsAddComponentRelation.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterTableMetricsAddComponentRelation extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::table('metrics', function (Blueprint $table) {
+            $table->integer('component_id')->after('order')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::table('metrics', function (Blueprint $table) {
+            $table->dropColumn('component_id');
+        });
+    }
+}

--- a/database/migrations/2016_11_10_160000_CreateStatusTransitionsTables.php
+++ b/database/migrations/2016_11_10_160000_CreateStatusTransitionsTables.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\ComponentGroup;
+use CachetHQ\Cachet\Models\ComponentStatusTransition;
+use CachetHQ\Cachet\Models\GroupStatusTransition;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateStatusTransitionsTables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('component_status_transitions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('component_id')->unsigned();
+            $table->integer('status');
+            $table->timestamps();
+
+            $table->index('component_id');
+            $table->index('created_at');
+        });
+
+        // Populate status transitions for existent component.
+        foreach (Component::query()->get() as $component) {
+            ComponentStatusTransition::create([
+                'component_id' => $component->id,
+                'status'       => $component->status,
+            ]);
+        }
+
+        Schema::create('group_status_transitions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('component_group_id')->unsigned();
+            $table->integer('status');
+            $table->text('offending_components');
+            $table->timestamps();
+
+            $table->index('component_group_id');
+            $table->index('created_at');
+        });
+
+        // Populate status transitions for existent component groups.
+        foreach (ComponentGroup::query()->get() as $group) {
+            $componentsStatuses = [];
+            foreach ($group->enabled_components_lowest()->get() as $component) {
+                $componentsStatuses[] = [
+                    'name'   => $component->name,
+                    'status' => $component->status,
+                ];
+            }
+
+            GroupStatusTransition::create([
+                'component_group_id'   => $group->id,
+                'status'               => $group->enabled_components_lowest()->first() ? $group->enabled_components_lowest()->first()->status : 0,
+                'offending_components' => json_encode($componentsStatuses),
+            ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('component_status_transitions');
+        Schema::drop('group_status_transitions');
+    }
+}

--- a/resources/assets/sass/plugins/_github-markdown.scss
+++ b/resources/assets/sass/plugins/_github-markdown.scss
@@ -172,6 +172,13 @@
   overflow: visible;
 }
 
+.markdown-body button:-moz-focusring,
+.markdown-body [type="button"]:-moz-focusring,
+.markdown-body [type="reset"]:-moz-focusring,
+.markdown-body [type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
 .markdown-body [type="checkbox"] {
   box-sizing: border-box;
   padding: 0;
@@ -321,6 +328,10 @@
 .markdown-body input {
   -webkit-font-feature-settings: "liga" 0;
   font-feature-settings: "liga" 0;
+}
+
+.markdown-body .form-select::-ms-expand {
+  opacity: 0;
 }
 
 .markdown-body::before {
@@ -517,6 +528,8 @@
   display: block;
   width: 100%;
   overflow: auto;
+  word-break: normal;
+  word-break: keep-all;
 }
 
 .markdown-body table th {

--- a/resources/assets/sass/status-page/_status-page.scss
+++ b/resources/assets/sass/status-page/_status-page.scss
@@ -43,6 +43,17 @@ body.status-page {
         }
     }
 
+    .dropdown-menu {
+        .group a {
+            font-weight: 600;
+            color: $cachet-gray-darker;
+        }
+
+        .grouped a {
+            margin-left: 15px;
+        }
+    }
+
     .help-icon {
         cursor: help;
     }
@@ -402,6 +413,11 @@ body.status-page {
         margin-top: 40px;
     }
 
+    .section-filters {
+        padding-bottom: 10px;
+        text-align: right;
+    }
+
     .navbar-custom {
         padding-top: 10px;
         padding-bottom: 10px;
@@ -420,6 +436,69 @@ body.status-page {
 
             &:hover {
                 background-color: transparent;
+            }
+        }
+    }
+
+    .historical-charts {
+        margin-top: 10px;
+        color: $cachet-gray-darker;
+
+        .transition-chart {
+            padding: 2rem;
+
+            .chart-title {
+                font-size: 0.85em;
+                font-weight: bold;
+                color: $cachet-gray-darker !important;
+                text-align: center;
+            }
+
+            .legend-column {
+                width: 6em;
+            }
+
+            .progress {
+                margin-bottom: 0;
+
+                .progress-bar label {
+                    width: 100%;
+                    height: 100%;
+                    margin: 0;
+                    padding: 0;
+                }
+            }
+        }
+
+        .chart-pager {
+            margin-top: 32px;
+
+            a {
+                font-size: 0.8em;
+                color: $cachet-gray-darker !important;
+                text-decoration: none;
+            }
+        }
+    }
+
+    .transition-tooltip {
+        font-family: 'Open Sans', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+        font-size: 0.9em;
+
+        .status-title {
+            padding: 8px 0;
+        }
+
+        dt {
+            margin-top: 8px;
+        }
+
+        ul {
+            padding: 0 0 0 18px;
+
+            li {
+                padding: 0;
+                margin: 0;
             }
         }
     }

--- a/resources/lang/en/cachet.php
+++ b/resources/lang/en/cachet.php
@@ -12,6 +12,7 @@
 return [
     // Components
     'components' => [
+        'filter'       => 'Display component:',
         'last_updated' => 'Last updated :timestamp',
         'status'       => [
             0 => 'Unknown',
@@ -21,7 +22,8 @@ return [
             4 => 'Major Outage',
         ],
         'group' => [
-            'other' => 'Other Components',
+            'other'  => 'Other Components',
+            'single' => 'Component',
         ],
     ],
 
@@ -72,6 +74,25 @@ return [
             'weekly'    => 'Week',
             'monthly'   => 'Month',
         ],
+    ],
+
+    // Status Transitions
+    'status_transitions' => [
+        'transition_chart' => [
+            'title'   => 'Status Transitions',
+            'tooltip' => [
+                'from_date'  => 'From Date',
+                'to_date'    => 'To Date',
+                'duration'   => 'Duration',
+                'components' => 'Components Summary',
+            ],
+        ],
+        'availability_chart' => [
+            'title'   => 'Availability',
+            'y_label' => 'Percentage',
+        ],
+        'previous_week' => 'Previous week',
+        'next_week'     => 'Next week',
     ],
 
     // Subscriber

--- a/resources/lang/en/forms.php
+++ b/resources/lang/en/forms.php
@@ -122,6 +122,7 @@ return [
     'metrics' => [
         'name'             => 'Name',
         'suffix'           => 'Suffix',
+        'component'        => 'Component',
         'description'      => 'Description',
         'description-help' => 'You may also use Markdown.',
         'display-chart'    => 'Display chart on status page?',

--- a/resources/views/dashboard/metrics/add.blade.php
+++ b/resources/views/dashboard/metrics/add.blade.php
@@ -31,6 +31,25 @@
                             <textarea name="metric[description]" class="form-control" rows="5" placeholder="{{ trans('forms.metrics.description') }}">{{ Binput::old('metric.description') }}</textarea>
                         </div>
                     </div>
+                    @if(!$components_in_groups->isEmpty() || !$components_out_groups->isEmpty())
+                    <div class="form-group">
+                        <label>{{ trans('forms.metrics.component') }}</label>
+                        <select name='metric[component_id]' class='form-control'>
+                            <option value='0' selected></option>
+                            @foreach($components_in_groups as $group)
+                            <optgroup label="{{ $group->name }}">
+                                @foreach($group->components as $component)
+                                <option value='{{ $component->id }}'>{{ $component->name }}</option>
+                                @endforeach
+                            </optgroup>
+                            @endforeach
+                            @foreach($components_out_groups as $component)
+                            <option value='{{ $component->id }}'>{{ $component->name }}</option>
+                            @endforeach
+                        </select>
+                        <span class='help-block'>{{ trans('forms.optional') }}</span>
+                    </div>
+                    @endif
                     <div class="form-group">
                         <label>{{ trans('forms.metrics.calc_type') }}</label>
                         <select name="metric[calc_type]" class="form-control" required>

--- a/resources/views/dashboard/metrics/edit.blade.php
+++ b/resources/views/dashboard/metrics/edit.blade.php
@@ -31,6 +31,12 @@
                             <textarea name="description" class="form-control" rows="5" placeholder="{{ trans('forms.metrics.description') }}">{{ $metric->description }}</textarea>
                         </div>
                     </div>
+                    @if($metric->component)
+                    <div class="form-group">
+                        <label for="metric-component">{{ trans('forms.metrics.component') }}</label>
+                        <input type="text" class="form-control" name="metric-cmoponent" id="metric-cmoponent" readonly value="{{ $metric->component->name }}">
+                    </div>
+                    @endif
                     <div class="form-group">
                         <label>{{ trans('forms.metrics.calc_type') }}</label>
                         <select name="calc_type" class="form-control" required>

--- a/resources/views/partials/components.blade.php
+++ b/resources/views/partials/components.blade.php
@@ -1,3 +1,7 @@
+<div class="section-filters">
+    @include('partials.components_filter')
+</div>
+
 @if($component_groups->count() > 0)
 @foreach($component_groups as $componentGroup)
 <ul class="list-group components">
@@ -21,11 +25,21 @@
 @endforeach
 @endif
 
-@if($ungrouped_components->count() > 0)
+@if($ungrouped_components->count() > 0 && !$component_selected && !$component_group_selected)
 <ul class="list-group components">
     <li class="list-group-item group-name"><strong>{{ trans('cachet.components.group.other') }}</strong></li>
     @foreach($ungrouped_components as $component)
     @include('partials.component', compact($component))
     @endforeach
 </ul>
+@endif
+
+@if($component_selected)
+<ul class="list-group components">
+    <li class="list-group-item group-name"><strong>{{ trans('cachet.components.group.single') }}</strong></li>
+    @include('partials.component', ['component' => $component_selected])
+</ul>
+@include('partials.components_transitions', ['component' => $component_selected])
+@elseif($component_group_selected)
+@include('partials.components_transitions', ['component' => $component_group_selected])
 @endif

--- a/resources/views/partials/components_filter.blade.php
+++ b/resources/views/partials/components_filter.blade.php
@@ -1,0 +1,25 @@
+<div class="dropdown">
+    {{ trans('cachet.components.filter') }}
+    <a href="javascript: void(0);" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+        @if($component_selected)
+        <span class="filter">{{ $component_selected->name }}</span>
+        @elseif($component_group_selected)
+        <span class="filter">{{ $component_group_selected->name }}</span>
+        @else
+        <span class="filter">All</span>
+        @endif
+        <span class="caret"></span>
+    </a>
+    <ul class="dropdown-menu dropdown-menu-right">
+        <li><a href="{{ cachet_route('status-page') }}">All</a></li>
+        @foreach($all_component_groups as $componentGroup)
+        <li class="group"><a href="{{ cachet_route('group-status-page', [$componentGroup->id]) }}">{{ $componentGroup->name }}</a></li>
+        @foreach($componentGroup->enabled_components()->orderBy('order')->get() as $component)
+        <li class="grouped"><a href="{{ cachet_route('component-status-page', [$component->id]) }}">{{ $component->name }}</a></li>
+        @endforeach
+        @endforeach
+        @foreach($ungrouped_components as $component)
+        <li><a href="{{ cachet_route('component-status-page', [$component->id]) }}">{{ $component->name }}</a></li>
+        @endforeach
+    </ul>
+</div>

--- a/resources/views/partials/components_transitions.blade.php
+++ b/resources/views/partials/components_transitions.blade.php
@@ -1,0 +1,468 @@
+<ul class="list-group">
+    <li class="list-group-item">
+        <div class="historical-charts" id="component-status-container" data-status-component-id="{{ $component->id }}">
+            <div id="component-status-table"></div>
+            <hr/>
+            <canvas id="component-status-bar" height="128"></canvas>
+            <div class="clearfix chart-pager">
+                <a href="javascript: updateChart('prev');" class="pull-left">
+                    <span aria-hidden="true">&laquo;</span>
+                    {{ trans('cachet.status_transitions.previous_week') }}
+                </a>
+                <a href="javascript: updateChart('next');" class="pull-right">
+                    {{ trans('cachet.status_transitions.next_week') }}
+                    <span aria-hidden="true">&raquo;</span>
+                </a>
+            </div>
+        </div>
+    </li>
+</ul>
+
+<script>
+    (function () {
+        var charts, visibleWeek = 0;
+
+        $('div[data-status-component-id]').each(function() {
+            drawChart($(this), getMappingDays(0));
+        });
+
+        // Update the chart with previous or next week data.
+        window.updateChart = function(direction) {
+            if (direction != 'next' || visibleWeek < 0) {
+                visibleWeek = (direction == 'prev') ? visibleWeek - 7 : (direction == 'next') ? visibleWeek + 7 : 0;
+                drawChart($("#component-status-container"), getMappingDays(visibleWeek));
+            }
+        };
+
+        function getMappingDays(startDay) {
+            return _.map([startDay-7, startDay-6, startDay-5, startDay-4, startDay-3, startDay-2, startDay-1, startDay], function(daysAgo) {
+                return moment.utc()
+                        .hours(0)
+                        .minutes(0)
+                        .seconds(0)
+                        .milliseconds(0)
+                        .add(daysAgo, 'days');
+            });
+        }
+
+        function drawChart($el, days) {
+            var componentId = $el.data('status-component-id'),
+                fromDate = days[0].toISOString(),
+                toDate = days[days.length - 1].clone().add(1, 'days').toISOString();
+
+            @if($component_group_selected)
+            var baseRestUrl = '/status/transitions/group/',
+                isGroup = true;
+            @elseif ($component_selected)
+            var baseRestUrl = '/status/transitions/component/',
+                isGroup = false;
+            @endif
+
+            $.getJSON(baseRestUrl + componentId, {
+                from: fromDate,
+                to: toDate
+            }).done(function (result) {
+
+                // 1. Convert to durations.
+                var durations = asDurations(result, days);
+                if (typeof charts === 'undefined') {
+                    charts = {
+                        bar: {
+                            context: document.getElementById("component-status-bar").getContext("2d"),
+                            chart: null
+                        }
+                    };
+                }
+
+                // 2. Create the bar chart.
+                var barChart = charts.bar,
+                    barChartData = asBarChartData(durations, days);
+
+                if (barChart.chart !== null) {
+                    barChart.chart.destroy();
+                }
+
+                Chart.defaults.global.defaultFontFamily = "'Open Sans', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif";
+                Chart.defaults.global.defaultFontColor = "#444";
+                Chart.defaults.global.defaultFontStyle = "normal";
+
+                barChart.chart = new Chart(barChart.context, {
+                    type: "bar",
+                    data: barChartData,
+                    options: {
+                        title: {
+                            display: true,
+                            text: '{{ trans("cachet.status_transitions.availability_chart.title") }}'
+                        },
+                        scales: {
+                            xAxes: [{
+                                stacked: true
+                            }],
+                            yAxes: [{
+                                stacked: true,
+                                scaleLabel: {
+                                    display: true,
+                                    labelString: '{{ trans("cachet.status_transitions.availability_chart.y_label") }}'
+                                }
+                            }]
+                        },
+                        legend: {
+                            display: true,
+                            position: "top",
+                            labels: {
+                                boxWidth: 30,
+                                generateLabels: function(chart) {
+                                    var data = chart.data;
+                                    return _.isArray(data.datasets) ? _.map(data.datasets, function(dataset, i) {
+                                        return {
+                                            text: dataset.label + ' (' + formatNumber(dataset.percent * 100) + '%)',
+                                            fillStyle: (!_.isArray(dataset.backgroundColor) ? dataset.backgroundColor : dataset.backgroundColor[0]),
+                                            hidden: !chart.isDatasetVisible(i),
+                                            lineCap: dataset.borderCapStyle,
+                                            lineDash: dataset.borderDash,
+                                            lineDashOffset: dataset.borderDashOffset,
+                                            lineJoin: dataset.borderJoinStyle,
+                                            lineWidth: dataset.borderWidth,
+                                            strokeStyle: dataset.borderColor,
+                                            pointStyle: dataset.pointStyle,
+                                            // Below is extra data used for toggling the datasets.
+                                            datasetIndex: i
+                                        };
+                                    }) : [];
+                                }
+                            }
+                        },
+                        tooltips: {
+                            custom: function(tooltip) {
+                                // Check if tooltip and tooltip.body.
+                                if (!tooltip || !tooltip.body) {
+                                    return;
+                                }
+                                // Read data.
+                                var tooltipInstance = this,
+                                    data = tooltipInstance._data,
+                                    datasetIndex = tooltipInstance._active[0]._datasetIndex,
+                                    index = tooltipInstance._active[0]._index,
+                                    dataset = data.datasets[datasetIndex],
+                                    value = formatNumber(dataset.data[index]);
+
+                                // Set tooltip text.
+                                tooltip.body = [{
+                                    after: [],
+                                    before: [],
+                                    lines: [
+                                        dataset.label + ' (' + value + '%)'
+                                    ]
+                                }];
+                            }
+                        }
+                    }
+                });
+
+                // 3. Create Transitions Table:
+                document.getElementById("component-status-table").innerHTML = asTable(durations, days);
+                $("#component-status-table").find('[data-toggle="popover"]').popover({
+                    container: 'body',
+                    trigger: 'focus hover',
+                    placement: 'top'
+                });
+            });
+
+            function asDurations(data, days) {
+                var result,
+                    previousTransition = data.data.previous_transition.length ? data.data.previous_transition[0] : null;
+
+                // Transform transition dates to durations.
+                if (data.data.transitions.length) {
+                    result = _.chain(data.data.transitions)
+                            .sortBy(['utc_created_at'])
+                            .reduce(function(result, transition, index, transitions) {
+                                var currentDate = moment.utc(transition.utc_created_at),
+                                    endOfDay = visibleWeek === 0 ? moment.utc() : moment.utc(days[days.length - 1]).endOf('day'),
+                                    nextDate = (index !== transitions.length -1) ? moment.utc(transitions[index + 1].utc_created_at) : endOfDay,
+                                    hours = nextDate.diff(currentDate, 'hours', true);
+
+                                // If it's the first iteration, add the first transition.
+                                if (index === 0) {
+                                    result.durations.push({
+                                        status: previousTransition ? previousTransition.status : 0,
+                                        fromDate: days[0].clone(),
+                                        toDate: currentDate.clone(),
+                                        duration: currentDate.diff(days[0], 'hours', true),
+                                        offendingComponents: (isGroup && previousTransition) ? previousTransition.offending_components : []
+                                    });
+                                }
+
+                                result.durations.push({
+                                    status: transition.status,
+                                    fromDate: currentDate.clone(),
+                                    toDate: nextDate.clone(),
+                                    duration: hours,
+                                    offendingComponents: isGroup ? transition.offending_components : []
+                                });
+
+                                result.sum += hours;
+
+                                return result;
+                            }, {
+                                durations: [],
+                                sum: 0
+                            }).value();
+
+                // If the transitions are empty, check the previous transition or display unknown status.
+                } else {
+                    var startOfWeek = moment.utc(days[0]).startOf('day'),
+                        endOfWeek = moment.utc(days[days.length - 1]).endOf('day'),
+                        duration = visibleWeek === 0 ? moment.utc().diff(startOfWeek, 'hours', true) : endOfWeek.diff(startOfWeek, 'hours', true);
+
+                    result = {
+                        durations: [{
+                            status: previousTransition ? previousTransition.status : 0,
+                            fromDate: startOfWeek,
+                            toDate: visibleWeek === 0 ? moment.utc() : endOfWeek,
+                            duration: duration,
+                            offendingComponents: (isGroup && previousTransition) ? previousTransition.offending_components : []
+                        }],
+                        sum: duration
+                    };
+                }
+
+                // Add percentages.
+                _.forEach(result.durations, function(d, index) {
+                    d.percentage = (d.duration  * 100 / result.sum) + '%' ;
+                });
+
+                return result.durations;
+            }
+
+            function groupDurations(durations, groupingPeriod) {
+                var result = [],
+                    group = 0,
+                    total = groupingPeriod;
+
+                _.forEach(durations, function(durationObj) {
+                    var duration = durationObj.duration;
+                    while (duration >= total) {
+                        if (!result[group]) {
+                            result[group] = [];
+                        }
+                        result[group].push(_.extend(_.cloneDeep(durationObj), {
+                            durationInGroup: total,
+                            percentageInGroup: (total / groupingPeriod)
+                        }));
+                        duration = duration - total;
+                        group = group + 1; // Next Group
+                        total = groupingPeriod;
+                    }
+                    // Add to dataset but do not increase the day number
+                    if (!result[group]) {
+                        result[group] = [];
+                    }
+                    result[group].push(_.extend(_.cloneDeep(durationObj), {
+                        durationInGroup: duration,
+                        percentageInGroup: (duration / groupingPeriod)
+                    }));
+                    total = total - duration;
+                });
+
+                return result;
+            }
+
+            function asBarChartData(durations, days) {
+
+                // 1. Prepare result object
+                var result = {
+                    labels: _.map(days, function(d) {
+                        return d.format('YYYY-MM-DD');
+                    }),
+                    total : 0,
+                    datasets: [
+                        {
+                            label: "Unknown",
+                            backgroundColor: 'rgba(136, 136, 136, 0.5)',
+                            borderColor: 'rgba(136, 136, 136, 1)',
+                            borderWidth: 1,
+                            total : 0,
+                            data: []
+                        },
+                        {
+                            label: "Operational",
+                            backgroundColor: 'rgba(126, 211, 33, 0.5)',
+                            borderColor: 'rgba(126, 211, 33, 1)',
+                            borderWidth: 1,
+                            total : 0,
+                            data: []
+                        },
+                        {
+                            label: "Performance Issues",
+                            backgroundColor: 'rgba(52, 152, 219, 0.5)',
+                            borderColor: 'rgba(52, 152, 219, 1)',
+                            borderWidth: 1,
+                            total : 0,
+                            data: []
+                        },
+                        {
+                            label: "Partial Outage",
+                            backgroundColor: 'rgba(247, 202, 24, 0.5)',
+                            borderColor: 'rgba(247, 202, 24, 1)',
+                            borderWidth: 1,
+                            total : 0,
+                            data: []
+                        },
+                        {
+                            label: "Major Outage",
+                            backgroundColor: 'rgba(255, 111, 111, 0.5)',
+                            borderColor: 'rgba(255, 111, 111, 1)',
+                            borderWidth: 1,
+                            total : 0,
+                            data: []
+                        }
+                    ]
+                };
+
+                // 2. Fill the Dataset based on durations
+                // 2.1. Init with '0'
+                _.forEach(result.datasets, function(dataset) {
+                    dataset.data = _.times(days.length, _.constant(0));
+                });
+
+                // 2.2. Group Durations in 24 hours groups
+                var groupedDurations = groupDurations(durations, 24);
+
+                // 2.3 Iterate and add to barChart
+                _.forEach(groupedDurations, function(durationsInDay, day) {
+                    _.forEach(durationsInDay, function(durationObj) {
+                        var status = durationObj.status,
+                            duration = durationObj.durationInGroup,
+                            percent = durationObj.percentageInGroup;
+
+                        result.datasets[status].data[day] += percent * 100;
+                        result.datasets[status].total += duration;
+                        result.total += duration;
+                    });
+                });
+
+                // 2.3. Add dataset percentage
+                _.forEach(result.datasets, function(dataset) {
+                    dataset.percent = dataset.total / result.total;
+                });
+
+                return result;
+            }
+
+            function asTable(durations, days) {
+                var tableTemplate = _.template(
+                        '<div class="transition-chart">' +
+                        '    <p class="chart-title">{{ trans("cachet.status_transitions.transition_chart.title") }}</p>' +
+                        '    <% _.forEach(data, function(row) { %>' +
+                        '    <div>' +
+                        '        <div class="pull-left legend-column">'+
+                        '        <small><%- row.startDate %></small>'+
+                        '    </div>' +
+                        '    <div class="progress">' +
+                        '        <% _.forEach(row.durations, function(d) { %>' +
+                        '        <div class="progress-bar" style="width: <%- d.width * 100 %>%; background-color:<%- d.backgroundColor %>">' +
+                        '            <label data-toggle="popover" data-content="<%- d.text %>" data-html="true">' +
+                        '                <input class="sr-only" type="radio" name="status">' +
+                        '            </label>' +
+                        '        </div>' +
+                        '        <% }); %>' +
+                        '    </div>' +
+                        '    <div class="clearfix"></div>' +
+                        '    <% }); %>' +
+                        '</div>'
+                );
+
+                var statusText = [{
+                    label: 'Unknown',
+                    backgroundColor: 'rgba(136, 136, 136, 0.5)',
+                    statusClass: 'greys'
+                },
+                {
+                    label: 'Operational',
+                    backgroundColor: 'rgba(126, 211, 33, 0.5)',
+                    statusClass: 'greens'
+                },
+                {
+                    label: 'Performance Issues',
+                    backgroundColor: 'rgba(52, 152, 219, 0.5)',
+                    statusClass: 'blues'
+                },
+                {
+                    label: 'Partial Outage',
+                    backgroundColor: 'rgba(247, 202, 24, 0.5)',
+                    statusClass: 'yellows'
+                },
+                {
+                    label: 'Major Outage',
+                    backgroundColor: 'rgba(255, 111, 111, 0.5)',
+                    statusClass: 'reds'
+                }];
+
+                // 1. Group By Day
+                var templateData = [],
+                    groupingPeriod = 24,
+                    groupedDurations = groupDurations(durations, groupingPeriod);
+
+                // 2. Map to templateData
+                _.forEach(groupedDurations, function(durations, group) {
+                    var fromDate = days[0].clone().add(group * groupingPeriod, 'hours'),
+                        toDate = fromDate.clone().add(groupingPeriod, 'hours'),
+                        groupData = _.chain(durations)
+                            .filter(function(d) {
+                                return d.duration > 0;
+                            })
+                            .map(function(d) {
+                                var text = '<div class="transition-tooltip">' +
+                                        '<div class="status-title clearfix">' +
+                                            '<i class="pull-right ion ion-ios-circle-filled ' + statusText[d.status].statusClass + '"></i>' +
+                                            '<span class="' + statusText[d.status].statusClass + '">' + statusText[d.status].label + '</span>' +
+                                        '</div>' +
+                                        '<dl>' +
+                                            '<dt>{{ trans("cachet.status_transitions.transition_chart.tooltip.from_date") }}</dt><dd>'+ d.fromDate.toISOString() + '</dd>' +
+                                            '<dt>{{ trans("cachet.status_transitions.transition_chart.tooltip.to_date") }}</dt><dd>' + d.toDate.toISOString() + '</dd>' +
+                                            '<dt>{{ trans("cachet.status_transitions.transition_chart.tooltip.duration") }}</dt><dd>' + humanizeDuration(d.duration) + '</dd>';
+
+                                if (isGroup && d.offendingComponents.length > 0) {
+                                    text += '<dt>{{ trans("cachet.status_transitions.transition_chart.tooltip.components") }}</dt><dd><ul>';
+                                    for (var i = 0; i < d.offendingComponents.length; i++) {
+                                        text += '<li>' + d.offendingComponents[i]['name'] + ': ' + d.offendingComponents[i]['status'] + '</li>';
+                                    }
+                                    text += '</ul></dd>';
+                                }
+                                text += '</dl></div>';
+
+                                return {
+                                    width: d.percentageInGroup,
+                                    backgroundColor: statusText[d.status].backgroundColor,
+                                    text: text
+                                };
+                            })
+                            .value();
+
+                    templateData.push({
+                        startDate: fromDate.format('YYYY-MM-DD'),
+                        endDate: toDate.format('YYYY-MM-DD'),
+                        durations: groupData
+                    });
+                });
+
+                return tableTemplate({
+                    data: templateData
+                });
+            }
+
+            function formatNumber(num) {
+                return (num.toFixed(1) * 1).toString();
+            }
+
+            function humanizeDuration(duration) {
+                var hours = Math.floor(duration),
+                    minutes = Math.floor((duration - hours) * 60),
+                    seconds = Math.floor(((duration - hours) * 60 - minutes) * 60);
+
+                return hours + ' hours, ' + minutes + ' minutes, ' + seconds + ' seconds';
+            }
+        }
+    }());
+</script>

--- a/resources/views/partials/metrics.blade.php
+++ b/resources/views/partials/metrics.blade.php
@@ -5,6 +5,9 @@
         <div class="row">
             <div class="col-xs-10">
                 <strong>
+                    @if($metric->component)
+                    <span class="label label-default">{{ $metric->component->name }}</span>
+                    @endif
                     {{ $metric->name }}
                     @if($metric->description)
                     <i class="ion ion-ios-help-outline" data-toggle="tooltip" data-title="{{ $metric->description }}"></i>

--- a/resources/views/partials/modules/components.blade.php
+++ b/resources/views/partials/modules/components.blade.php
@@ -1,4 +1,4 @@
-@if(!$component_groups->isEmpty() || !$ungrouped_components->isEmpty())
+@if(!$component_groups->isEmpty() || !$ungrouped_components->isEmpty() || $component_group_selected || $component_selected)
 <div class="section-components">
     @include('partials.components')
 </div>

--- a/resources/views/partials/modules/timeline.blade.php
+++ b/resources/views/partials/modules/timeline.blade.php
@@ -10,14 +10,14 @@
     <ul class="pager">
         @if($can_page_backward)
         <li class="previous">
-            <a href="{{ cachet_route('status-page') }}?start_date={{ $previous_date }}" class="links">
+            <a href="{{ Request::url() }}?start_date={{ $previous_date }}" class="links">
                 <span aria-hidden="true">&larr;</span> {{ trans('cachet.incidents.previous_week') }}
             </a>
         </li>
         @endif
         @if($can_page_forward)
         <li class="next">
-            <a href="{{ cachet_route('status-page') }}?start_date={{ $next_date }}" class="links">
+            <a href="{{ Request::url() }}?start_date={{ $next_date }}" class="links">
                 {{ trans('cachet.incidents.next_week') }} <span aria-hidden="true">&rarr;</span>
             </a>
         </li>

--- a/tests/Api/MetricTest.php
+++ b/tests/Api/MetricTest.php
@@ -63,6 +63,7 @@ class MetricTest extends AbstractApiTestCase
             'places'        => 0,
             'view'          => 0,
             'threshold'     => 5,
+            'component_id'  => 0,
             'order'         => 1,
         ]);
         $this->seeJson(['name' => 'Foo']);

--- a/tests/Bus/Commands/Metric/AddMetricCommandTest.php
+++ b/tests/Bus/Commands/Metric/AddMetricCommandTest.php
@@ -38,6 +38,7 @@ class AddMetricCommandTest extends AbstractTestCase
             'places'        => 0,
             'default_view'  => 0,
             'threshold'     => 0,
+            'component_id'  => 0,
             'order'         => 0,
         ];
 
@@ -51,6 +52,7 @@ class AddMetricCommandTest extends AbstractTestCase
             $params['places'],
             $params['default_view'],
             $params['threshold'],
+            $params['component_id'],
             $params['order']
         );
 

--- a/tests/Bus/Commands/Metric/UpdateMetricCommandTest.php
+++ b/tests/Bus/Commands/Metric/UpdateMetricCommandTest.php
@@ -40,6 +40,7 @@ class UpdateMetricCommandTest extends AbstractTestCase
             'places'        => 0,
             'default_view'  => 0,
             'threshold'     => 0,
+            'component_id'  => 0,
             'order'         => 0,
         ];
 
@@ -54,6 +55,7 @@ class UpdateMetricCommandTest extends AbstractTestCase
             $params['places'],
             $params['default_view'],
             $params['threshold'],
+            $params['component_id'],
             $params['order']
         );
 


### PR DESCRIPTION
Hi! We are using the next branch for filtering the specific component/group information and also support the historical status transition information.

Features on this branch:
* Status page dropdown for allowing filtering components/groups.
* Separated pages showing information only related to the component/group filtered (status, metrics, incidents, etc.)
* Historical status transitions for components/groups. Each component/group status change is saved for showing these transitions on different kind of charts.

When a component/group is filtered, the status transition charts are displayed like in the next image:
![status_transition_charts](https://cloud.githubusercontent.com/assets/922783/20235862/22546588-a87e-11e6-8dd8-b24fa761d982.png)
