### PR TITLE
Email input placeholder in subscription form

### DIFF
--- a/resources/views/subscribe/subscribe.blade.php
+++ b/resources/views/subscribe/subscribe.blade.php
@@ -17,7 +17,7 @@
                 <form action="{{ cachet_route('subscribe', [], 'post') }}" method="POST" class="form">
                     <input type="hidden" name="_token" value="{{ csrf_token() }}">
                     <div class="form-group">
-                        <input class="form-control" type="email" name="email">
+                        <input class="form-control" type="email" name="email" placeholder="email@example.com">
                     </div>
                     <button type="submit" class="btn btn-success">{{ trans('cachet.subscriber.button') }}</button>
                 </form>


### PR DESCRIPTION
Closes https://github.com/CachetHQ/Cachet/issues/2547

Running on 2.3.9 subscribers don't see an email placeholder on a subscription page and are in doubt what is required to subscribe.
Adding such placeholder will be a good fit for 2.4 redesign efforts.