### PR TITLE
Show incident updates on the status page

### DIFF
--- a/resources/assets/sass/status-page/_status-page.scss
+++ b/resources/assets/sass/status-page/_status-page.scss
@@ -423,4 +423,8 @@ body.status-page {
             }
         }
     }
+    //Display inline the incident update message.
+    .incident-update-item > p {
+        display: inline-block;
+    }
 }

--- a/resources/views/partials/incidents.blade.php
+++ b/resources/views/partials/incidents.blade.php
@@ -34,9 +34,17 @@
                         <div class="list-group">
                             @foreach($incident->updates as $update)
                             <a class="list-group-item" href="{{ $update->permalink }}">
-                                <i class="{{ $update->icon }}" title="{{ $update->human_status }}" data-toggle="tooltip"></i> <strong>{{ Str::limit($update->raw_message, 20) }}</strong>
-                                <small>{{ $update->created_at_diff }}</small>
-                                <span class="ion-ios-arrow-right pull-right"></span>
+                                <p>
+                                    <i class="{{ $update->icon }}" title="{{ $update->human_status }}" data-toggle="tooltip"></i>
+                                    {{ $update->raw_message }}
+                                    <small>
+                                        <abbr class="timeago links" data-toggle="tooltip"
+                                            data-placement="right" title="{{ $update->timestamp_formatted }}"
+                                            data-timeago="{{ $update->timestamp_iso }}">
+                                        </abbr>
+                                    </small>
+                                    <span class="ion-ios-arrow-right pull-right"></span>
+                                </p>
                             </a>
                             @endforeach
                         </div>

--- a/resources/views/partials/incidents.blade.php
+++ b/resources/views/partials/incidents.blade.php
@@ -33,18 +33,17 @@
                         @if($incident->updates->isNotEmpty())
                         <div class="list-group">
                             @foreach($incident->updates as $update)
-                            <a class="list-group-item" href="{{ $update->permalink }}">
-                                <p>
-                                    <i class="{{ $update->icon }}" title="{{ $update->human_status }}" data-toggle="tooltip"></i>
-                                    {{ $update->raw_message }}
-                                    <small>
-                                        <abbr class="timeago links" data-toggle="tooltip"
-                                            data-placement="right" title="{{ $update->timestamp_formatted }}"
-                                            data-timeago="{{ $update->timestamp_iso }}">
-                                        </abbr>
-                                    </small>
-                                    <span class="ion-ios-arrow-right pull-right"></span>
-                                </p>
+                            <a class="list-group-item incident-update-item" href="{{ $update->permalink }}">
+                                <i class="{{ $update->icon }}" title="{{ $update->human_status }}" data-toggle="tooltip"></i>
+                                {!! $update->formatted_message !!}
+                                <small>
+                                    <abbr class="timeago links" data-toggle="tooltip"
+                                        data-placement="right" title="{{ $update->timestamp_formatted }}"
+                                        data-timeago="{{ $update->timestamp_iso }}">
+                                    </abbr>
+                                </small>
+                                <span class="ion-ios-arrow-right pull-right"></span>
+
                             </a>
                             @endforeach
                         </div>


### PR DESCRIPTION
This pull request is the next of #2863.
It displays the incident status updates on the status page instead of truncate them.
