### PR TITLE
Components can now be supplied meta data

### DIFF
--- a/app/Bus/Commands/Component/AddComponentCommand.php
+++ b/app/Bus/Commands/Component/AddComponentCommand.php
@@ -63,6 +63,13 @@ final class AddComponentCommand
     public $enabled;
 
     /**
+     * JSON meta data for the component.
+     *
+     * @var string|null
+     */
+    public $meta;
+
+    /**
      * The validation rules.
      *
      * @var string[]
@@ -75,22 +82,24 @@ final class AddComponentCommand
         'order'       => 'nullable|int',
         'group_id'    => 'nullable|int',
         'enabled'     => 'nullable|bool',
+        'meta'        => 'nullable|string',
     ];
 
     /**
      * Create a new add component command instance.
      *
-     * @param string $name
-     * @param string $description
-     * @param int    $status
-     * @param string $link
-     * @param int    $order
-     * @param int    $group_id
-     * @param bool   $enabled
+     * @param string      $name
+     * @param string      $description
+     * @param int         $status
+     * @param string      $link
+     * @param int         $order
+     * @param int         $group_id
+     * @param bool        $enabled
+     * @param string|null $meta
      *
      * @return void
      */
-    public function __construct($name, $description, $status, $link, $order, $group_id, $enabled)
+    public function __construct($name, $description, $status, $link, $order, $group_id, $enabled, $meta)
     {
         $this->name = $name;
         $this->description = $description;
@@ -99,5 +108,6 @@ final class AddComponentCommand
         $this->order = $order;
         $this->group_id = $group_id;
         $this->enabled = $enabled;
+        $this->meta = $meta;
     }
 }

--- a/app/Bus/Commands/Component/UpdateComponentCommand.php
+++ b/app/Bus/Commands/Component/UpdateComponentCommand.php
@@ -72,6 +72,13 @@ final class UpdateComponentCommand
     public $enabled;
 
     /**
+     * JSON meta data for the component.
+     *
+     * @var string|null
+     */
+    public $meta;
+
+    /**
      * The validation rules.
      *
      * @var string[]
@@ -84,6 +91,7 @@ final class UpdateComponentCommand
         'order'       => 'nullable|int',
         'group_id'    => 'nullable|int',
         'enabled'     => 'nullable|bool',
+        'meta'        => 'nullable|string',
     ];
 
     /**
@@ -97,10 +105,11 @@ final class UpdateComponentCommand
      * @param int                               $order
      * @param int                               $group_id
      * @param bool                              $enabled
+     * @param string|null                       $meta
      *
      * @return void
      */
-    public function __construct(Component $component, $name, $description, $status, $link, $order, $group_id, $enabled)
+    public function __construct(Component $component, $name, $description, $status, $link, $order, $group_id, $enabled, $meta)
     {
         $this->component = $component;
         $this->name = $name;
@@ -110,5 +119,6 @@ final class UpdateComponentCommand
         $this->order = $order;
         $this->group_id = $group_id;
         $this->enabled = $enabled;
+        $this->meta = $meta;
     }
 }

--- a/app/Bus/Handlers/Commands/Component/AddComponentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Component/AddComponentCommandHandler.php
@@ -50,6 +50,7 @@ class AddComponentCommandHandler
             'enabled'     => $command->enabled,
             'order'       => $command->order,
             'group_id'    => $command->group_id,
+            'meta'        => $command->meta,
         ];
 
         return array_filter($params, function ($val) {

--- a/app/Bus/Handlers/Commands/Component/UpdateComponentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Component/UpdateComponentCommandHandler.php
@@ -56,6 +56,7 @@ class UpdateComponentCommandHandler
             'enabled'     => $command->enabled,
             'order'       => $command->order,
             'group_id'    => $command->group_id,
+            'meta'        => $command->meta,
         ];
 
         return array_filter($params, function ($val) {

--- a/app/Bus/Handlers/Commands/Incident/ReportIncidentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Incident/ReportIncidentCommandHandler.php
@@ -100,6 +100,7 @@ class ReportIncidentCommandHandler
                 null,
                 null,
                 null,
+                null,
                 null
             ));
         }

--- a/app/Http/Controllers/Api/ComponentController.php
+++ b/app/Http/Controllers/Api/ComponentController.php
@@ -77,7 +77,8 @@ class ComponentController extends AbstractApiController
                 Binput::get('link'),
                 Binput::get('order'),
                 Binput::get('group_id'),
