### PR TITLE
Component notifications can be silenced

### DIFF
--- a/app/Bus/Commands/Component/UpdateComponentCommand.php
+++ b/app/Bus/Commands/Component/UpdateComponentCommand.php
@@ -79,6 +79,13 @@ final class UpdateComponentCommand
     public $meta;
 
     /**
+     * If this is true, we won't notify subscribers of the change.
+     *
+     * @var bool
+     */
+    public $silent;
+
+    /**
      * The validation rules.
      *
      * @var string[]
@@ -92,6 +99,7 @@ final class UpdateComponentCommand
         'group_id'    => 'nullable|int',
         'enabled'     => 'nullable|bool',
         'meta'        => 'nullable|string',
+        'silent'      => 'nullable|bool',
     ];
 
     /**
@@ -106,10 +114,11 @@ final class UpdateComponentCommand
      * @param int                               $group_id
      * @param bool                              $enabled
      * @param string|null                       $meta
+     * @param bool                              $silent
      *
      * @return void
      */
-    public function __construct(Component $component, $name, $description, $status, $link, $order, $group_id, $enabled, $meta)
+    public function __construct(Component $component, $name, $description, $status, $link, $order, $group_id, $enabled, $meta, $silent)
     {
         $this->component = $component;
         $this->name = $name;
@@ -120,5 +129,6 @@ final class UpdateComponentCommand
         $this->group_id = $group_id;
         $this->enabled = $enabled;
         $this->meta = $meta;
+        $this->silent = $silent;
     }
 }

--- a/app/Bus/Events/Component/ComponentStatusWasUpdatedEvent.php
+++ b/app/Bus/Events/Component/ComponentStatusWasUpdatedEvent.php
@@ -51,21 +51,30 @@ final class ComponentStatusWasUpdatedEvent implements ActionInterface, Component
     public $new_status;
 
     /**
+     * If silent, we won't notify.
+     *
+     * @var bool
+     */
+    public $silent;
+
+    /**
      * Create a new component was updated event instance.
      *
      * @param \CachetHQ\Cachet\Models\User      $user
      * @param \CachetHQ\Cachet\Models\Component $component
      * @param int                               $original_status
      * @param int                               $new_status
+     * @param bool                              $silent
      *
      * @return void
      */
-    public function __construct(User $user, Component $component, $original_status, $new_status)
+    public function __construct(User $user, Component $component, $original_status, $new_status, $silent)
     {
         $this->user = $user;
         $this->component = $component;
         $this->original_status = $original_status;
         $this->new_status = $new_status;
+        $this->silent = $silent;
     }
 
     /**

--- a/app/Bus/Handlers/Commands/Component/UpdateComponentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Component/UpdateComponentCommandHandler.php
@@ -50,7 +50,7 @@ class UpdateComponentCommandHandler
         $component = $command->component;
         $originalStatus = $component->status;
 
-        event(new ComponentStatusWasUpdatedEvent($this->auth->user(), $component, $originalStatus, $command->status));
+        event(new ComponentStatusWasUpdatedEvent($this->auth->user(), $component, $originalStatus, $command->status, $command->silent));
 
         $component->update($this->filter($command));
 

--- a/app/Bus/Handlers/Commands/Incident/ReportIncidentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Incident/ReportIncidentCommandHandler.php
@@ -111,7 +111,8 @@ class ReportIncidentCommandHandler
                 null,
                 null,
                 null,
-                null
+                null,
+                false
             ));
         }
 

--- a/app/Bus/Handlers/Events/Component/SendComponentUpdateEmailNotificationHandler.php
+++ b/app/Bus/Handlers/Events/Component/SendComponentUpdateEmailNotificationHandler.php
@@ -48,6 +48,11 @@ class SendComponentUpdateEmailNotificationHandler
     {
         $component = $event->component;
 
+        // If we're silent, then don't send this.
+        if ($event->silent) {
+            return;
+        }
+
         // Don't email anything if the status hasn't changed.
         if ($event->original_status === $event->new_status) {
             return;

--- a/app/Http/Controllers/Api/ComponentController.php
+++ b/app/Http/Controllers/Api/ComponentController.php
@@ -120,7 +120,8 @@ class ComponentController extends AbstractApiController
                 Binput::get('order'),
                 Binput::get('group_id'),
                 (bool) Binput::get('enabled', true),
-                Binput::get('meta', null)
+                Binput::get('meta', null),
+                (bool) Binput::get('silent', false)
             ));
         } catch (QueryException $e) {
             throw new BadRequestHttpException();

--- a/tests/Bus/Commands/Component/UpdateComponentCommandTest.php
+++ b/tests/Bus/Commands/Component/UpdateComponentCommandTest.php
@@ -39,6 +39,7 @@ class UpdateComponentCommandTest extends AbstractTestCase
             'group_id'    => 0,
             'enabled'     => true,
             'meta'        => null,
+            'silent'      => false,
         ];
 
         $object = new UpdateComponentCommand(
@@ -50,7 +51,8 @@ class UpdateComponentCommandTest extends AbstractTestCase
             $params['order'],
             $params['group_id'],
             $params['enabled'],
-            $params['meta']
+            $params['meta'],
+            $params['silent']
         );
 
         return compact('params', 'object');

--- a/tests/Bus/Events/Component/ComponentStatusWasUpdatedEventTest.php
+++ b/tests/Bus/Events/Component/ComponentStatusWasUpdatedEventTest.php
@@ -40,7 +40,7 @@ class ComponentStatusWasUpdatedEventTest extends AbstractComponentEventTestCase
 
         $subscriber->subscriptions()->create(['component_id' => $component->id]);
 
-        $this->app['events']->fire(new ComponentStatusWasUpdatedEvent($user, $component, 1, 2));
+        $this->app['events']->fire(new ComponentStatusWasUpdatedEvent($user, $component, 1, 2, false));
 
         $this->seeMessageFor($subscriber->email);
         $this->seeMessageWithSubject(trans('notifications.component.status_update.mail.subject'));
@@ -58,12 +58,19 @@ class ComponentStatusWasUpdatedEventTest extends AbstractComponentEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['user' => new User(), 'component' => new Component(), 'original_status' => 1, 'new_status' => 2];
+        $params = [
+            'user'            => new User(),
+            'component'       => new Component(),
+            'original_status' => 1,
+            'new_status'      => 2,
+            'silent'          => false
+        ];
         $object = new ComponentStatusWasUpdatedEvent(
             $params['user'],
             $params['component'],
             $params['original_status'],
-            $params['new_status']
+            $params['new_status'],
+            $params['silent']
         );
 
         return compact('params', 'object');

--- a/tests/Bus/Events/Component/ComponentStatusWasUpdatedEventTest.php
+++ b/tests/Bus/Events/Component/ComponentStatusWasUpdatedEventTest.php
@@ -63,7 +63,7 @@ class ComponentStatusWasUpdatedEventTest extends AbstractComponentEventTestCase
             'component'       => new Component(),
             'original_status' => 1,
             'new_status'      => 2,
-            'silent'          => false
+            'silent'          => false,
         ];
         $object = new ComponentStatusWasUpdatedEvent(
             $params['user'],


### PR DESCRIPTION
Fixes #2316

---

You can now supply `silent` as a boolean parameter. If `true` then we won't notify about component status changes.