### PR TITLE
Fix invalid amount of arguments in CreateIncidentUpdateCommandTest

### DIFF
--- a/app/Http/Controllers/Api/IncidentUpdateController.php
+++ b/app/Http/Controllers/Api/IncidentUpdateController.php
@@ -78,6 +78,8 @@ class IncidentUpdateController extends AbstractApiController
                 $incident,
                 Binput::get('status'),
                 Binput::get('message'),
+                Binput::get('component_id'),
+                Binput::get('component_status'),
                 Auth::user()
             ));
         } catch (QueryException $e) {

--- a/tests/Bus/Commands/IncidentUpdate/CreateIncidentUpdateCommandTest.php
+++ b/tests/Bus/Commands/IncidentUpdate/CreateIncidentUpdateCommandTest.php
@@ -35,7 +35,7 @@ class CreateIncidentUpdateCommandTest extends AbstractTestCase
             'message'  => 'Foo',
             'user'     => new User(),
         ];
-        $object = new CreateIncidentUpdateCommand($params['incident'], $params['status'], $params['message'], $params['user']);
+        $object = new CreateIncidentUpdateCommand($params['incident'], $params['status'], $params['message'], null, null, $params['user']);
 
         return compact('params', 'object');
     }


### PR DESCRIPTION
Heya :raising_hand_man: ,

I noticed how the build was failing. Turns out the arugments passed to the constructor of `CreateIncidentUpdateCommand` werent patched on two locations. This should do the Trick.

### What has been done:
- The Api/IncidentUpdateController now uses the component_id and component_status when creating an incident update.


### How to test
- The Travis build should be green now