### PR TITLE
Autofocus totp input

### DIFF
--- a/resources/views/auth/two-factor-auth.blade.php
+++ b/resources/views/auth/two-factor-auth.blade.php
@@ -28,7 +28,7 @@
 
                                 <div class="form-group">
                                     <label class="sr-only">{{ trans('forms.login.2fauth') }}</label>
-                                    <input type="text" name="code" class="form-control" placeholder="{{ trans('forms.login.2fauth') }}" required>
+                                    <input type="text" name="code" class="form-control" placeholder="{{ trans('forms.login.2fauth') }}" required autofocus>
                                 </div>
                                 <div class="form-group">
                                     <button type="submit" class="btn btn-info btn-lg btn-block btn-trans">{{ trans('dashboard.login.login') }}</button>


### PR DESCRIPTION
It is quite nasty to click into the text input for the totp token after login. It should autofocus like the login form.