### PR TITLE
Add missing silent paramater, and cast status to Int before comparing

### DIFF
--- a/app/Bus/Handlers/Commands/Incident/UpdateIncidentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Incident/UpdateIncidentCommandHandler.php
@@ -97,7 +97,8 @@ class UpdateIncidentCommandHandler
                 null,
                 null,
                 null,
-                null
+                null,
+                false
             ));
         }
 

--- a/app/Models/Incident.php
+++ b/app/Models/Incident.php
@@ -199,10 +199,10 @@ class Incident extends Model implements HasPresenter
     public function getIsResolvedAttribute()
     {
         if ($updates = $this->updates->first()) {
-            return intVal($updates->status) === self::FIXED;
+            return (int) $updates->status === self::FIXED;
         }
 
-        return intVal($this->status) === self::FIXED;
+        return (int) $this->status === self::FIXED;
     }
 
     /**

--- a/app/Models/Incident.php
+++ b/app/Models/Incident.php
@@ -199,10 +199,10 @@ class Incident extends Model implements HasPresenter
     public function getIsResolvedAttribute()
     {
         if ($updates = $this->updates->first()) {
-            return $updates->status === self::FIXED;
+            return intVal($updates->status) === self::FIXED;
         }
 
-        return $this->status === self::FIXED;
+        return intVal($this->status) === self::FIXED;
     }
 
     /**


### PR DESCRIPTION
It would appears that if an incident has no updates and you check the parent incident's status, it can often be a string rather than an Int. I noticed this was the case with incidents being created and updated via the Cachet API and a number of popular third party tools/monitors. 