### PR TITLE
#2895 duplicate title and meta tags

### DIFF
--- a/resources/lang/en/cachet.php
+++ b/resources/lang/en/cachet.php
@@ -118,13 +118,13 @@ return [
     ],
 
     // Meta descriptions
-    'meta' =>  [
+    'meta' => [
         'description' => [
             'incident'  => 'Details and updates about the :name incident that occurred on :date',
             'schedule'  => 'Details about the scheduled maintenance period :name starting :startDate',
             'subscribe' => 'Subscribe to :app in order to receive updates of incidents and scheduled maintenance periods',
             'overview'  => 'Stay up to date with the latest service updates from :app.',
-        ]
+        ],
     ],
 
     // Other

--- a/resources/lang/en/cachet.php
+++ b/resources/lang/en/cachet.php
@@ -117,9 +117,18 @@ return [
         ],
     ],
 
+    // Meta descriptions
+    'meta' =>  [
+        'description' => [
+            'incident'  => 'Details and updates about the :name incident that occurred on :date',
+            'schedule'  => 'Details about the scheduled maintenance period :name starting :startDate',
+            'subscribe' => 'Subscribe to :app in order to receive updates of incidents and scheduled maintenance periods',
+            'overview'  => 'Stay up to date with the latest service updates from :app.',
+        ]
+    ],
+
     // Other
     'home'            => 'Home',
-    'description'     => 'Stay up to date with the latest service updates from :app.',
     'powered_by'      => 'Powered by <a href="https://cachethq.io" class="links">Cachet</a>.',
     'timezone'        => 'Times are shown in :timezone.',
     'about_this_site' => 'About This Site',

--- a/resources/views/layout/master.blade.php
+++ b/resources/views/layout/master.blade.php
@@ -15,12 +15,12 @@
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="description" content="{{ trans('cachet.description', ['app' => $app_name]) }}">
+    <meta name="description" content="@yield('description', trans('cachet.meta.description.overview', ['app' => $app_name]))">
 
     <meta property="og:type" content="website">
     <meta property="og:title" content="{{ $site_title }}">
     <meta property="og:image" content="/img/favicon.png">
-    <meta property="og:description" content="{{ trans('cachet.description', ['app' => $app_name]) }}">
+    <meta property="og:description" content="@yield('description', trans('cachet.meta.description.overview', ['app' => $app_name]))">
 
     <!-- Mobile IE allows us to activate ClearType technology for smoothing fonts for easy reading -->
     <meta http-equiv="cleartype" content="on">

--- a/resources/views/single-incident.blade.php
+++ b/resources/views/single-incident.blade.php
@@ -2,6 +2,8 @@
 
 @section('title', $incident->name.' | '.$site_title)
 
+@section('description', trans('cachet.meta.description.incident', ['name' => $incident->name, 'date' => $incident->occurred_at_formatted]))
+
 @section('bodyClass', 'no-padding')
 
 @section('outer-content')

--- a/resources/views/single-schedule.blade.php
+++ b/resources/views/single-schedule.blade.php
@@ -2,6 +2,8 @@
 
 @section('title', $schedule->name.' | '.$site_title)
 
+@section('description', trans('cachet.meta.description.schedule', ['name' => $schedule->name, 'startDate' => $schedule->scheduled_at_formatted]))
+
 @section('bodyClass', 'no-padding')
 
 @section('outer-content')

--- a/resources/views/subscribe/subscribe.blade.php
+++ b/resources/views/subscribe/subscribe.blade.php
@@ -1,5 +1,7 @@
 @extends('layout.master')
 
+@section('description', trans('cachet.meta.description.subscribe', ['app' => $site_title]))
+
 @section('content')
 <div class="pull-right">
     <p><a class="btn btn-success btn-outline" href="{{ cachet_route('status-page') }}"><i class="ion ion-home"></i></a></p>

--- a/resources/views/subscribe/subscribe.blade.php
+++ b/resources/views/subscribe/subscribe.blade.php
@@ -1,5 +1,7 @@
 @extends('layout.master')
 
+@section('title',  trans('cachet.subscriber.subscribe'). " | ". $site_title))
+
 @section('description', trans('cachet.meta.description.subscribe', ['app' => $site_title]))
 
 @section('content')


### PR DESCRIPTION
Its finally here :tada: 

An implementation #2895.

### What has been done:
- Created a new view yield for the `description` and `og:description` meta tags
- Configured these yields in the single-incident, single-schedule and subscription pages

### How to test:
- Make sure [your Cachet is up and running](https://docs.cachethq.io/docs/installing-cachet).
- Seed your installation to assure the incidents and schedules exist: `php artisan cachet:seed`
- Checkout PR
- Acknowledge the meta description on the [subscribe page](view-source:http://localhost:8000/subscribe)
- Acknowledge the meta description on the [incident details page ](view-source:http://localhost:8000/incidents/1)
- Acknowledge the meta description on the [schedule details page](view-source:http://localhost:8000/schedules/1)

### Notes:
- I noticed how some public facing pages use `{page title} | {app name}` in their description. Should we perhaps apply this principle in the entire codebase?