### PR TITLE
Place the '* optional' label behind the Component form field

### DIFF
--- a/resources/lang/en/forms.php
+++ b/resources/lang/en/forms.php
@@ -49,6 +49,7 @@ return [
         'name'               => 'Name',
         'status'             => 'Status',
         'component'          => 'Component',
+        'component_status'   => 'Component Status',
         'message'            => 'Message',
         'message-help'       => 'You may also use Markdown.',
         'occurred_at'        => 'When did this incident occur?',

--- a/resources/views/dashboard/incidents/add.blade.php
+++ b/resources/views/dashboard/incidents/add.blade.php
@@ -72,7 +72,7 @@
                         </div>
                         @if(!$components_in_groups->isEmpty() || !$components_out_groups->isEmpty())
                         <div class="form-group">
-                            <label>{{ trans('forms.incidents.component') }}</label>
+                            <label>{{ trans('forms.incidents.component') }}</label> <small class="text-muted">{{ trans('forms.optional') }}</small>
                             <select name="component_id" class="form-control" v-model="component.id">
                                 <option value="" selected></option>
                                 @foreach($components_in_groups as $group)
@@ -86,10 +86,10 @@
                                 <option value="{{ $component->id }}">{{ $component->name }}</option>
                                 @endforeach
                             </select>
-                            <span class='help-block'>{{ trans('forms.optional') }}</span>
                         </div>
                         @endif
                         <div class="form-group" id="component-status" v-if="component.id">
+                            <label>{{ trans('forms.incidents.component_status') }}</label>
                             <div class="panel panel-default">
                                 <div class="panel-body">
                                     <div class="radio-items">


### PR DESCRIPTION
Hi, :raising_hand_man: 

This PR is a small cosmetic fix. When creating a new Incident, I noticed that the "* optional" label wasn't correctly aligned behind the label like it does when selecting the "occured_at" date. This PR should fix that.

### What has been done:
From:
![screenshot from 2018-01-20 23-27-02](https://user-images.githubusercontent.com/3368018/35188629-81aa3e88-fe39-11e7-9569-d17e69f51a58.png)

To:
![screenshot from 2018-01-20 23-28-17](https://user-images.githubusercontent.com/3368018/35188637-9d571610-fe39-11e7-9ad0-b0a99a973f56.png)

### How to test:
- Make sure [your Cachet is up and running](https://docs.cachethq.io/docs/installing-cachet).
- Log into the dashboard and create a new incident
- Acknowledge that the "* Optional" label of the Component field is placed below the input field
- Checkout PR
-  Acknowledge that the "* Optional" label of the Component field is now placed besides the field label