### PR TITLE
Metrics: Calculation set to average always sums

### DIFF
--- a/app/Models/MetricPoint.php
+++ b/app/Models/MetricPoint.php
@@ -83,8 +83,6 @@ class MetricPoint extends Model implements HasPresenter
     {
         if ($this->metric->calc_type === Metric::CALC_SUM) {
             return round((float) $value * $this->counter, $this->metric->places);
-        } elseif ($this->metric->calc_type === Metric::CALC_AVG) {
-            return round((float) $value * $this->counter, $this->metric->places);
         }
 
         return round((float) $value, $this->metric->places);

--- a/app/Repositories/Metric/AbstractMetricRepository.php
+++ b/app/Repositories/Metric/AbstractMetricRepository.php
@@ -85,7 +85,7 @@ abstract class AbstractMetricRepository
         if (!isset($metric->calc_type) || $metric->calc_type == Metric::CALC_SUM) {
             return "sum({$this->getMetricPointsTable()}.value * {$this->getMetricPointsTable()}.counter) AS value";
         } elseif ($metric->calc_type == Metric::CALC_AVG) {
-            return "avg({$this->getMetricPointsTable()}.value * {$this->getMetricPointsTable()}.counter) AS value";
+            return "avg({$this->getMetricPointsTable()}.value) AS value";
         } else {
             return "sum({$this->getMetricPointsTable()}.value * {$this->getMetricPointsTable()}.counter) AS value";
         }


### PR DESCRIPTION
This commit is two part:

1. getActiveValueAttribute should always return the active attribute
without any further calculation here.  My guess is that this should also happen with sum but I was not going to modify it due to implications on the PR itself.

2. The query to create the average was incorrect and was taking the
count value * the value which we are really looking for the average of
the value.