### PR TITLE
Event action system

### DIFF
--- a/app/Bus/Events/ActionInterface.php
+++ b/app/Bus/Events/ActionInterface.php
@@ -9,17 +9,20 @@
  * file that was distributed with this source code.
  */
 
-namespace CachetHQ\Cachet\Bus\Events\Component;
-
-use CachetHQ\Cachet\Bus\Events\EventInterface;
+namespace CachetHQ\Cachet\Bus\Events;
 
 /**
- * This is the component event interface.
+ * This is the action interface.
  *
  * @author Graham Campbell <graham@alt-three.com>
  * @author James Brooks <james@alt-three.com>
  */
-interface ComponentEventInterface extends EventInterface
+interface ActionInterface
 {
-    //
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction();
 }

--- a/app/Bus/Events/Component/ComponentStatusWasUpdatedEvent.php
+++ b/app/Bus/Events/Component/ComponentStatusWasUpdatedEvent.php
@@ -11,15 +11,24 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Component;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\User;
 
 /**
  * This is the component status was updated event.
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class ComponentStatusWasUpdatedEvent implements ComponentEventInterface
+final class ComponentStatusWasUpdatedEvent implements ActionInterface, ComponentEventInterface
 {
+    /**
+     * The user who updated the component.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The component that was updated.
      *
@@ -44,14 +53,16 @@ final class ComponentStatusWasUpdatedEvent implements ComponentEventInterface
     /**
      * Create a new component was updated event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User      $user
      * @param \CachetHQ\Cachet\Models\Component $component
      * @param int                               $original_status
      * @param int                               $new_status
      *
      * @return void
      */
