### PR TITLE
Update requirements section of readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can now [join our Slack community!](http://cachethq-slack.herokuapp.com)
 
 ## Requirements
 
-- PHP 5.5.9+ or newer
+- PHP 5.6.4+ or newer
 - HTTP server with PHP support (eg: Apache, Nginx, Caddy)
 - [Composer](https://getcomposer.org)
 - A supported database: MySQL, PostgreSQL or SQLite


### PR DESCRIPTION
Cachet 2.4 require 5.6.4+ but there was written 5.5.9+. I update that PHP version.