### PR TITLE
Use unsigned tiny int instead of boolean for visible metrics

### DIFF
--- a/database/migrations/2016_12_04_163502_AlterTableMetricsAddVisibleColumn.php
+++ b/database/migrations/2016_12_04_163502_AlterTableMetricsAddVisibleColumn.php
@@ -23,7 +23,7 @@ class AlterTableMetricsAddVisibleColumn extends Migration
     public function up()
     {
         Schema::table('metrics', function (Blueprint $table) {
-            $table->boolean('visible')->after('order')->default(1);
+            $table->unsignedTinyInteger('visible')->after('order')->default(1);
 
             $table->index('visible');
         });


### PR DESCRIPTION
This field should be an int since we have 0, 1, 2 values https://github.com/CachetHQ/Cachet/blob/2.4/app/Models/Metric.php#L58

/cc @jbrooksuk 