-                (bool) Binput::get('enabled', true)
+                (bool) Binput::get('enabled', true),
+                Binput::get('meta', null)
             ));
         } catch (QueryException $e) {
             throw new BadRequestHttpException();
@@ -118,7 +119,8 @@ class ComponentController extends AbstractApiController
                 Binput::get('link'),
                 Binput::get('order'),
                 Binput::get('group_id'),
-                (bool) Binput::get('enabled', true)
+                (bool) Binput::get('enabled', true),
+                Binput::get('meta', null)
             ));
         } catch (QueryException $e) {
             throw new BadRequestHttpException();

--- a/app/Http/Controllers/Dashboard/ComponentController.php
+++ b/app/Http/Controllers/Dashboard/ComponentController.php
@@ -134,7 +134,8 @@ class ComponentController extends Controller
                 $componentData['link'],
                 $componentData['order'],
                 $componentData['group_id'],
-                $componentData['enabled']
+                $componentData['enabled'],
+                null // Meta data cannot be supplied through the dashboard yet.
             ));
         } catch (ValidationException $e) {
             return cachet_redirect('dashboard.components.edit', [$component->id])
@@ -187,7 +188,8 @@ class ComponentController extends Controller
                 $componentData['link'],
                 $componentData['order'],
                 $componentData['group_id'],
-                $componentData['enabled']
+                $componentData['enabled'],
+                null // Meta data cannot be supplied through the dashboard yet.
             ));
         } catch (ValidationException $e) {
             return cachet_redirect('dashboard.components.create')

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -35,6 +35,7 @@ class Component extends Model implements HasPresenter
         'description' => '',
         'link'        => '',
         'enabled'     => true,
+        'meta'        => null,
     ];
 
     /**
@@ -50,6 +51,7 @@ class Component extends Model implements HasPresenter
         'link'        => 'string',
         'group_id'    => 'int',
         'enabled'     => 'bool',
+        'meta'        => 'json',
         'deleted_at'  => 'date',
     ];
 
@@ -67,6 +69,7 @@ class Component extends Model implements HasPresenter
         'order',
         'group_id',
         'enabled',
+        'meta',
     ];
 
     /**

--- a/database/migrations/2016_12_05_185045_AlterTableComponentsAddMetaColumn.php
+++ b/database/migrations/2016_12_05_185045_AlterTableComponentsAddMetaColumn.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterTableComponentsAddMetaColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('components', function (Blueprint $table) {
+            $table->longText('meta')->nullable()->default(null)->after('enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('components', function (Blueprint $table) {
+            $table->dropColumn('meta');
+        });
+    }
+}

--- a/tests/Api/ComponentTest.php
+++ b/tests/Api/ComponentTest.php
@@ -84,6 +84,31 @@ class ComponentTest extends AbstractApiTestCase
         $this->assertResponseOk();
     }
 
+    public function testPostComponentWithMetaData()
+    {
+        $this->beUser();
+
+        $this->post('/api/v1/components', [
+            'name'        => 'Foo',
+            'description' => 'Bar',
+            'status'      => 1,
+            'link'        => 'http://example.com',
+            'order'       => 1,
+            'group_id'    => 1,
+            'enabled'     => true,
+            'meta'        => [
+                'uuid' => '172ff3fb-41f7-49d3-8bcd-f57b53627fa0',
+            ],
+        ]);
+
+        $this->seeJson([
+            'meta' => [
+                'uuid' => '172ff3fb-41f7-49d3-8bcd-f57b53627fa0',
+            ],
+        ]);
+        $this->assertResponseOk();
+    }
+
     public function testPostDisabledComponent()
     {
         $this->beUser();
@@ -119,6 +144,31 @@ class ComponentTest extends AbstractApiTestCase
             'name' => 'Foo',
         ]);
         $this->seeJson(['name' => 'Foo']);
+        $this->assertResponseOk();
+    }
+
+    public function testPutComponentWithMetaData()
+    {
+        $this->beUser();
+        $component = factory('CachetHQ\Cachet\Models\Component')->create([
+            'meta' => [
+                'uuid' => '172ff3fb-41f7-49d3-8bcd-f57b53627fa0',
+            ],
+        ]);
+
+        $this->put('/api/v1/components/1', [
+            'meta' => [
+                'uuid' => '172ff3fb-41f7-49d3-8bcd-f57b53627fa0',
+                'foo'  => 'bar',
+            ],
+        ]);
+
+        $this->seeJson([
+            'meta' => [
+                'uuid' => '172ff3fb-41f7-49d3-8bcd-f57b53627fa0',
+                'foo'  => 'bar',
+            ],
+        ]);
         $this->assertResponseOk();
     }
 

--- a/tests/Bus/Commands/Component/AddComponentCommandTest.php
+++ b/tests/Bus/Commands/Component/AddComponentCommandTest.php
@@ -36,6 +36,7 @@ class AddComponentCommandTest extends AbstractTestCase
             'order'       => 0,
             'group_id'    => 0,
             'enabled'     => true,
+            'meta'        => null,
         ];
         $object = new AddComponentCommand(
             $params['name'],
@@ -44,7 +45,8 @@ class AddComponentCommandTest extends AbstractTestCase
             $params['link'],
             $params['order'],
             $params['group_id'],
-            $params['enabled']
+            $params['enabled'],
+            $params['meta']
         );
 
         return compact('params', 'object');

--- a/tests/Bus/Commands/Component/UpdateComponentCommandTest.php
+++ b/tests/Bus/Commands/Component/UpdateComponentCommandTest.php
@@ -38,6 +38,7 @@ class UpdateComponentCommandTest extends AbstractTestCase
             'order'       => 0,
             'group_id'    => 0,
             'enabled'     => true,
+            'meta'        => null,
         ];
 
         $object = new UpdateComponentCommand(
@@ -48,7 +49,8 @@ class UpdateComponentCommandTest extends AbstractTestCase
             $params['link'],
             $params['order'],
             $params['group_id'],
-            $params['enabled']
+            $params['enabled'],
+            $params['meta']
         );
 
         return compact('params', 'object');


### PR DESCRIPTION
Closes #2226

---

I'd still like to get incidents being able to supply meta data, but for now I imagine it's more useful for components. And, if somebody wants to add this to incidents, this is how 🙂 