### PR TITLE
 Makes the editor focusable.

### DIFF
--- a/resources/views/dashboard/templates/add.blade.php
+++ b/resources/views/dashboard/templates/add.blade.php
@@ -9,13 +9,14 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.8.0/mode/twig/twig.min.js"></script>
 
 <script>
-(function() {
-    var editor = CodeMirror.fromTextArea(document.getElementById('cm-editor'), {
-        lineNumbers: true,
-        mode: 'twig',
-        lineWrapping: true
-    });
-}());
+//Initializes the editor only once the DOM is loaded.
+window.addEventListener("DOMContentLoaded", function(e) {
+     var editor = CodeMirror.fromTextArea(document.getElementById('cm-editor'), {
+         lineNumbers: true,
+         mode: 'twig',
+         lineWrapping: true
+     });
+});
 </script>
 @stop
 


### PR DESCRIPTION
On the incident template creation the editor was not focusable, now it
is.
The problem was the initialization of the editor that was done before
the DOM is fully loaded.
Using addEventListener and DOMContentLoaded fixes the problem and is
compatible from IE9.