### PR TITLE
Don't hide the component-status form group in add view. Fixes #2829.

### DIFF
--- a/resources/views/dashboard/incidents/add.blade.php
+++ b/resources/views/dashboard/incidents/add.blade.php
@@ -89,7 +89,7 @@
                             <span class='help-block'>{{ trans('forms.optional') }}</span>
                         </div>
                         @endif
-                        <div class="form-group hidden" id="component-status" v-if="component.id">
+                        <div class="form-group" id="component-status" v-if="component.id">
                             <div class="panel panel-default">
                                 <div class="panel-body">
                                     <div class="radio-items">


### PR DESCRIPTION
This patch should fix #2829. After doing the following the form-group was hidden by default (intended) but when selecting a component it unhides.

(Note: I tested this on a live environment, not a new development one for testing, please test before merging).