### PR TITLE
Replace Inf with asterisk when using pluralization in translations

### DIFF
--- a/resources/lang/en/cachet.php
+++ b/resources/lang/en/cachet.php
@@ -53,9 +53,9 @@ return [
 
     // Service Status
     'service' => [
-        'good'  => '[0,1]System operational|[2,Inf] All systems are operational',
-        'bad'   => '[0,1]The system is experiencing issues|[2,Inf]Some systems are experiencing issues',
-        'major' => '[0,1]The system is experiencing major issues|[2,Inf]Some systems are experiencing major issues',
+        'good'  => '[0,1]System operational|[2,*] All systems are operational',
+        'bad'   => '[0,1]The system is experiencing issues|[2,*]Some systems are experiencing issues',
+        'major' => '[0,1]The system is experiencing major issues|[2,*]Some systems are experiencing major issues',
     ],
 
     'api' => [

--- a/resources/lang/en/dashboard.php
+++ b/resources/lang/en/dashboard.php
@@ -18,7 +18,7 @@ return [
     'incidents' => [
         'title'                    => 'Incidents & Maintenance',
         'incidents'                => 'Incidents',
-        'logged'                   => '{0} There are no incidents, good work.|[1] You have logged one incident.|[2, Inf] You have reported <strong>:count</strong> incidents.',
+        'logged'                   => '{0} There are no incidents, good work.|[1] You have logged one incident.|[2,*] You have reported <strong>:count</strong> incidents.',
         'incident-create-template' => 'Create Template',
         'incident-templates'       => 'Incident Templates',
         'updates'                  => [
@@ -74,7 +74,7 @@ return [
     // Incident Maintenance
     'schedule' => [
         'schedule'     => 'Maintenance',
-        'logged'       => '{0} There has been no Maintenance, good work.|[1] You have logged one schedule.|[2,Inf] You have reported <strong>:count</strong> schedules.',
+        'logged'       => '{0} There has been no Maintenance, good work.|[1] You have logged one schedule.|[2,*] You have reported <strong>:count</strong> schedules.',
         'scheduled_at' => 'Scheduled at :timestamp',
         'add'          => [
             'title'   => 'Add Maintenance',


### PR DESCRIPTION
Hi again :raising_hand_man: 

This PR should fix a bug where pluralization is falling back to the first option because it no longer understands `Inf`. Since Laravel 5.4 the "Inf" has been replaced with *.

### What has been done:
- Replaced `,Inf` with `,*` in the translations

### How to test
- Make sure [your Cachet is up and running](https://docs.cachethq.io/docs/installing-cachet).
- Make sure you cachet has some incidents or updates, you can use the `php artisan cachet:seed` if required.
- Create at least 4 incident updates for a single incident.
- Acknowledge the dashboard incident overview page tells you "One update".
- Checkout PR.
- Acknowledge the dashboard incident overview page now tells you "Several updates".
