### PR TITLE
Fix a bug where the redirect route is unable to resolve when rate limited

### DIFF
--- a/app/Foundation/Exceptions/Displayers/ThrottleDisplayer.php
+++ b/app/Foundation/Exceptions/Displayers/ThrottleDisplayer.php
@@ -49,7 +49,7 @@ class ThrottleDisplayer implements DisplayerInterface
      */
     public function display(Exception $exception, $id, $code, array $headers)
     {
-        return redirect()->route('auth.login')->withError(trans('forms.login.rate-limit'));
+        return cachet_redirect('auth.login')->withError(trans('forms.login.rate-limit'));
     }
 
     /**


### PR DESCRIPTION
Buongiorno :raising_hand_man: 

A small fix I found while guessing the password for my local cachet instance.

### What has been done:
- Used `cachet_route` to resolve the route when redirecting from the ThrottleDisplayer.

### How to test:
- Create a rate limit by trying to login
- Acknowledge the exception message 
- Checkout PR
- Refresh/Retry to login
- Acknowledge you are now taken to the login page with the `Rate limit exceeded.` message