### PR TITLE
Work in Progress: Feature always authenticate

### DIFF
--- a/app/Foundation/Providers/RouteServiceProvider.php
+++ b/app/Foundation/Providers/RouteServiceProvider.php
@@ -13,7 +13,9 @@ namespace CachetHQ\Cachet\Foundation\Providers;
 
 use Barryvdh\Cors\HandleCors;
 use CachetHQ\Cachet\Http\Middleware\Acceptable;
+use CachetHQ\Cachet\Http\Middleware\Authenticate;
 use CachetHQ\Cachet\Http\Middleware\Timezone;
+use CachetHQ\Cachet\Http\Routes\AuthRoutes;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
@@ -126,6 +128,10 @@ class RouteServiceProvider extends ServiceProvider
             VerifyCsrfToken::class,
             SubstituteBindings::class,
         ];
+
+        if ($this->app['config']->get('setting.always_authenticate', false) && !$routes instanceof AuthRoutes) {
+            $middleware[] = Authenticate::class;
+        }
 
         $router->group(['middleware' => $middleware], function (Router $router) use ($routes) {
             $routes->map($router);

--- a/app/Foundation/Providers/RouteServiceProvider.php
+++ b/app/Foundation/Providers/RouteServiceProvider.php
@@ -167,6 +167,11 @@ class RouteServiceProvider extends ServiceProvider
             Timezone::class,
         ];
 
+        $applyAlwaysAuthenticate = $this->app['config']->get('setting.always_authenticate', false);
+        if ($applyAlwaysAuthenticate && !$this->isWhiteListedAuthRoute($routes)) {
+            $middleware[] = 'auth.api:true';
+        }
+
         $router->group(['middleware' => $middleware], function (Router $router) use ($routes) {
             $routes->map($router);
         });

--- a/app/Http/Controllers/Dashboard/SettingsController.php
+++ b/app/Http/Controllers/Dashboard/SettingsController.php
@@ -21,6 +21,7 @@ use GrahamCampbell\Binput\Facades\Binput;
 use Illuminate\Log\Writer;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Redirect;
@@ -382,6 +383,10 @@ class SettingsController extends Controller
 
         if (Binput::has('app_locale')) {
             Lang::setLocale(Binput::get('app_locale'));
+        }
+
+        if (Binput::has('always_authenticate')) {
+            Artisan::call('route:cache');
         }
 
         return Redirect::back()->withSuccess(trans('dashboard.settings.edit.success'));

--- a/config/security.php
+++ b/config/security.php
@@ -22,4 +22,15 @@ return [
     */
     'evil' => ['(?<!\w)on\w*', 'style', 'xmlns', 'formaction', 'form', 'xlink:href', 'FSCommand', 'seekSegmentTime'],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Always authenticate
+    |--------------------------------------------------------------------------
+    |
+    | Whether to lock down Cachet and only allow viewing pages
+    | when authenticated.
+    |
+    */
+    'always_authenticate' => true,
+
 ];

--- a/resources/assets/js/cachet.js
+++ b/resources/assets/js/cachet.js
@@ -16,6 +16,9 @@ $(function () {
         beforeSend: function (xhr) {
             xhr.setRequestHeader('Accept', 'application/json');
             // xhr.setRequestHeader('Content-Type', 'application/json; charset=utf-8');
+          if (typeof window.apiKey !== 'undefined') {
+            xhr.setRequestHeader('X-Cachet-Token', window.apiKey);
+          }
         },
         statusCode: {
             401: function () {

--- a/resources/lang/en/forms.php
+++ b/resources/lang/en/forms.php
@@ -177,8 +177,10 @@ return [
             'incident-date-format' => 'Incident timestamp format',
         ],
         'security' => [
-            'allowed-domains'      => 'Allowed domains',
-            'allowed-domains-help' => 'Comma separated. The domain set above is automatically allowed by default.',
+            'allowed-domains'           => 'Allowed domains',
+            'allowed-domains-help'      => 'Comma separated. The domain set above is automatically allowed by default.',
+            'always-authenticate'       => 'Always authenticate',
+            'always-authenticate-help'  => 'Require login to view any Cachet page',
         ],
         'stylesheet' => [
             'custom-css' => 'Custom Stylesheet',

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -36,11 +36,13 @@
                 <div class="form-group">
                     <div class="row">
                         <div class="col-xs-2">
+                            @if(!config('setting.always_authenticate', false))
                             <a class="btn btn-default btn-lg btn-trans" href="{{ cachet_route('status-page') }}">
                                 <span class="text-center">
                                     <i class="ion ion-home"></i>
                                 </span>
                             </a>
+                            @endif
                         </div>
                         <div class="col-xs-9 col-xs-push-1">
                             <button type="submit" class="btn btn-success btn-lg btn-block btn-trans">{{ trans('dashboard.login.login') }}</button>

--- a/resources/views/dashboard/settings/security.blade.php
+++ b/resources/views/dashboard/settings/security.blade.php
@@ -17,6 +17,18 @@
                     <fieldset>
                         <div class="row">
                             <div class="col-xs-12">
+                                <label>{{ trans('forms.settings.security.always-authenticate') }}</label>
+                                <div class="checkbox">
+                                    <label>
+                                        <input type="hidden" value="0" name="always_authenticate">
+                                        <input type="checkbox" value="1" name="always_authenticate" {{ Config::get('setting.always_authenticate') ? 'checked' : null }}>
+                                        {{ trans('forms.settings.security.always-authenticate-help') }}
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-xs-12">
                                 <div class="form-group">
                                     <label>{{ trans('forms.settings.security.allowed-domains') }}</label>
                                     <textarea class="form-control" name="allowed_domains" rows="5" placeholder="http://cachet.io, http://cachet.herokuapp.com">{{ Config::get('setting.allowed_domains') }}</textarea>

--- a/resources/views/layout/dashboard.blade.php
+++ b/resources/views/layout/dashboard.blade.php
@@ -62,4 +62,7 @@
 </body>
 @yield('js')
 <script src="{{ mix('dist/js/all.js') }}"></script>
+<script type="text/javascript">
+    window.apiKey = "{{ auth()->user()->api_key }}";
+</script>
 </html>


### PR DESCRIPTION
Hi again :raising_hand_man: 

A trial implementation of #2812. In this state I would advice against merging this because I had to implement a lot of hacks / workarounds to get this working nicely. I took a lot of shortcuts and would love some input before continuing. 

### What has been done:
- Added a new setting in the security section allowing you to enforce authentication on all routes.
- Added logic to the RouteServiceProvider that will read this configuration value and inject `auth` or `api.auth` middleware into the routing group.
- When you have the always authenticate feature enabled, we wont show you a "back to home" button on the login

### How to test:
- Make sure [your Cachet is up and running](https://docs.cachethq.io/docs/installing-cachet).
- Log into the dashboard and enable the `Always authenticate` checkbox at the security settings
- Logout
- Acknowledge you cannot visit the status page without authenticating
- Acknowledge you cannot visit the api routes like `api/v1/components` without authenticating

### Todo:
- [ ] Get rid of the hacks
- [ ] Write tests

### Notes:
- See inline notes in code
