### PR TITLE
Remove duplicate closing bracket in the mail template

### DIFF
--- a/resources/views/vendor/notifications/email.blade.php
+++ b/resources/views/vendor/notifications/email.blade.php
@@ -140,7 +140,7 @@ $style = [
 
                                         <!-- Salutation -->
                                         <p style="{{ $style['paragraph'] }}">
-                                            Regards,<br>{{ setting('app_name', config('app.name')) }} }}
+                                            Regards,<br>{{ setting('app_name', config('app.name')) }}
                                         </p>
 
                                         <!-- Sub Copy -->
@@ -176,7 +176,7 @@ $style = [
                                     <td style="{{ $fontFamily }} {{ $style['email-footer_cell'] }}">
                                         <p style="{{ $style['paragraph-sub'] }}">
                                             &copy; {{ date('Y') }}
-                                            <a style="{{ $style['anchor'] }}" href="{{ url('/') }}" target="_blank">{{ setting('app_name', config('app.name')) }} }}</a>.
+                                            <a style="{{ $style['anchor'] }}" href="{{ url('/') }}" target="_blank">{{ setting('app_name', config('app.name')) }}</a>.
                                             All rights reserved.
                                         </p>
                                     </td>


### PR DESCRIPTION
Good day :raising_hand_man: ,

When sending a test e-mail I saw a duplicate closing bracket. This PR will convert this:
![screenshot from 2018-01-27 12-00-04](https://user-images.githubusercontent.com/3368018/35471365-2d3f0cd6-035a-11e8-8459-ccf0591c5b31.png)
Into this:
![screenshot from 2018-01-27 12-00-49](https://user-images.githubusercontent.com/3368018/35471366-317bff20-035a-11e8-9771-f1b4d30a2a76.png)
