### PR TITLE
Fixes the template editing as it was done in pull #2866 for creation.

### DIFF
--- a/resources/views/dashboard/templates/edit.blade.php
+++ b/resources/views/dashboard/templates/edit.blade.php
@@ -9,13 +9,14 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.8.0/mode/twig/twig.min.js"></script>
 
 <script>
-(function() {
-    var editor = CodeMirror.fromTextArea(document.getElementById('cm-editor'), {
-        lineNumbers: true,
-        mode: 'twig',
-        lineWrapping: true
-    });
-}());
+//Initializes the editor only once the DOM is loaded.
+window.addEventListener("DOMContentLoaded", function(e) {
+     var editor = CodeMirror.fromTextArea(document.getElementById('cm-editor'), {
+         lineNumbers: true,
+         mode: 'twig',
+         lineWrapping: true
+     });
+});
 </script>
 @stop
 


### PR DESCRIPTION
In the pull request #2866 the template creation was fixed by loading CodeMirror only after DOM loaded, the same thing is done here with editing.