### PR TITLE
Metric visibility flag was named incorrectly

### DIFF
--- a/resources/views/dashboard/metrics/add.blade.php
+++ b/resources/views/dashboard/metrics/add.blade.php
@@ -68,7 +68,7 @@
                     </div>
                     <div class="form-group">
                         <label>{{ trans('forms.metrics.visibility') }}</label>
-                        <select name="visible" class="form-control" required>
+                        <select name="metric[visible]" class="form-control" required>
                             <option value="0">{{ trans('forms.metrics.visibility_authenticated') }}</option>
                             <option value="1">{{ trans('forms.metrics.visibility_public') }}</option>
                             <option value="2">{{ trans('forms.metrics.visibility_hidden') }}</option>


### PR DESCRIPTION
The visibility flag was not properly wrapped into the array leading to
an error when adding in a metric as it would have an undefined index.

This would then crash adding in a metric from the view.   This was caused by PR #2261 in the merge commit 7dadef9