### PR TITLE
Revert "Dashboard API routes are not meant for the browser"

### DIFF
--- a/app/Http/Routes/Dashboard/ApiRoutes.php
+++ b/app/Http/Routes/Dashboard/ApiRoutes.php
@@ -26,7 +26,7 @@ class ApiRoutes
      *
      * @var bool
      */
-    public static $browser = false;
+    public static $browser = true;
 
     /**
      * Define the dashboard api routes.


### PR DESCRIPTION
This reverts commit 8fcef7b711423816260aba7669283fe2840f7893.

Closes #2711 and closes #2685