-    public function __construct(Component $component, $original_status, $new_status)
+    public function __construct(User $user, Component $component, $original_status, $new_status)
     {
+        $this->user = $user;
         $this->component = $component;
         $this->original_status = $original_status;
         $this->new_status = $new_status;
@@ -65,5 +76,18 @@ final class ComponentStatusWasUpdatedEvent implements ComponentEventInterface
     public function __toString()
     {
         return 'Component status was updated.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/Component/ComponentWasAddedEvent.php
+++ b/app/Bus/Events/Component/ComponentWasAddedEvent.php
@@ -11,10 +11,19 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Component;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\User;
 
-final class ComponentWasAddedEvent implements ComponentEventInterface
+final class ComponentWasAddedEvent implements ActionInterface, ComponentEventInterface
 {
+    /**
+     * The user who added the component.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The component that was added.
      *
@@ -25,12 +34,14 @@ final class ComponentWasAddedEvent implements ComponentEventInterface
     /**
      * Create a new component was added event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User      $user
      * @param \CachetHQ\Cachet\Models\Component $component
      *
      * @return void
      */
-    public function __construct(Component $component)
+    public function __construct(User $user, Component $component)
     {
+        $this->user = $user;
         $this->component = $component;
     }
 
@@ -42,5 +53,18 @@ final class ComponentWasAddedEvent implements ComponentEventInterface
     public function __toString()
     {
         return 'Component was added.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/Component/ComponentWasRemovedEvent.php
+++ b/app/Bus/Events/Component/ComponentWasRemovedEvent.php
@@ -11,10 +11,24 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Component;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\User;
 
-final class ComponentWasRemovedEvent implements ComponentEventInterface
+/**
+ * This is the component was removed event class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+final class ComponentWasRemovedEvent implements ActionInterface, ComponentEventInterface
 {
+    /**
+     * The user who removed the component.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The component that was removed.
      *
@@ -25,12 +39,14 @@ final class ComponentWasRemovedEvent implements ComponentEventInterface
     /**
      * Create a new component was removed event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User      $user
      * @param \CachetHQ\Cachet\Models\Component $component
      *
      * @return void
      */
-    public function __construct(Component $component)
+    public function __construct(User $user, Component $component)
     {
+        $this->user = $user;
         $this->component = $component;
     }
 
@@ -42,5 +58,18 @@ final class ComponentWasRemovedEvent implements ComponentEventInterface
     public function __toString()
     {
         return 'Component was removed.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/Component/ComponentWasUpdatedEvent.php
+++ b/app/Bus/Events/Component/ComponentWasUpdatedEvent.php
@@ -11,7 +11,9 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Component;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\User;
 
 /**
  * This is the component was updated event class.
@@ -19,8 +21,15 @@ use CachetHQ\Cachet\Models\Component;
  * @author James Brooks <james@alt-three.com>
  * @author Graham Campbell <graham@alt-three.com>
  */
-final class ComponentWasUpdatedEvent implements ComponentEventInterface
+final class ComponentWasUpdatedEvent implements ActionInterface, ComponentEventInterface
 {
+    /**
+     * The user who updated the component.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The component that was updated.
      *
@@ -31,12 +40,14 @@ final class ComponentWasUpdatedEvent implements ComponentEventInterface
     /**
      * Create a new component was updated event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User      $user
      * @param \CachetHQ\Cachet\Models\Component $component
      *
      * @return void
      */
-    public function __construct(Component $component)
+    public function __construct(User $user, Component $component)
     {
+        $this->user = $user;
         $this->component = $component;
     }
 
@@ -48,5 +59,18 @@ final class ComponentWasUpdatedEvent implements ComponentEventInterface
     public function __toString()
     {
         return 'Component was updated.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/ComponentGroup/ComponentGroupEventInterface.php
+++ b/app/Bus/Events/ComponentGroup/ComponentGroupEventInterface.php
@@ -13,6 +13,12 @@ namespace CachetHQ\Cachet\Bus\Events\ComponentGroup;
 
 use CachetHQ\Cachet\Bus\Events\EventInterface;
 
+/**
+ * This is the component group event interface.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ * @author James Brooks <james@alt-three.com>
+ */
 interface ComponentGroupEventInterface extends EventInterface
 {
     //

--- a/app/Bus/Events/ComponentGroup/ComponentGroupWasAddedEvent.php
+++ b/app/Bus/Events/ComponentGroup/ComponentGroupWasAddedEvent.php
@@ -11,10 +11,19 @@
 
 namespace CachetHQ\Cachet\Bus\Events\ComponentGroup;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\ComponentGroup;
+use CachetHQ\Cachet\Models\User;
 
-final class ComponentGroupWasAddedEvent implements ComponentGroupEventInterface
+final class ComponentGroupWasAddedEvent implements ActionInterface, ComponentGroupEventInterface
 {
+    /**
+     * The user who added the component group.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The component group that was added.
      *
@@ -25,12 +34,14 @@ final class ComponentGroupWasAddedEvent implements ComponentGroupEventInterface
     /**
      * Create a new component group was added event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User           $group
      * @param \CachetHQ\Cachet\Models\ComponentGroup $group
      *
      * @return void
      */
-    public function __construct(ComponentGroup $group)
+    public function __construct(User $user, ComponentGroup $group)
     {
+        $this->user = $user;
         $this->group = $group;
     }
 
@@ -42,5 +53,18 @@ final class ComponentGroupWasAddedEvent implements ComponentGroupEventInterface
     public function __toString()
     {
         return 'Component Group was added.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/ComponentGroup/ComponentGroupWasRemovedEvent.php
+++ b/app/Bus/Events/ComponentGroup/ComponentGroupWasRemovedEvent.php
@@ -11,10 +11,19 @@
 
 namespace CachetHQ\Cachet\Bus\Events\ComponentGroup;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\ComponentGroup;
+use CachetHQ\Cachet\Models\User;
 
-final class ComponentGroupWasRemovedEvent implements ComponentGroupEventInterface
+final class ComponentGroupWasRemovedEvent implements ActionInterface, ComponentGroupEventInterface
 {
+    /**
+     * The user who removed the component group.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The component group that was removed.
      *
@@ -25,12 +34,14 @@ final class ComponentGroupWasRemovedEvent implements ComponentGroupEventInterfac
     /**
      * Create a new component group was removed event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User           $user
      * @param \CachetHQ\Cachet\Models\ComponentGroup $group
      *
      * @return void
      */
-    public function __construct(ComponentGroup $group)
+    public function __construct(User $user, ComponentGroup $group)
     {
+        $this->user = $user;
         $this->group = $group;
     }
 
@@ -42,5 +53,18 @@ final class ComponentGroupWasRemovedEvent implements ComponentGroupEventInterfac
     public function __toString()
     {
         return 'Component Group was removed.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/ComponentGroup/ComponentGroupWasUpdatedEvent.php
+++ b/app/Bus/Events/ComponentGroup/ComponentGroupWasUpdatedEvent.php
@@ -11,10 +11,19 @@
 
 namespace CachetHQ\Cachet\Bus\Events\ComponentGroup;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\ComponentGroup;
+use CachetHQ\Cachet\Models\User;
 
-final class ComponentGroupWasUpdatedEvent implements ComponentGroupEventInterface
+final class ComponentGroupWasUpdatedEvent implements ActionInterface, ComponentGroupEventInterface
 {
+    /**
+     * The user who updated the component group.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The component group that was updated.
      *
@@ -25,12 +34,14 @@ final class ComponentGroupWasUpdatedEvent implements ComponentGroupEventInterfac
     /**
      * Create a new component group was updated event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User           $user
      * @param \CachetHQ\Cachet\Models\ComponentGroup $group
      *
      * @return void
      */
-    public function __construct(ComponentGroup $group)
+    public function __construct(User $user, ComponentGroup $group)
     {
+        $this->user = $user;
         $this->group = $group;
     }
 
@@ -42,5 +53,18 @@ final class ComponentGroupWasUpdatedEvent implements ComponentGroupEventInterfac
     public function __toString()
     {
         return 'Component Group was updated.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/EventInterface.php
+++ b/app/Bus/Events/EventInterface.php
@@ -11,6 +11,12 @@
 
 namespace CachetHQ\Cachet\Bus\Events;
 
+/**
+ * This is the event interface.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ * @author James Brooks <james@alt-three.com>
+ */
 interface EventInterface
 {
     //

--- a/app/Bus/Events/Incident/IncidentEventInterface.php
+++ b/app/Bus/Events/Incident/IncidentEventInterface.php
@@ -13,6 +13,12 @@ namespace CachetHQ\Cachet\Bus\Events\Incident;
 
 use CachetHQ\Cachet\Bus\Events\EventInterface;
 
+/**
+ * This is the incident event interface.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ * @author James Brooks <james@alt-three.com>
+ */
 interface IncidentEventInterface extends EventInterface
 {
     //

--- a/app/Bus/Events/Incident/IncidentWasRemovedEvent.php
+++ b/app/Bus/Events/Incident/IncidentWasRemovedEvent.php
@@ -11,10 +11,19 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Incident;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\Incident;
+use CachetHQ\Cachet\Models\User;
 
-final class IncidentWasRemovedEvent implements IncidentEventInterface
+final class IncidentWasRemovedEvent implements ActionInterface, IncidentEventInterface
 {
+    /**
+     * The user who removed the event.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The incident that has been removed.
      *
@@ -25,12 +34,14 @@ final class IncidentWasRemovedEvent implements IncidentEventInterface
     /**
      * Create a new incident was removed event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User     $user
      * @param \CachetHQ\Cachet\Models\Incident $incident
      *
      * @return void
      */
-    public function __construct(Incident $incident)
+    public function __construct(User $user, Incident $incident)
     {
+        $this->user = $user;
         $this->incident = $incident;
     }
 
@@ -42,5 +53,18 @@ final class IncidentWasRemovedEvent implements IncidentEventInterface
     public function __toString()
     {
         return 'Incident was removed.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/Incident/IncidentWasReportedEvent.php
+++ b/app/Bus/Events/Incident/IncidentWasReportedEvent.php
@@ -11,10 +11,19 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Incident;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\Incident;
+use CachetHQ\Cachet\Models\User;
 
-final class IncidentWasReportedEvent implements IncidentEventInterface
+final class IncidentWasReportedEvent implements ActionInterface, IncidentEventInterface
 {
+    /**
+     * The user who reported the event.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The incident that has been reported.
      *
@@ -32,13 +41,15 @@ final class IncidentWasReportedEvent implements IncidentEventInterface
     /**
      * Create a new incident has reported event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User     $user
      * @param \CachetHQ\Cachet\Models\Incident $incident
      * @param bool                             $notify
      *
      * @return void
      */
-    public function __construct(Incident $incident, $notify = false)
+    public function __construct(User $user, Incident $incident, $notify = false)
     {
+        $this->user = $user;
         $this->incident = $incident;
         $this->notify = $notify;
     }
@@ -51,5 +62,18 @@ final class IncidentWasReportedEvent implements IncidentEventInterface
     public function __toString()
     {
         return 'Incident was reported.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/Incident/IncidentWasUpdatedEvent.php
+++ b/app/Bus/Events/Incident/IncidentWasUpdatedEvent.php
@@ -11,10 +11,19 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Incident;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\Incident;
+use CachetHQ\Cachet\Models\User;
 
-final class IncidentWasUpdatedEvent implements IncidentEventInterface
+final class IncidentWasUpdatedEvent implements ActionInterface, IncidentEventInterface
 {
+    /**
+     * The user who updated the event.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The incident that has been updated.
      *
@@ -25,12 +34,14 @@ final class IncidentWasUpdatedEvent implements IncidentEventInterface
     /**
      * Create a new incident has updated event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User     $user
      * @param \CachetHQ\Cachet\Models\Incident $incident
      *
      * @return void
      */
-    public function __construct(Incident $incident)
+    public function __construct(User $user, Incident $incident)
     {
+        $this->user = $user;
         $this->incident = $incident;
     }
 
@@ -42,5 +53,18 @@ final class IncidentWasUpdatedEvent implements IncidentEventInterface
     public function __toString()
     {
         return 'Incident was updated.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/IncidentUpdate/IncidentUpdateWasRemovedEvent.php
+++ b/app/Bus/Events/IncidentUpdate/IncidentUpdateWasRemovedEvent.php
@@ -11,15 +11,24 @@
 
 namespace CachetHQ\Cachet\Bus\Events\IncidentUpdate;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\IncidentUpdate;
+use CachetHQ\Cachet\Models\User;
 
 /**
  * This is the incident update was removed event.
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class IncidentUpdateWasRemovedEvent implements IncidentUpdateEventInterface
+final class IncidentUpdateWasRemovedEvent implements ActionInterface, IncidentUpdateEventInterface
 {
+    /**
+     * The user who removed the incident update.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The incident update that has been removed.
      *
@@ -30,12 +39,14 @@ final class IncidentUpdateWasRemovedEvent implements IncidentUpdateEventInterfac
     /**
      * Create a new incident update was removed event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User           $user
      * @param \CachetHQ\Cachet\Models\IncidentUpdate $update
      *
      * @return void
      */
-    public function __construct(IncidentUpdate $update)
+    public function __construct(User $user, IncidentUpdate $update)
     {
+        $this->user = $user;
         $this->update = $update;
     }
 
@@ -47,5 +58,18 @@ final class IncidentUpdateWasRemovedEvent implements IncidentUpdateEventInterfac
     public function __toString()
     {
         return 'Incident Update was removed.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/IncidentUpdate/IncidentUpdateWasReportedEvent.php
+++ b/app/Bus/Events/IncidentUpdate/IncidentUpdateWasReportedEvent.php
@@ -11,15 +11,24 @@
 
 namespace CachetHQ\Cachet\Bus\Events\IncidentUpdate;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\IncidentUpdate;
+use CachetHQ\Cachet\Models\User;
 
 /**
  * This is the incident update was reported event.
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class IncidentUpdateWasReportedEvent implements IncidentUpdateEventInterface
+final class IncidentUpdateWasReportedEvent implements ActionInterface, IncidentUpdateEventInterface
 {
+    /**
+     * The user who reported the incident update.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The incident update that has been reported.
      *
@@ -30,12 +39,14 @@ final class IncidentUpdateWasReportedEvent implements IncidentUpdateEventInterfa
     /**
      * Create a new incident update was reported event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User           $user
      * @param \CachetHQ\Cachet\Models\IncidentUpdate $update
      *
      * @return void
      */
-    public function __construct(IncidentUpdate $update)
+    public function __construct(User $user, IncidentUpdate $update)
     {
+        $this->user = $user;
         $this->update = $update;
     }
 
@@ -47,5 +58,18 @@ final class IncidentUpdateWasReportedEvent implements IncidentUpdateEventInterfa
     public function __toString()
     {
         return 'Incident Update was reported.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/IncidentUpdate/IncidentUpdateWasUpdatedEvent.php
+++ b/app/Bus/Events/IncidentUpdate/IncidentUpdateWasUpdatedEvent.php
@@ -11,15 +11,24 @@
 
 namespace CachetHQ\Cachet\Bus\Events\IncidentUpdate;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\IncidentUpdate;
+use CachetHQ\Cachet\Models\User;
 
 /**
  * This is the incident update was updated event.
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class IncidentUpdateWasUpdatedEvent implements IncidentUpdateEventInterface
+final class IncidentUpdateWasUpdatedEvent implements ActionInterface, IncidentUpdateEventInterface
 {
+    /**
+     * The user who updated the incident update.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The incident update that has been updated.
      *
@@ -34,8 +43,9 @@ final class IncidentUpdateWasUpdatedEvent implements IncidentUpdateEventInterfac
      *
      * @return void
      */
-    public function __construct(IncidentUpdate $update)
+    public function __construct(User $user, IncidentUpdate $update)
     {
+        $this->user = $user;
         $this->update = $update;
     }
 
@@ -47,5 +57,18 @@ final class IncidentUpdateWasUpdatedEvent implements IncidentUpdateEventInterfac
     public function __toString()
     {
         return 'Incident Update was updated.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/Invite/InviteEventInterface.php
+++ b/app/Bus/Events/Invite/InviteEventInterface.php
@@ -13,6 +13,12 @@ namespace CachetHQ\Cachet\Bus\Events\Invite;
 
 use CachetHQ\Cachet\Bus\Events\EventInterface;
 
+/**
+ * This is the invite event interface.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ * @author James Brooks <james@alt-three.com>
+ */
 interface InviteEventInterface extends EventInterface
 {
     //

--- a/app/Bus/Events/Metric/MetricEventInterface.php
+++ b/app/Bus/Events/Metric/MetricEventInterface.php
@@ -13,6 +13,12 @@ namespace CachetHQ\Cachet\Bus\Events\Metric;
 
 use CachetHQ\Cachet\Bus\Events\EventInterface;
 
+/**
+ * This is the metric event interface.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ * @author James Brooks <james@alt-three.com>
+ */
 interface MetricEventInterface extends EventInterface
 {
     //

--- a/app/Bus/Events/Metric/MetricPointWasAddedEvent.php
+++ b/app/Bus/Events/Metric/MetricPointWasAddedEvent.php
@@ -11,10 +11,19 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Metric;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\MetricPoint;
+use CachetHQ\Cachet\Models\User;
 
-final class MetricPointWasAddedEvent implements MetricEventInterface
+final class MetricPointWasAddedEvent implements ActionInterface, MetricEventInterface
 {
+    /**
+     * The user who added the metric point.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The metric point that was added.
      *
@@ -25,12 +34,14 @@ final class MetricPointWasAddedEvent implements MetricEventInterface
     /**
      * Create a new metric point was added event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User        $user
      * @param \CachetHQ\Cachet\Models\MetricPoint $metricPoint
      *
      * @return void
      */
-    public function __construct(MetricPoint $metricPoint)
+    public function __construct(User $user, MetricPoint $metricPoint)
     {
+        $this->user = $user;
         $this->metricPoint = $metricPoint;
     }
 
@@ -42,5 +53,18 @@ final class MetricPointWasAddedEvent implements MetricEventInterface
     public function __toString()
     {
         return 'Metric Point was added.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/Metric/MetricPointWasRemovedEvent.php
+++ b/app/Bus/Events/Metric/MetricPointWasRemovedEvent.php
@@ -11,10 +11,19 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Metric;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\MetricPoint;
+use CachetHQ\Cachet\Models\User;
 
-final class MetricPointWasRemovedEvent implements MetricEventInterface
+final class MetricPointWasRemovedEvent implements ActionInterface, MetricEventInterface
 {
+    /**
+     * The user who removed the metric point.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The metric point that was removed.
      *
@@ -25,12 +34,14 @@ final class MetricPointWasRemovedEvent implements MetricEventInterface
     /**
      * Create a new metric point was removed event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User        $user
      * @param \CachetHQ\Cachet\Models\MetricPoint $memtricPoint
      *
      * @return void
      */
-    public function __construct(MetricPoint $metricPoint)
+    public function __construct(User $user, MetricPoint $metricPoint)
     {
+        $this->user = $user;
         $this->metricPoint = $metricPoint;
     }
 
@@ -42,5 +53,18 @@ final class MetricPointWasRemovedEvent implements MetricEventInterface
     public function __toString()
     {
         return 'Metric Point was removed.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/Metric/MetricPointWasUpdatedEvent.php
+++ b/app/Bus/Events/Metric/MetricPointWasUpdatedEvent.php
@@ -11,10 +11,19 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Metric;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\MetricPoint;
+use CachetHQ\Cachet\Models\User;
 
-final class MetricPointWasUpdatedEvent implements MetricEventInterface
+final class MetricPointWasUpdatedEvent implements ActionInterface, MetricEventInterface
 {
+    /**
+     * The user who updated the metric point.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The metric point that was updated.
      *
@@ -25,12 +34,14 @@ final class MetricPointWasUpdatedEvent implements MetricEventInterface
     /**
      * Create a new metric point was updated event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User        $user
      * @param \CachetHQ\Cachet\Models\MetricPoint $metricPoint
      *
      * @return void
      */
-    public function __construct(MetricPoint $metricPoint)
+    public function __construct(User $user, MetricPoint $metricPoint)
     {
+        $this->user = $user;
         $this->metricPoint = $metricPoint;
     }
 
@@ -42,5 +53,18 @@ final class MetricPointWasUpdatedEvent implements MetricEventInterface
     public function __toString()
     {
         return 'Metric Point was updated.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/Metric/MetricWasAddedEvent.php
+++ b/app/Bus/Events/Metric/MetricWasAddedEvent.php
@@ -11,10 +11,19 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Metric;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\Metric;
+use CachetHQ\Cachet\Models\User;
 
-final class MetricWasAddedEvent implements MetricEventInterface
+final class MetricWasAddedEvent implements ActionInterface, MetricEventInterface
 {
+    /**
+     * The user who added the metric.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The metric that was added.
      *
@@ -25,12 +34,14 @@ final class MetricWasAddedEvent implements MetricEventInterface
     /**
      * Create a new metric was added event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User   $user
      * @param \CachetHQ\Cachet\Models\Metric $metric
      *
      * @return void
      */
-    public function __construct(Metric $metric)
+    public function __construct(User $user, Metric $metric)
     {
+        $this->user = $user;
         $this->metric = $metric;
     }
 
@@ -42,5 +53,18 @@ final class MetricWasAddedEvent implements MetricEventInterface
     public function __toString()
     {
         return 'Metric was added.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/Metric/MetricWasRemovedEvent.php
+++ b/app/Bus/Events/Metric/MetricWasRemovedEvent.php
@@ -11,10 +11,19 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Metric;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\Metric;
+use CachetHQ\Cachet\Models\User;
 
-final class MetricWasRemovedEvent implements MetricEventInterface
+final class MetricWasRemovedEvent implements ActionInterface, MetricEventInterface
 {
+    /**
+     * The user who removed the metric.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The metric that was removed.
      *
@@ -25,12 +34,14 @@ final class MetricWasRemovedEvent implements MetricEventInterface
     /**
      * Create a new metric was removed event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User   $user
      * @param \CachetHQ\Cachet\Models\Metric $metric
      *
      * @return void
      */
-    public function __construct(Metric $metric)
+    public function __construct(User $user, Metric $metric)
     {
+        $this->user = $user;
         $this->metric = $metric;
     }
 
@@ -42,5 +53,18 @@ final class MetricWasRemovedEvent implements MetricEventInterface
     public function __toString()
     {
         return 'Metric was removed.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/Metric/MetricWasUpdatedEvent.php
+++ b/app/Bus/Events/Metric/MetricWasUpdatedEvent.php
@@ -11,10 +11,19 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Metric;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\Metric;
+use CachetHQ\Cachet\Models\User;
 
-final class MetricWasUpdatedEvent implements MetricEventInterface
+final class MetricWasUpdatedEvent implements ActionInterface, MetricEventInterface
 {
+    /**
+     * The user who update the metric.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The metric that was updated.
      *
@@ -25,12 +34,14 @@ final class MetricWasUpdatedEvent implements MetricEventInterface
     /**
      * Create a new metric was updated event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User   $user
      * @param \CachetHQ\Cachet\Models\Metric $metric
      *
      * @return void
      */
-    public function __construct(Metric $metric)
+    public function __construct(User $user, Metric $metric)
     {
+        $this->user = $user;
         $this->metric = $metric;
     }
 
@@ -42,5 +53,18 @@ final class MetricWasUpdatedEvent implements MetricEventInterface
     public function __toString()
     {
         return 'Metric was updated.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/Schedule/ScheduleWasCreatedEvent.php
+++ b/app/Bus/Events/Schedule/ScheduleWasCreatedEvent.php
@@ -11,15 +11,24 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Schedule;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\Schedule;
+use CachetHQ\Cachet\Models\User;
 
 /**
  * This is the schedule was created event class.
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class ScheduleWasCreatedEvent implements ScheduleEventInterface
+final class ScheduleWasCreatedEvent implements ActionInterface, ScheduleEventInterface
 {
+    /**
+     * The user that created the schedule.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The schedule that has been created.
      *
@@ -30,12 +39,14 @@ final class ScheduleWasCreatedEvent implements ScheduleEventInterface
     /**
      * Create a new schedule was created event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User     $user
      * @param \CachetHQ\Cachet\Models\Schedule $schedule
      *
      * @return void
      */
-    public function __construct(Schedule $schedule)
+    public function __construct(User $user, Schedule $schedule)
     {
+        $this->user = $user;
         $this->schedule = $schedule;
     }
 
@@ -47,5 +58,18 @@ final class ScheduleWasCreatedEvent implements ScheduleEventInterface
     public function __toString()
     {
         return 'Schedule was created.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/Schedule/ScheduleWasRemovedEvent.php
+++ b/app/Bus/Events/Schedule/ScheduleWasRemovedEvent.php
@@ -11,15 +11,24 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Schedule;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\Schedule;
+use CachetHQ\Cachet\Models\User;
 
 /**
  * This is the schedule was removed event class.
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class ScheduleWasRemovedEvent implements ScheduleEventInterface
+final class ScheduleWasRemovedEvent implements ActionInterface, ScheduleEventInterface
 {
+    /**
+     * The user that removed the schedule.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The schedule that has been removed.
      *
@@ -30,12 +39,14 @@ final class ScheduleWasRemovedEvent implements ScheduleEventInterface
     /**
      * Create a new schedule was removed event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User     $user
      * @param \CachetHQ\Cachet\Models\Schedule $schedule
      *
      * @return void
      */
-    public function __construct(Schedule $schedule)
+    public function __construct(User $user, Schedule $schedule)
     {
+        $this->user = $user;
         $this->schedule = $schedule;
     }
 
@@ -47,5 +58,18 @@ final class ScheduleWasRemovedEvent implements ScheduleEventInterface
     public function __toString()
     {
         return 'Schedule was removed.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/Schedule/ScheduleWasUpdatedEvent.php
+++ b/app/Bus/Events/Schedule/ScheduleWasUpdatedEvent.php
@@ -11,15 +11,24 @@
 
 namespace CachetHQ\Cachet\Bus\Events\Schedule;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\Schedule;
+use CachetHQ\Cachet\Models\User;
 
 /**
  * This is the schedule was updated event class.
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class ScheduleWasUpdatedEvent implements ScheduleEventInterface
+final class ScheduleWasUpdatedEvent implements ActionInterface, ScheduleEventInterface
 {
+    /**
+     * The user that created the schedule.
+     *
+     * @var \CachetHQ\Cachet\Models\User
+     */
+    public $user;
+
     /**
      * The schedule that has been updated.
      *
@@ -30,12 +39,14 @@ final class ScheduleWasUpdatedEvent implements ScheduleEventInterface
     /**
      * Create a new schedule was updated event instance.
      *
+     * @param \CachetHQ\Cachet\Models\User     $user
      * @param \CachetHQ\Cachet\Models\Schedule $schedule
      *
      * @return void
      */
-    public function __construct(Schedule $schedule)
+    public function __construct(User $user, Schedule $schedule)
     {
+        $this->user = $user;
         $this->schedule = $schedule;
     }
 
@@ -47,5 +58,18 @@ final class ScheduleWasUpdatedEvent implements ScheduleEventInterface
     public function __toString()
     {
         return 'Schedule was updated.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/Subscriber/SubscriberEventInterface.php
+++ b/app/Bus/Events/Subscriber/SubscriberEventInterface.php
@@ -13,6 +13,12 @@ namespace CachetHQ\Cachet\Bus\Events\Subscriber;
 
 use CachetHQ\Cachet\Bus\Events\EventInterface;
 
+/**
+ * This is the subscriber event interface.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ * @author James Brooks <james@alt-three.com>
+ */
 interface SubscriberEventInterface extends EventInterface
 {
     //

--- a/app/Bus/Events/User/UserAcceptedInviteEvent.php
+++ b/app/Bus/Events/User/UserAcceptedInviteEvent.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Cachet\Bus\Events\User;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\Invite;
 use CachetHQ\Cachet\Models\User;
 
@@ -19,7 +20,7 @@ use CachetHQ\Cachet\Models\User;
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class UserAcceptedInviteEvent implements UserEventInterface
+final class UserAcceptedInviteEvent implements ActionInterface, UserEventInterface
 {
     /**
      * The user that accepted the invite.
@@ -57,5 +58,18 @@ final class UserAcceptedInviteEvent implements UserEventInterface
     public function __toString()
     {
         return 'User accepted invite.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/User/UserDisabledTwoAuthEvent.php
+++ b/app/Bus/Events/User/UserDisabledTwoAuthEvent.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Cachet\Bus\Events\User;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\User;
 
 /**
@@ -18,7 +19,7 @@ use CachetHQ\Cachet\Models\User;
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class UserDisabledTwoAuthEvent implements UserEventInterface
+final class UserDisabledTwoAuthEvent implements ActionInterface, UserEventInterface
 {
     /**
      * The user that disabled two auth.
@@ -47,5 +48,18 @@ final class UserDisabledTwoAuthEvent implements UserEventInterface
     public function __toString()
     {
         return 'User disabled two-factor authentication.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/User/UserEnabledTwoAuthEvent.php
+++ b/app/Bus/Events/User/UserEnabledTwoAuthEvent.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Cachet\Bus\Events\User;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\User;
 
 /**
@@ -18,7 +19,7 @@ use CachetHQ\Cachet\Models\User;
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class UserEnabledTwoAuthEvent implements UserEventInterface
+final class UserEnabledTwoAuthEvent implements ActionInterface, UserEventInterface
 {
     /**
      * The user that enabled two auth.
@@ -47,5 +48,18 @@ final class UserEnabledTwoAuthEvent implements UserEventInterface
     public function __toString()
     {
         return 'User enabled two-factor authentication.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/User/UserEventInterface.php
+++ b/app/Bus/Events/User/UserEventInterface.php
@@ -13,6 +13,12 @@ namespace CachetHQ\Cachet\Bus\Events\User;
 
 use CachetHQ\Cachet\Bus\Events\EventInterface;
 
+/**
+ * This is the user event interface.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ * @author James Brooks <james@alt-three.com>
+ */
 interface UserEventInterface extends EventInterface
 {
     //

--- a/app/Bus/Events/User/UserFailedTwoAuthEvent.php
+++ b/app/Bus/Events/User/UserFailedTwoAuthEvent.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Cachet\Bus\Events\User;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\User;
 
 /**
@@ -18,7 +19,7 @@ use CachetHQ\Cachet\Models\User;
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class UserFailedTwoAuthEvent implements UserEventInterface
+final class UserFailedTwoAuthEvent implements ActionInterface, UserEventInterface
 {
     /**
      * The user that failed two auth.
@@ -47,5 +48,18 @@ final class UserFailedTwoAuthEvent implements UserEventInterface
     public function __toString()
     {
         return 'User failed two-factor authentication.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/User/UserLoggedInEvent.php
+++ b/app/Bus/Events/User/UserLoggedInEvent.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Cachet\Bus\Events\User;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\User;
 
 /**
@@ -18,7 +19,7 @@ use CachetHQ\Cachet\Models\User;
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class UserLoggedInEvent implements UserEventInterface
+final class UserLoggedInEvent implements ActionInterface, UserEventInterface
 {
     /**
      * The user that logged in.
@@ -47,5 +48,18 @@ final class UserLoggedInEvent implements UserEventInterface
     public function __toString()
     {
         return 'User logged in.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/User/UserLoggedOutEvent.php
+++ b/app/Bus/Events/User/UserLoggedOutEvent.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Cachet\Bus\Events\User;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\User;
 
 /**
@@ -18,7 +19,7 @@ use CachetHQ\Cachet\Models\User;
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class UserLoggedOutEvent implements UserEventInterface
+final class UserLoggedOutEvent implements ActionInterface, UserEventInterface
 {
     /**
      * The user that logged out.
@@ -47,5 +48,18 @@ final class UserLoggedOutEvent implements UserEventInterface
     public function __toString()
     {
         return 'User logged out.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/User/UserPassedTwoAuthEvent.php
+++ b/app/Bus/Events/User/UserPassedTwoAuthEvent.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Cachet\Bus\Events\User;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\User;
 
 /**
@@ -18,7 +19,7 @@ use CachetHQ\Cachet\Models\User;
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class UserPassedTwoAuthEvent implements UserEventInterface
+final class UserPassedTwoAuthEvent implements ActionInterface, UserEventInterface
 {
     /**
      * The user that passed two auth.
@@ -47,5 +48,18 @@ final class UserPassedTwoAuthEvent implements UserEventInterface
     public function __toString()
     {
         return 'User passed two-factor authentication.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/User/UserRegeneratedApiTokenEvent.php
+++ b/app/Bus/Events/User/UserRegeneratedApiTokenEvent.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Cachet\Bus\Events\User;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\User;
 
 /**
@@ -18,7 +19,7 @@ use CachetHQ\Cachet\Models\User;
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class UserRegeneratedApiTokenEvent implements UserEventInterface
+final class UserRegeneratedApiTokenEvent implements ActionInterface, UserEventInterface
 {
     /**
      * The user that regenerated their api token.
@@ -47,5 +48,18 @@ final class UserRegeneratedApiTokenEvent implements UserEventInterface
     public function __toString()
     {
         return 'User regenerated api token.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/User/UserWasAddedEvent.php
+++ b/app/Bus/Events/User/UserWasAddedEvent.php
@@ -11,9 +11,10 @@
 
 namespace CachetHQ\Cachet\Bus\Events\User;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\User;
 
-final class UserWasAddedEvent implements UserEventInterface
+final class UserWasAddedEvent implements ActionInterface, UserEventInterface
 {
     /**
      * The user that has been added.
@@ -42,5 +43,18 @@ final class UserWasAddedEvent implements UserEventInterface
     public function __toString()
     {
         return 'User was added.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/User/UserWasInvitedEvent.php
+++ b/app/Bus/Events/User/UserWasInvitedEvent.php
@@ -11,9 +11,10 @@
 
 namespace CachetHQ\Cachet\Bus\Events\User;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\Invite;
 
-final class UserWasInvitedEvent implements UserEventInterface
+final class UserWasInvitedEvent implements ActionInterface, UserEventInterface
 {
     /**
      * The invite that has been added.
@@ -42,5 +43,18 @@ final class UserWasInvitedEvent implements UserEventInterface
     public function __toString()
     {
         return 'User was invited.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/User/UserWasRemovedEvent.php
+++ b/app/Bus/Events/User/UserWasRemovedEvent.php
@@ -11,9 +11,10 @@
 
 namespace CachetHQ\Cachet\Bus\Events\User;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\User;
 
-final class UserWasRemovedEvent implements UserEventInterface
+final class UserWasRemovedEvent implements ActionInterface, UserEventInterface
 {
     /**
      * The user that has been removed.
@@ -42,5 +43,18 @@ final class UserWasRemovedEvent implements UserEventInterface
     public function __toString()
     {
         return 'User was removed.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Events/User/UserWasWelcomedEvent.php
+++ b/app/Bus/Events/User/UserWasWelcomedEvent.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Cachet\Bus\Events\User;
 
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
 use CachetHQ\Cachet\Models\User;
 
 /**
@@ -18,7 +19,7 @@ use CachetHQ\Cachet\Models\User;
  *
  * @author James Brooks <james@alt-three.com>
  */
-final class UserWasWelcomedEvent implements UserEventInterface
+final class UserWasWelcomedEvent implements ActionInterface, UserEventInterface
 {
     /**
      * The user.
@@ -47,5 +48,18 @@ final class UserWasWelcomedEvent implements UserEventInterface
     public function __toString()
     {
         return 'User was welcomed.';
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return array
+     */
+    public function getAction()
+    {
+        return [
+            'user'        => $this->user,
+            'description' => (string) $this,
+        ];
     }
 }

--- a/app/Bus/Handlers/Commands/Component/AddComponentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Component/AddComponentCommandHandler.php
@@ -14,9 +14,29 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\Component;
 use CachetHQ\Cachet\Bus\Commands\Component\AddComponentCommand;
 use CachetHQ\Cachet\Bus\Events\Component\ComponentWasAddedEvent;
 use CachetHQ\Cachet\Models\Component;
+use Illuminate\Contracts\Auth\Guard;
 
 class AddComponentCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new remove component command handler instance.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard $auth
+     *
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
     /**
      * Handle the add component command.
      *
@@ -28,7 +48,7 @@ class AddComponentCommandHandler
     {
         $component = Component::create($this->filter($command));
 
-        event(new ComponentWasAddedEvent($component));
+        event(new ComponentWasAddedEvent($this->auth->user(), $component));
 
         return $component;
     }

--- a/app/Bus/Handlers/Commands/Component/RemoveComponentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Component/RemoveComponentCommandHandler.php
@@ -13,9 +13,29 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\Component;
 
 use CachetHQ\Cachet\Bus\Commands\Component\RemoveComponentCommand;
 use CachetHQ\Cachet\Bus\Events\Component\ComponentWasRemovedEvent;
+use Illuminate\Contracts\Auth\Guard;
 
 class RemoveComponentCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new remove component command handler instance.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard $auth
+     *
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
     /**
      * Handle the remove component command.
      *
@@ -27,7 +47,7 @@ class RemoveComponentCommandHandler
     {
         $component = $command->component;
 
-        event(new ComponentWasRemovedEvent($component));
+        event(new ComponentWasRemovedEvent($this->auth->user(), $component));
 
         $component->delete();
     }

--- a/app/Bus/Handlers/Commands/Component/UpdateComponentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Component/UpdateComponentCommandHandler.php
@@ -15,9 +15,29 @@ use CachetHQ\Cachet\Bus\Commands\Component\UpdateComponentCommand;
 use CachetHQ\Cachet\Bus\Events\Component\ComponentStatusWasUpdatedEvent;
 use CachetHQ\Cachet\Bus\Events\Component\ComponentWasUpdatedEvent;
 use CachetHQ\Cachet\Models\Component;
+use Illuminate\Contracts\Auth\Guard;
 
 class UpdateComponentCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new update component command handler instance.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard $auth
+     *
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
     /**
      * Handle the update component command.
      *
@@ -30,11 +50,11 @@ class UpdateComponentCommandHandler
         $component = $command->component;
         $originalStatus = $component->status;
 
-        event(new ComponentStatusWasUpdatedEvent($component, $originalStatus, $command->status));
+        event(new ComponentStatusWasUpdatedEvent($this->auth->user(), $component, $originalStatus, $command->status));
 
         $component->update($this->filter($command));
 
-        event(new ComponentWasUpdatedEvent($component));
+        event(new ComponentWasUpdatedEvent($this->auth->user(), $component));
 
         return $component;
     }

--- a/app/Bus/Handlers/Commands/ComponentGroup/AddComponentGroupCommandHandler.php
+++ b/app/Bus/Handlers/Commands/ComponentGroup/AddComponentGroupCommandHandler.php
@@ -14,9 +14,29 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\ComponentGroup;
 use CachetHQ\Cachet\Bus\Commands\ComponentGroup\AddComponentGroupCommand;
 use CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupWasAddedEvent;
 use CachetHQ\Cachet\Models\ComponentGroup;
+use Illuminate\Contracts\Auth\Guard;
 
 class AddComponentGroupCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new add component group command handler instance.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard $auth
+     *
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
     /**
      * Handle the add component group command.
      *
@@ -33,7 +53,7 @@ class AddComponentGroupCommandHandler
             'visible'   => $command->visible,
         ]);
 
-        event(new ComponentGroupWasAddedEvent($group));
+        event(new ComponentGroupWasAddedEvent($this->auth->user(), $group));
 
         return $group;
     }

--- a/app/Bus/Handlers/Commands/ComponentGroup/RemoveComponentGroupCommandHandler.php
+++ b/app/Bus/Handlers/Commands/ComponentGroup/RemoveComponentGroupCommandHandler.php
@@ -13,9 +13,29 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\ComponentGroup;
 
 use CachetHQ\Cachet\Bus\Commands\ComponentGroup\RemoveComponentGroupCommand;
 use CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupWasRemovedEvent;
+use Illuminate\Contracts\Auth\Guard;
 
 class RemoveComponentGroupCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new remove component group command handler instance.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard $auth
+     *
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
     /**
      * Handle the remove component group command.
      *
@@ -27,7 +47,7 @@ class RemoveComponentGroupCommandHandler
     {
         $group = $command->group;
 
-        event(new ComponentGroupWasRemovedEvent($group));
+        event(new ComponentGroupWasRemovedEvent($this->auth->user(), $group));
 
         // Remove the group id from all component.
         $group->components->map(function ($component) {

--- a/app/Bus/Handlers/Commands/ComponentGroup/UpdateComponentGroupCommandHandler.php
+++ b/app/Bus/Handlers/Commands/ComponentGroup/UpdateComponentGroupCommandHandler.php
@@ -13,9 +13,29 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\ComponentGroup;
 
 use CachetHQ\Cachet\Bus\Commands\ComponentGroup\UpdateComponentGroupCommand;
 use CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupWasUpdatedEvent;
+use Illuminate\Contracts\Auth\Guard;
 
 class UpdateComponentGroupCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new update component command handler instance.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard $auth
+     *
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
     /**
      * Handle the update component group command.
      *
@@ -28,7 +48,7 @@ class UpdateComponentGroupCommandHandler
         $group = $command->group;
         $group->update($this->filter($command));
 
-        event(new ComponentGroupWasUpdatedEvent($group));
+        event(new ComponentGroupWasUpdatedEvent($this->auth->user(), $group));
 
         return $group;
     }

--- a/app/Bus/Handlers/Commands/Incident/RemoveIncidentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Incident/RemoveIncidentCommandHandler.php
@@ -13,9 +13,29 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\Incident;
 
 use CachetHQ\Cachet\Bus\Commands\Incident\RemoveIncidentCommand;
 use CachetHQ\Cachet\Bus\Events\Incident\IncidentWasRemovedEvent;
+use Illuminate\Contracts\Auth\Guard;
 
 class RemoveIncidentCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new remove incident command handler instance.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard $auth
+     *
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
     /**
      * Handle the remove incident command.
      *
@@ -27,7 +47,7 @@ class RemoveIncidentCommandHandler
     {
         $incident = $command->incident;
 
-        event(new IncidentWasRemovedEvent($incident));
+        event(new IncidentWasRemovedEvent($this->auth->user(), $incident));
 
         $incident->delete();
     }

--- a/app/Bus/Handlers/Commands/Incident/ReportIncidentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Incident/ReportIncidentCommandHandler.php
@@ -48,7 +48,7 @@ class ReportIncidentCommandHandler
     /**
      * Create a new report incident command handler instance.
      *
-     * @param \Illuminate\Contracts\Auth\Guard   $auth
+     * @param \Illuminate\Contracts\Auth\Guard            $auth
      * @param \CachetHQ\Cachet\Services\Dates\DateFactory $dates
      *
      * @return void

--- a/app/Bus/Handlers/Commands/Incident/ReportIncidentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Incident/ReportIncidentCommandHandler.php
@@ -20,6 +20,7 @@ use CachetHQ\Cachet\Models\Incident;
 use CachetHQ\Cachet\Models\IncidentTemplate;
 use CachetHQ\Cachet\Services\Dates\DateFactory;
 use Carbon\Carbon;
+use Illuminate\Contracts\Auth\Guard;
 use Twig_Environment;
 use Twig_Loader_Array;
 
@@ -31,6 +32,13 @@ use Twig_Loader_Array;
 class ReportIncidentCommandHandler
 {
     /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
      * The date factory instance.
      *
      * @var \CachetHQ\Cachet\Services\Dates\DateFactory
@@ -40,12 +48,14 @@ class ReportIncidentCommandHandler
     /**
      * Create a new report incident command handler instance.
      *
+     * @param \Illuminate\Contracts\Auth\Guard   $auth
      * @param \CachetHQ\Cachet\Services\Dates\DateFactory $dates
      *
      * @return void
      */
-    public function __construct(DateFactory $dates)
+    public function __construct(Guard $auth, DateFactory $dates)
     {
+        $this->auth = $auth;
         $this->dates = $dates;
     }
 
@@ -105,7 +115,7 @@ class ReportIncidentCommandHandler
             ));
         }
 
-        event(new IncidentWasReportedEvent($incident, (bool) $command->notify));
+        event(new IncidentWasReportedEvent($this->auth->user(), $incident, (bool) $command->notify));
 
         return $incident;
     }

--- a/app/Bus/Handlers/Commands/Incident/UpdateIncidentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Incident/UpdateIncidentCommandHandler.php
@@ -19,6 +19,7 @@ use CachetHQ\Cachet\Models\Component;
 use CachetHQ\Cachet\Models\Incident;
 use CachetHQ\Cachet\Models\IncidentTemplate;
 use CachetHQ\Cachet\Services\Dates\DateFactory;
+use Illuminate\Contracts\Auth\Guard;
 use Twig_Environment;
 use Twig_Loader_Array;
 
@@ -30,6 +31,13 @@ use Twig_Loader_Array;
 class UpdateIncidentCommandHandler
 {
     /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
      * The date factory instance.
      *
      * @var \CachetHQ\Cachet\Services\Dates\DateFactory
@@ -39,12 +47,14 @@ class UpdateIncidentCommandHandler
     /**
      * Create a new update incident command handler instance.
      *
+     * @param \Illuminate\Contracts\Auth\Guard   $auth
      * @param \CachetHQ\Cachet\Services\Dates\DateFactory $dates
      *
      * @return void
      */
-    public function __construct(DateFactory $dates)
+    public function __construct(Guard $auth, DateFactory $dates)
     {
+        $this->auth = $auth;
         $this->dates = $dates;
     }
 
@@ -91,7 +101,7 @@ class UpdateIncidentCommandHandler
             ));
         }
 
-        event(new IncidentWasUpdatedEvent($incident));
+        event(new IncidentWasUpdatedEvent($this->auth->user(), $incident));
 
         return $incident;
     }

--- a/app/Bus/Handlers/Commands/Incident/UpdateIncidentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Incident/UpdateIncidentCommandHandler.php
@@ -47,7 +47,7 @@ class UpdateIncidentCommandHandler
     /**
      * Create a new update incident command handler instance.
      *
-     * @param \Illuminate\Contracts\Auth\Guard   $auth
+     * @param \Illuminate\Contracts\Auth\Guard            $auth
      * @param \CachetHQ\Cachet\Services\Dates\DateFactory $dates
      *
      * @return void

--- a/app/Bus/Handlers/Commands/IncidentUpdate/RemoveIncidentUpdateCommandHandler.php
+++ b/app/Bus/Handlers/Commands/IncidentUpdate/RemoveIncidentUpdateCommandHandler.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\IncidentUpdate;
 
 use CachetHQ\Cachet\Bus\Commands\IncidentUpdate\RemoveIncidentUpdateCommand;
 use CachetHQ\Cachet\Bus\Events\IncidentUpdate\IncidentUpdateWasRemovedEvent;
+use Illuminate\Contracts\Auth\Guard;
 
 /**
  * This is the remove incident update command handler.
@@ -21,6 +22,25 @@ use CachetHQ\Cachet\Bus\Events\IncidentUpdate\IncidentUpdateWasRemovedEvent;
  */
 class RemoveIncidentUpdateCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new remove incident update command handler instance.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard $auth
+     *
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
     /**
      * Handle the remove incident update command.
      *
@@ -32,7 +52,7 @@ class RemoveIncidentUpdateCommandHandler
     {
         $update = $command->incidentUpdate;
 
-        event(new IncidentUpdateWasRemovedEvent($update));
+        event(new IncidentUpdateWasRemovedEvent($this->auth->user(), $update));
 
         $update->delete();
     }

--- a/app/Bus/Handlers/Commands/IncidentUpdate/ReportIncidentUpdateCommandHandler.php
+++ b/app/Bus/Handlers/Commands/IncidentUpdate/ReportIncidentUpdateCommandHandler.php
@@ -15,6 +15,7 @@ use CachetHQ\Cachet\Bus\Commands\Incident\UpdateIncidentCommand;
 use CachetHQ\Cachet\Bus\Commands\IncidentUpdate\ReportIncidentUpdateCommand;
 use CachetHQ\Cachet\Bus\Events\IncidentUpdate\IncidentUpdateWasReportedEvent;
 use CachetHQ\Cachet\Models\IncidentUpdate;
+use Illuminate\Contracts\Auth\Guard;
 
 /**
  * This is the report incident update command handler.
@@ -23,6 +24,25 @@ use CachetHQ\Cachet\Models\IncidentUpdate;
  */
 class ReportIncidentUpdateCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new report incident update command handler instance.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard $auth
+     *
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
     /**
      * Handle the report incident command.
      *
@@ -58,7 +78,7 @@ class ReportIncidentUpdateCommandHandler
             []
         ));
 
-        event(new IncidentUpdateWasReportedEvent($update));
+        event(new IncidentUpdateWasReportedEvent($this->auth->user(), $update));
 
         return $update;
     }

--- a/app/Bus/Handlers/Commands/IncidentUpdate/UpdateIncidentUpdateCommandHandler.php
+++ b/app/Bus/Handlers/Commands/IncidentUpdate/UpdateIncidentUpdateCommandHandler.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\IncidentUpdate;
 
 use CachetHQ\Cachet\Bus\Commands\IncidentUpdate\UpdateIncidentUpdateCommand;
 use CachetHQ\Cachet\Bus\Events\IncidentUpdate\IncidentUpdateWasUpdatedEvent;
+use Illuminate\Contracts\Auth\Guard;
 
 /**
  * This is the update incident update command handler.
@@ -21,6 +22,25 @@ use CachetHQ\Cachet\Bus\Events\IncidentUpdate\IncidentUpdateWasUpdatedEvent;
  */
 class UpdateIncidentUpdateCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new update incident update command handler instance.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard $auth
+     *
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
     /**
      * Handle the update incident update command.
      *
@@ -32,7 +52,7 @@ class UpdateIncidentUpdateCommandHandler
     {
         $command->update->update($this->filter($command));
 
-        event(new IncidentUpdateWasUpdatedEvent($command->update));
+        event(new IncidentUpdateWasUpdatedEvent($this->auth->user(), $command->update));
 
         return $command->update;
     }

--- a/app/Bus/Handlers/Commands/Metric/AddMetricCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Metric/AddMetricCommandHandler.php
@@ -14,9 +14,29 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\Metric;
 use CachetHQ\Cachet\Bus\Commands\Metric\AddMetricCommand;
 use CachetHQ\Cachet\Bus\Events\Metric\MetricWasAddedEvent;
 use CachetHQ\Cachet\Models\Metric;
+use Illuminate\Contracts\Auth\Guard;
 
 class AddMetricCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new add metric command handler instance.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard $auth
+     *
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
     /**
      * Handle the add metric command.
      *
@@ -40,7 +60,7 @@ class AddMetricCommandHandler
             'visible'       => $command->visible,
         ]);
 
-        event(new MetricWasAddedEvent($metric));
+        event(new MetricWasAddedEvent($this->auth->user(), $metric));
 
         return $metric;
     }

--- a/app/Bus/Handlers/Commands/Metric/AddMetricPointCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Metric/AddMetricPointCommandHandler.php
@@ -37,7 +37,7 @@ class AddMetricPointCommandHandler
     /**
      * Create a new add metric point command handler instance.
      *
-     * @param \Illuminate\Contracts\Auth\Guard   $auth
+     * @param \Illuminate\Contracts\Auth\Guard            $auth
      * @param \CachetHQ\Cachet\Services\Dates\DateFactory $dates
      *
      * @return void

--- a/app/Bus/Handlers/Commands/Metric/AddMetricPointCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Metric/AddMetricPointCommandHandler.php
@@ -16,9 +16,17 @@ use CachetHQ\Cachet\Bus\Events\Metric\MetricPointWasAddedEvent;
 use CachetHQ\Cachet\Models\MetricPoint;
 use CachetHQ\Cachet\Services\Dates\DateFactory;
 use Carbon\Carbon;
+use Illuminate\Contracts\Auth\Guard;
 
 class AddMetricPointCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
     /**
      * The date factory instance.
      *
@@ -29,12 +37,14 @@ class AddMetricPointCommandHandler
     /**
      * Create a new add metric point command handler instance.
      *
+     * @param \Illuminate\Contracts\Auth\Guard   $auth
      * @param \CachetHQ\Cachet\Services\Dates\DateFactory $dates
      *
      * @return void
      */
-    public function __construct(DateFactory $dates)
+    public function __construct(Guard $auth, DateFactory $dates)
     {
+        $this->auth = $auth;
         $this->dates = $dates;
     }
 
@@ -55,7 +65,7 @@ class AddMetricPointCommandHandler
 
         $point->increment('counter', 1);
 
-        event(new MetricPointWasAddedEvent($point));
+        event(new MetricPointWasAddedEvent($this->auth->user(), $point));
 
         return $point;
     }

--- a/app/Bus/Handlers/Commands/Metric/RemoveMetricCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Metric/RemoveMetricCommandHandler.php
@@ -14,9 +14,29 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\Metric;
 use CachetHQ\Cachet\Bus\Commands\Metric\RemoveMetricCommand;
 use CachetHQ\Cachet\Bus\Events\Metric\MetricWasRemovedEvent;
 use CachetHQ\Cachet\Models\Metric;
+use Illuminate\Contracts\Auth\Guard;
 
 class RemoveMetricCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new remove metric command handler instance.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard $auth
+     *
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
     /**
      * Handle the remove metric command.
      *
@@ -28,7 +48,7 @@ class RemoveMetricCommandHandler
     {
         $metric = $command->metric;
 
-        event(new MetricWasRemovedEvent($metric));
+        event(new MetricWasRemovedEvent($this->auth->user(), $metric));
 
         $metric->delete();
     }

--- a/app/Bus/Handlers/Commands/Metric/RemoveMetricPointCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Metric/RemoveMetricPointCommandHandler.php
@@ -14,9 +14,29 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\Metric;
 use CachetHQ\Cachet\Bus\Commands\Metric\RemoveMetricPointCommand;
 use CachetHQ\Cachet\Bus\Events\Metric\MetricPointWasRemovedEvent;
 use CachetHQ\Cachet\Models\Metric;
+use Illuminate\Contracts\Auth\Guard;
 
 class RemoveMetricPointCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new remove metric point command handler instance.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard $auth
+     *
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
     /**
      * Handle the remove metric point command.
      *
@@ -28,7 +48,7 @@ class RemoveMetricPointCommandHandler
     {
         $metricPoint = $command->metricPoint;
 
-        event(new MetricPointWasRemovedEvent($metricPoint));
+        event(new MetricPointWasRemovedEvent($this->auth->user(), $metricPoint));
 
         $metricPoint->delete();
     }

--- a/app/Bus/Handlers/Commands/Metric/UpdateMetricCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Metric/UpdateMetricCommandHandler.php
@@ -14,9 +14,29 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\Metric;
 use CachetHQ\Cachet\Bus\Commands\Metric\UpdateMetricCommand;
 use CachetHQ\Cachet\Bus\Events\Metric\MetricWasUpdatedEvent;
 use CachetHQ\Cachet\Models\Metric;
+use Illuminate\Contracts\Auth\Guard;
 
 class UpdateMetricCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new update metric command handler instance.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard $auth
+     *
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
     /**
      * Handle the update metric command.
      *
@@ -30,7 +50,7 @@ class UpdateMetricCommandHandler
 
         $metric->update($this->filter($command));
 
-        event(new MetricWasUpdatedEvent($metric));
+        event(new MetricWasUpdatedEvent($this->auth->user(), $metric));
 
         return $metric;
     }

--- a/app/Bus/Handlers/Commands/Metric/UpdateMetricPointCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Metric/UpdateMetricPointCommandHandler.php
@@ -35,7 +35,7 @@ class UpdateMetricPointCommandHandler
     /**
      * Create a new update metric point command handler instance.
      *
-     * @param \Illuminate\Contracts\Auth\Guard   $auth
+     * @param \Illuminate\Contracts\Auth\Guard            $auth
      * @param \CachetHQ\Cachet\Services\Dates\DateFactory $dates
      *
      * @return void

--- a/app/Bus/Handlers/Commands/Metric/UpdateMetricPointCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Metric/UpdateMetricPointCommandHandler.php
@@ -14,9 +14,17 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\Metric;
 use CachetHQ\Cachet\Bus\Commands\Metric\UpdateMetricPointCommand;
 use CachetHQ\Cachet\Bus\Events\Metric\MetricPointWasUpdatedEvent;
 use CachetHQ\Cachet\Services\Dates\DateFactory;
+use Illuminate\Contracts\Auth\Guard;
 
 class UpdateMetricPointCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
     /**
      * The date factory instance.
      *
@@ -27,12 +35,14 @@ class UpdateMetricPointCommandHandler
     /**
      * Create a new update metric point command handler instance.
      *
+     * @param \Illuminate\Contracts\Auth\Guard   $auth
      * @param \CachetHQ\Cachet\Services\Dates\DateFactory $dates
      *
      * @return void
      */
-    public function __construct(DateFactory $dates)
+    public function __construct(Guard $auth, DateFactory $dates)
     {
+        $this->auth = $auth;
         $this->dates = $dates;
     }
 
@@ -60,7 +70,7 @@ class UpdateMetricPointCommandHandler
 
         $point->update($data);
 
-        event(new MetricPointWasUpdatedEvent($point));
+        event(new MetricPointWasUpdatedEvent($this->auth->user(), $point));
 
         return $point;
     }

--- a/app/Bus/Handlers/Commands/Schedule/CreateScheduleCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Schedule/CreateScheduleCommandHandler.php
@@ -41,7 +41,7 @@ class CreateScheduleCommandHandler
     /**
      * Create a new update schedule command handler instance.
      *
-     * @param \Illuminate\Contracts\Auth\Guard   $auth
+     * @param \Illuminate\Contracts\Auth\Guard            $auth
      * @param \CachetHQ\Cachet\Services\Dates\DateFactory $dates
      *
      * @return void

--- a/app/Bus/Handlers/Commands/Schedule/CreateScheduleCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Schedule/CreateScheduleCommandHandler.php
@@ -15,6 +15,7 @@ use CachetHQ\Cachet\Bus\Commands\Schedule\CreateScheduleCommand;
 use CachetHQ\Cachet\Bus\Events\Schedule\ScheduleWasCreatedEvent;
 use CachetHQ\Cachet\Models\Schedule;
 use CachetHQ\Cachet\Services\Dates\DateFactory;
+use Illuminate\Contracts\Auth\Guard;
 
 /**
  * This is the create schedule command handler.
@@ -23,6 +24,13 @@ use CachetHQ\Cachet\Services\Dates\DateFactory;
  */
 class CreateScheduleCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
     /**
      * The date factory instance.
      *
@@ -33,12 +41,14 @@ class CreateScheduleCommandHandler
     /**
      * Create a new update schedule command handler instance.
      *
+     * @param \Illuminate\Contracts\Auth\Guard   $auth
      * @param \CachetHQ\Cachet\Services\Dates\DateFactory $dates
      *
      * @return void
      */
-    public function __construct(DateFactory $dates)
+    public function __construct(Guard $auth, DateFactory $dates)
     {
+        $this->auth = $auth;
         $this->dates = $dates;
     }
 
@@ -53,7 +63,7 @@ class CreateScheduleCommandHandler
     {
         $schedule = Schedule::create($this->filter($command));
 
-        event(new ScheduleWasCreatedEvent($schedule));
+        event(new ScheduleWasCreatedEvent($this->auth->user(), $schedule));
 
         return $schedule;
     }

--- a/app/Bus/Handlers/Commands/Schedule/DeleteScheduleCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Schedule/DeleteScheduleCommandHandler.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\Schedule;
 
 use CachetHQ\Cachet\Bus\Commands\Schedule\DeleteScheduleCommand;
 use CachetHQ\Cachet\Bus\Events\Schedule\ScheduleWasRemovedEvent;
+use Illuminate\Contracts\Auth\Guard;
 
 /**
  * This is the delete schedule command handler.
@@ -21,6 +22,25 @@ use CachetHQ\Cachet\Bus\Events\Schedule\ScheduleWasRemovedEvent;
  */
 class DeleteScheduleCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new delete schedule command handler instance.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard $auth
+     *
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
     /**
      * Handle the delete schedule command.
      *
@@ -32,7 +52,7 @@ class DeleteScheduleCommandHandler
     {
         $schedule = $command->schedule;
 
-        event(new ScheduleWasRemovedEvent($schedule));
+        event(new ScheduleWasRemovedEvent($this->auth->user(), $schedule));
 
         $schedule->delete();
     }

--- a/app/Bus/Handlers/Commands/Schedule/UpdateScheduleCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Schedule/UpdateScheduleCommandHandler.php
@@ -15,6 +15,7 @@ use CachetHQ\Cachet\Bus\Commands\Schedule\UpdateScheduleCommand;
 use CachetHQ\Cachet\Bus\Events\Schedule\ScheduleWasUpdatedEvent;
 use CachetHQ\Cachet\Models\Schedule;
 use CachetHQ\Cachet\Services\Dates\DateFactory;
+use Illuminate\Contracts\Auth\Guard;
 
 /**
  * This is the update schedule command handler.
@@ -23,6 +24,13 @@ use CachetHQ\Cachet\Services\Dates\DateFactory;
  */
 class UpdateScheduleCommandHandler
 {
+    /**
+     * The authentication guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $auth;
+
     /**
      * The date factory instance.
      *
@@ -33,12 +41,14 @@ class UpdateScheduleCommandHandler
     /**
      * Create a new update schedule command handler instance.
      *
+     * @param \Illuminate\Contracts\Auth\Guard   $auth
      * @param \CachetHQ\Cachet\Services\Dates\DateFactory $dates
      *
      * @return void
      */
-    public function __construct(DateFactory $dates)
+    public function __construct(Guard $auth, DateFactory $dates)
     {
+        $this->auth = $auth;
         $this->dates = $dates;
     }
 
@@ -55,7 +65,7 @@ class UpdateScheduleCommandHandler
 
         $schedule->update($this->filter($command));
 
-        event(new ScheduleWasUpdatedEvent($schedule));
+        event(new ScheduleWasUpdatedEvent($this->auth->user(), $schedule));
 
         return $schedule;
     }

--- a/app/Bus/Handlers/Commands/Schedule/UpdateScheduleCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Schedule/UpdateScheduleCommandHandler.php
@@ -41,7 +41,7 @@ class UpdateScheduleCommandHandler
     /**
      * Create a new update schedule command handler instance.
      *
-     * @param \Illuminate\Contracts\Auth\Guard   $auth
+     * @param \Illuminate\Contracts\Auth\Guard            $auth
      * @param \CachetHQ\Cachet\Services\Dates\DateFactory $dates
      *
      * @return void

--- a/app/Bus/Handlers/Events/ActionStorageHandler.php
+++ b/app/Bus/Handlers/Events/ActionStorageHandler.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Events;
+
+use CachetHQ\Cachet\Bus\Events\ActionInterface;
+use CachetHQ\Cachet\Models\Action;
+
+/**
+ * This is the action storage handler class.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ * @author James Brooks <james@alt-three.com>
+ */
+class ActionStorageHandler
+{
+    /**
+     * Handle the any actions that need storing.
+     *
+     * @param \CachetHQ\Cachet\Bus\Events\ActionInterface $event
+     *
+     * @return void
+     */
+    public function handle(ActionInterface $event)
+    {
+        $data = $event->getAction();
+
+        $action = [
+            'class_name'  => get_class($event),
+            'user_id'     => $data['user']->id,
+            'username'    => $data['user']->username,
+            'description' => $data['description'],
+        ];
+
+        if ($data['information'] ?? null) {
+            $action['information'] = $data['information'];
+        }
+
+        Action::create($action);
+    }
+}

--- a/app/Console/Commands/DemoSeederCommand.php
+++ b/app/Console/Commands/DemoSeederCommand.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Cachet\Console\Commands;
 
+use CachetHQ\Cachet\Models\Action;
 use CachetHQ\Cachet\Models\Component;
 use CachetHQ\Cachet\Models\ComponentGroup;
 use CachetHQ\Cachet\Models\Incident;
@@ -84,6 +85,7 @@ class DemoSeederCommand extends Command
             return;
         }
 
+        $this->seedActions();
         $this->seedComponentGroups();
         $this->seedComponents();
         $this->seedIncidents();
@@ -96,6 +98,16 @@ class DemoSeederCommand extends Command
         $this->seedUsers();
 
         $this->info('Database seeded with demo data successfully!');
+    }
+
+    /**
+     * Seed the actions table.
+     *
+     * @return void
+     */
+    protected function seedActions()
+    {
+        Action::truncate();
     }
 
     /**

--- a/app/Foundation/Providers/EventServiceProvider.php
+++ b/app/Foundation/Providers/EventServiceProvider.php
@@ -21,6 +21,9 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
+        'CachetHQ\Cachet\Bus\Events\ActionInterface' => [
+            'CachetHQ\Cachet\Bus\Handlers\Events\ActionStorageHandler',
+        ],
         'CachetHQ\Cachet\Bus\Events\Beacon\BeaconFailedToSendEvent' => [
             'CachetHQ\Cachet\Bus\Handlers\Events\Beacon\LogBeaconFailedHandler',
         ],

--- a/app/Models/Action.php
+++ b/app/Models/Action.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Models;
+
+use AltThree\Validator\ValidatingTrait;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * This is the action model class.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ * @author James Brooks <james@alt-three.com>
+ */
+class Action extends Model
+{
+    use ValidatingTrait;
+
+    /**
+     * A list of methods protected from mass assignment.
+     *
+     * @var string[]
+     */
+    protected $guarded = ['_token', '_method'];
+
+    /**
+     * The relations to eager load on every query.
+     *
+     * @var string[]
+     */
+    protected $with = ['user'];
+
+    /**
+     * The attributes that should be casted to native types.
+     *
+     * @var string[]
+     */
+    protected $casts = [
+        'id'          => 'int',
+        'class_name'  => 'string',
+        'user_id'     => 'int',
+        'username'    => 'string',
+        'information' => 'string',
+        'description' => 'string',
+    ];
+
+    /**
+     * The validation rules.
+     *
+     * @var string[]
+     */
+    public $rules = [
+        'id'          => 'nullable|int|min:1',
+        'class_name'  => 'required|string',
+        'user_id'     => 'required|int|min:1',
+        'username'    => 'required|string',
+        'information' => 'nullable|string',
+        'description' => 'required|string',
+    ];
+
+    /**
+     * Get the user relation.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2017_02_03_222218_CreateActionsTable.php
+++ b/database/migrations/2017_02_03_222218_CreateActionsTable.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateActionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('actions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('class_name');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->string('username');
+            $table->string('information')->nullable();
+            $table->string('description');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('actions');
+    }
+}

--- a/tests/Bus/Events/Component/ComponentStatusWasUpdatedEventTest.php
+++ b/tests/Bus/Events/Component/ComponentStatusWasUpdatedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Component;
 
 use CachetHQ\Cachet\Bus\Events\Component\ComponentStatusWasUpdatedEvent;
 use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\User;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use MailThief\Testing\InteractsWithMail;
 
@@ -27,6 +28,8 @@ class ComponentStatusWasUpdatedEventTest extends AbstractComponentEventTestCase
 
     public function testComponentUpdateEmailWasSent()
     {
+        $user = factory('CachetHQ\Cachet\Models\User')->create();
+
         $component = factory('CachetHQ\Cachet\Models\Component')->create([
             'status' => 2,
         ]);
@@ -37,7 +40,7 @@ class ComponentStatusWasUpdatedEventTest extends AbstractComponentEventTestCase
 
         $subscriber->subscriptions()->create(['component_id' => $component->id]);
 
-        $this->app['events']->fire(new ComponentStatusWasUpdatedEvent($component, 1, 2));
+        $this->app['events']->fire(new ComponentStatusWasUpdatedEvent($user, $component, 1, 2));
 
         $this->seeMessageFor($subscriber->email);
         $this->seeMessageWithSubject(trans('notifications.component.status_update.mail.subject'));
@@ -55,8 +58,13 @@ class ComponentStatusWasUpdatedEventTest extends AbstractComponentEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['component' => new Component(), 'original_status' => 1, 'new_status' => 2];
-        $object = new ComponentStatusWasUpdatedEvent($params['component'], $params['original_status'], $params['new_status']);
+        $params = ['user' => new User(), 'component' => new Component(), 'original_status' => 1, 'new_status' => 2];
+        $object = new ComponentStatusWasUpdatedEvent(
+            $params['user'],
+            $params['component'],
+            $params['original_status'],
+            $params['new_status']
+        );
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/Component/ComponentWasAddedEventTest.php
+++ b/tests/Bus/Events/Component/ComponentWasAddedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Component;
 
 use CachetHQ\Cachet\Bus\Events\Component\ComponentWasAddedEvent;
 use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\User;
 
 class ComponentWasAddedEventTest extends AbstractComponentEventTestCase
 {
@@ -23,8 +24,8 @@ class ComponentWasAddedEventTest extends AbstractComponentEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['component' => new Component()];
-        $object = new ComponentWasAddedEvent($params['component']);
+        $params = ['user' => new User(), 'component' => new Component()];
+        $object = new ComponentWasAddedEvent($params['user'], $params['component']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/Component/ComponentWasRemovedEventTest.php
+++ b/tests/Bus/Events/Component/ComponentWasRemovedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Component;
 
 use CachetHQ\Cachet\Bus\Events\Component\ComponentWasRemovedEvent;
 use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\User;
 
 class ComponentWasRemovedEventTest extends AbstractComponentEventTestCase
 {
@@ -23,8 +24,8 @@ class ComponentWasRemovedEventTest extends AbstractComponentEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['component' => new Component()];
-        $object = new ComponentWasRemovedEvent($params['component']);
+        $params = ['user' => new User(), 'component' => new Component()];
+        $object = new ComponentWasRemovedEvent($params['user'], $params['component']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/Component/ComponentWasUpdatedEventTest.php
+++ b/tests/Bus/Events/Component/ComponentWasUpdatedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Component;
 
 use CachetHQ\Cachet\Bus\Events\Component\ComponentWasUpdatedEvent;
 use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\User;
 
 class ComponentWasUpdatedEventTest extends AbstractComponentEventTestCase
 {
@@ -23,8 +24,8 @@ class ComponentWasUpdatedEventTest extends AbstractComponentEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['component' => new Component()];
-        $object = new ComponentWasUpdatedEvent($params['component']);
+        $params = ['user' => new User(), 'component' => new Component()];
+        $object = new ComponentWasUpdatedEvent($params['user'], $params['component']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/ComponentGroup/ComponentGroupWasAddedEventTest.php
+++ b/tests/Bus/Events/ComponentGroup/ComponentGroupWasAddedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\ComponentGroup;
 
 use CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupWasAddedEvent;
 use CachetHQ\Cachet\Models\ComponentGroup;
+use CachetHQ\Cachet\Models\User;
 
 class ComponentGroupWasAddedEventTest extends AbstractComponentGroupEventTestCase
 {
@@ -23,8 +24,8 @@ class ComponentGroupWasAddedEventTest extends AbstractComponentGroupEventTestCas
 
     protected function getObjectAndParams()
     {
-        $params = ['group' => new ComponentGroup()];
-        $object = new ComponentGroupWasAddedEvent($params['group']);
+        $params = ['user' => new User(), 'group' => new ComponentGroup()];
+        $object = new ComponentGroupWasAddedEvent($params['user'], $params['group']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/ComponentGroup/ComponentGroupWasRemovedEventTest.php
+++ b/tests/Bus/Events/ComponentGroup/ComponentGroupWasRemovedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\ComponentGroup;
 
 use CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupWasRemovedEvent;
 use CachetHQ\Cachet\Models\ComponentGroup;
+use CachetHQ\Cachet\Models\User;
 
 class ComponentGroupWasRemovedEventTest extends AbstractComponentGroupEventTestCase
 {
@@ -23,8 +24,8 @@ class ComponentGroupWasRemovedEventTest extends AbstractComponentGroupEventTestC
 
     protected function getObjectAndParams()
     {
-        $params = ['group' => new ComponentGroup()];
-        $object = new ComponentGroupWasRemovedEvent($params['group']);
+        $params = ['user' => new User(), 'group' => new ComponentGroup()];
+        $object = new ComponentGroupWasRemovedEvent($params['user'], $params['group']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/ComponentGroup/ComponentGroupWasUpdatedEventTest.php
+++ b/tests/Bus/Events/ComponentGroup/ComponentGroupWasUpdatedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\ComponentGroup;
 
 use CachetHQ\Cachet\Bus\Events\ComponentGroup\ComponentGroupWasUpdatedEvent;
 use CachetHQ\Cachet\Models\ComponentGroup;
+use CachetHQ\Cachet\Models\User;
 
 class ComponentGroupWasUpdatedEventTest extends AbstractComponentGroupEventTestCase
 {
@@ -23,8 +24,8 @@ class ComponentGroupWasUpdatedEventTest extends AbstractComponentGroupEventTestC
 
     protected function getObjectAndParams()
     {
-        $params = ['group' => new ComponentGroup()];
-        $object = new ComponentGroupWasUpdatedEvent($params['group']);
+        $params = ['user' => new User(), 'group' => new ComponentGroup()];
+        $object = new ComponentGroupWasUpdatedEvent($params['user'], $params['group']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/Incident/IncidentWasRemovedEventTest.php
+++ b/tests/Bus/Events/Incident/IncidentWasRemovedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Incident;
 
 use CachetHQ\Cachet\Bus\Events\Incident\IncidentWasRemovedEvent;
 use CachetHQ\Cachet\Models\Incident;
+use CachetHQ\Cachet\Models\User;
 
 /**
  * This is the incident was removed event test class.
@@ -28,8 +29,8 @@ class IncidentWasRemovedEventTest extends AbstractIncidentEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['incident' => new Incident()];
-        $object = new IncidentWasRemovedEvent($params['incident']);
+        $params = ['user' => new User(), 'incident' => new Incident()];
+        $object = new IncidentWasRemovedEvent($params['user'], $params['incident']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/Incident/IncidentWasReportedEventTest.php
+++ b/tests/Bus/Events/Incident/IncidentWasReportedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Incident;
 
 use CachetHQ\Cachet\Bus\Events\Incident\IncidentWasReportedEvent;
 use CachetHQ\Cachet\Models\Incident;
+use CachetHQ\Cachet\Models\User;
 
 /**
  * This is the incident was reported event test class.
@@ -29,10 +30,11 @@ class IncidentWasReportedEventTest extends AbstractIncidentEventTestCase
     protected function getObjectAndParams()
     {
         $params = [
+            'user'     => new User(),
             'incident' => new Incident(),
             'notify'   => true,
         ];
-        $object = new IncidentWasReportedEvent($params['incident'], $params['notify']);
+        $object = new IncidentWasReportedEvent($params['user'], $params['incident'], $params['notify']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/Incident/IncidentWasUpdatedEventTest.php
+++ b/tests/Bus/Events/Incident/IncidentWasUpdatedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Incident;
 
 use CachetHQ\Cachet\Bus\Events\Incident\IncidentWasUpdatedEvent;
 use CachetHQ\Cachet\Models\Incident;
+use CachetHQ\Cachet\Models\User;
 
 /**
  * This is the incident was updated event test class.
@@ -28,8 +29,8 @@ class IncidentWasUpdatedEventTest extends AbstractIncidentEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['incident' => new Incident()];
-        $object = new IncidentWasUpdatedEvent($params['incident']);
+        $params = ['user' => new User(), 'incident' => new Incident()];
+        $object = new IncidentWasUpdatedEvent($params['user'], $params['incident']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/IncidentUpdate/IncidentUpdateWasRemovedEventTest.php
+++ b/tests/Bus/Events/IncidentUpdate/IncidentUpdateWasRemovedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\IncidentUpdate;
 
 use CachetHQ\Cachet\Bus\Events\IncidentUpdate\IncidentUpdateWasRemovedEvent;
 use CachetHQ\Cachet\Models\IncidentUpdate;
+use CachetHQ\Cachet\Models\User;
 
 class IncidentUpdateWasRemovedEventTest extends AbstractIncidentUpdateEventTestCase
 {
@@ -23,8 +24,8 @@ class IncidentUpdateWasRemovedEventTest extends AbstractIncidentUpdateEventTestC
 
     protected function getObjectAndParams()
     {
-        $params = ['update' => new IncidentUpdate()];
-        $object = new IncidentUpdateWasRemovedEvent($params['update']);
+        $params = ['user' => new User(), 'update' => new IncidentUpdate()];
+        $object = new IncidentUpdateWasRemovedEvent($params['user'], $params['update']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/IncidentUpdate/IncidentUpdateWasReportedEventTest.php
+++ b/tests/Bus/Events/IncidentUpdate/IncidentUpdateWasReportedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\IncidentUpdate;
 
 use CachetHQ\Cachet\Bus\Events\IncidentUpdate\IncidentUpdateWasReportedEvent;
 use CachetHQ\Cachet\Models\IncidentUpdate;
+use CachetHQ\Cachet\Models\User;
 
 class IncidentUpdateWasReportedEventTest extends AbstractIncidentUpdateEventTestCase
 {
@@ -23,8 +24,8 @@ class IncidentUpdateWasReportedEventTest extends AbstractIncidentUpdateEventTest
 
     protected function getObjectAndParams()
     {
-        $params = ['update' => new IncidentUpdate()];
-        $object = new IncidentUpdateWasReportedEvent($params['update']);
+        $params = ['user' => new User(), 'update' => new IncidentUpdate()];
+        $object = new IncidentUpdateWasReportedEvent($params['user'], $params['update']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/IncidentUpdate/IncidentUpdateWasUpdatedEventTest.php
+++ b/tests/Bus/Events/IncidentUpdate/IncidentUpdateWasUpdatedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\IncidentUpdate;
 
 use CachetHQ\Cachet\Bus\Events\IncidentUpdate\IncidentUpdateWasUpdatedEvent;
 use CachetHQ\Cachet\Models\IncidentUpdate;
+use CachetHQ\Cachet\Models\User;
 
 class IncidentUpdateWasUpdatedEventTest extends AbstractIncidentUpdateEventTestCase
 {
@@ -23,8 +24,8 @@ class IncidentUpdateWasUpdatedEventTest extends AbstractIncidentUpdateEventTestC
 
     protected function getObjectAndParams()
     {
-        $params = ['update' => new IncidentUpdate()];
-        $object = new IncidentUpdateWasUpdatedEvent($params['update']);
+        $params = ['user' => new User(), 'update' => new IncidentUpdate()];
+        $object = new IncidentUpdateWasUpdatedEvent($params['user'], $params['update']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/Metric/MetricPointWasAddedEventTest.php
+++ b/tests/Bus/Events/Metric/MetricPointWasAddedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Metric;
 
 use CachetHQ\Cachet\Bus\Events\Metric\MetricPointWasAddedEvent;
 use CachetHQ\Cachet\Models\MetricPoint;
+use CachetHQ\Cachet\Models\User;
 
 /**
  * This is the metric point was added event test class.
@@ -28,8 +29,8 @@ class MetricPointWasAddedEventTest extends AbstractMetricEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['metricPoint' => new MetricPoint()];
-        $object = new MetricPointWasAddedEvent($params['metricPoint']);
+        $params = ['user' => new User(), 'metricPoint' => new MetricPoint()];
+        $object = new MetricPointWasAddedEvent($params['user'], $params['metricPoint']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/Metric/MetricPointWasRemovedEventTest.php
+++ b/tests/Bus/Events/Metric/MetricPointWasRemovedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Metric;
 
 use CachetHQ\Cachet\Bus\Events\Metric\MetricPointWasRemovedEvent;
 use CachetHQ\Cachet\Models\MetricPoint;
+use CachetHQ\Cachet\Models\User;
 
 /**
  * This is the metric point was removed event test class.
@@ -28,8 +29,8 @@ class MetricPointWasRemovedEventTest extends AbstractMetricEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['metricPoint' => new MetricPoint()];
-        $object = new MetricPointWasRemovedEvent($params['metricPoint']);
+        $params = ['user' => new User(), 'metricPoint' => new MetricPoint()];
+        $object = new MetricPointWasRemovedEvent($params['user'], $params['metricPoint']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/Metric/MetricPointWasUpdatedEventTest.php
+++ b/tests/Bus/Events/Metric/MetricPointWasUpdatedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Metric;
 
 use CachetHQ\Cachet\Bus\Events\Metric\MetricPointWasUpdatedEvent;
 use CachetHQ\Cachet\Models\MetricPoint;
+use CachetHQ\Cachet\Models\User;
 
 /**
  * This is the metric point was updated event test class.
@@ -28,8 +29,8 @@ class MetricPointWasUpdatedEventTest extends AbstractMetricEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['metricPoint' => new MetricPoint()];
-        $object = new MetricPointWasUpdatedEvent($params['metricPoint']);
+        $params = ['user' => new User(), 'metricPoint' => new MetricPoint()];
+        $object = new MetricPointWasUpdatedEvent($params['user'], $params['metricPoint']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/Metric/MetricWasAddedEventTest.php
+++ b/tests/Bus/Events/Metric/MetricWasAddedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Metric;
 
 use CachetHQ\Cachet\Bus\Events\Metric\MetricWasAddedEvent;
 use CachetHQ\Cachet\Models\Metric;
+use CachetHQ\Cachet\Models\User;
 
 class MetricWasAddedEventTest extends AbstractMetricEventTestCase
 {
@@ -23,8 +24,8 @@ class MetricWasAddedEventTest extends AbstractMetricEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['metric' => new Metric()];
-        $object = new MetricWasAddedEvent($params['metric']);
+        $params = ['user' => new User(), 'metric' => new Metric()];
+        $object = new MetricWasAddedEvent($params['user'], $params['metric']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/Metric/MetricWasRemovedEventTest.php
+++ b/tests/Bus/Events/Metric/MetricWasRemovedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Metric;
 
 use CachetHQ\Cachet\Bus\Events\Metric\MetricWasRemovedEvent;
 use CachetHQ\Cachet\Models\Metric;
+use CachetHQ\Cachet\Models\User;
 
 class MetricWasRemovedEventTest extends AbstractMetricEventTestCase
 {
@@ -23,8 +24,8 @@ class MetricWasRemovedEventTest extends AbstractMetricEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['metric' => new Metric()];
-        $object = new MetricWasRemovedEvent($params['metric']);
+        $params = ['user' => new User(), 'metric' => new Metric()];
+        $object = new MetricWasRemovedEvent($params['user'], $params['metric']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/Metric/MetricWasUpdatedEventTest.php
+++ b/tests/Bus/Events/Metric/MetricWasUpdatedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Metric;
 
 use CachetHQ\Cachet\Bus\Events\Metric\MetricWasUpdatedEvent;
 use CachetHQ\Cachet\Models\Metric;
+use CachetHQ\Cachet\Models\User;
 
 class MetricWasUpdatedEventTest extends AbstractMetricEventTestCase
 {
@@ -23,8 +24,8 @@ class MetricWasUpdatedEventTest extends AbstractMetricEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['metric' => new Metric()];
-        $object = new MetricWasUpdatedEvent($params['metric']);
+        $params = ['user' => new User(), 'metric' => new Metric()];
+        $object = new MetricWasUpdatedEvent($params['user'], $params['metric']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/Schedule/ScheduleWasCreatedEventTest.php
+++ b/tests/Bus/Events/Schedule/ScheduleWasCreatedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Schedule;
 
 use CachetHQ\Cachet\Bus\Events\Schedule\ScheduleWasCreatedEvent;
 use CachetHQ\Cachet\Models\Schedule;
+use CachetHQ\Cachet\Models\User;
 
 class ScheduleWasCreatedEventTest extends AbstractScheduleEventTestCase
 {
@@ -23,8 +24,8 @@ class ScheduleWasCreatedEventTest extends AbstractScheduleEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['schedule' => new Schedule()];
-        $object = new ScheduleWasCreatedEvent($params['schedule']);
+        $params = ['user' => new User(), 'schedule' => new Schedule()];
+        $object = new ScheduleWasCreatedEvent($params['user'], $params['schedule']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/Schedule/ScheduleWasRemovedEventTest.php
+++ b/tests/Bus/Events/Schedule/ScheduleWasRemovedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Schedule;
 
 use CachetHQ\Cachet\Bus\Events\Schedule\ScheduleWasRemovedEvent;
 use CachetHQ\Cachet\Models\Schedule;
+use CachetHQ\Cachet\Models\User;
 
 class ScheduleWasRemovedEventTest extends AbstractScheduleEventTestCase
 {
@@ -23,8 +24,8 @@ class ScheduleWasRemovedEventTest extends AbstractScheduleEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['schedule' => new Schedule()];
-        $object = new ScheduleWasRemovedEvent($params['schedule']);
+        $params = ['user' => new User(), 'schedule' => new Schedule()];
+        $object = new ScheduleWasRemovedEvent($params['user'], $params['schedule']);
 
         return compact('params', 'object');
     }

--- a/tests/Bus/Events/Schedule/ScheduleWasUpdatedEventTest.php
+++ b/tests/Bus/Events/Schedule/ScheduleWasUpdatedEventTest.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Tests\Cachet\Bus\Events\Schedule;
 
 use CachetHQ\Cachet\Bus\Events\Schedule\ScheduleWasUpdatedEvent;
 use CachetHQ\Cachet\Models\Schedule;
+use CachetHQ\Cachet\Models\User;
 
 class ScheduleWasUpdatedEventTest extends AbstractScheduleEventTestCase
 {
@@ -23,8 +24,8 @@ class ScheduleWasUpdatedEventTest extends AbstractScheduleEventTestCase
 
     protected function getObjectAndParams()
     {
-        $params = ['schedule' => new Schedule()];
-        $object = new ScheduleWasUpdatedEvent($params['schedule']);
+        $params = ['user' => new User(), 'schedule' => new Schedule()];
+        $object = new ScheduleWasUpdatedEvent($params['user'], $params['schedule']);
 
         return compact('params', 'object');
     }

--- a/tests/Models/ActionTest.php
+++ b/tests/Models/ActionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Models;
+
+use AltThree\TestBench\ValidationTrait;
+use CachetHQ\Cachet\Models\Action;
+use CachetHQ\Tests\Cachet\AbstractTestCase;
+
+/**
+ * This is the action model test class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class ActionTest extends AbstractTestCase
+{
+    use ValidationTrait;
+
+    public function testValidation()
+    {
+        $this->checkRules(new Action());
+    }
+}


### PR DESCRIPTION
Closes #2344 

---

To get this working, any events that are fired due to a user action need to supply the user responsible for the event occurring. A pretty big change that I'll aim to get done tomorrow.

The following events need updating:

- [x] Component
- [x] ComponentGroup
- [x] Incident
- [x] IncidentUpdate
- [x] Metric
- [x] Schedule
- [x] User