### PR TITLE
Generation of the API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /node_modules
 /public/hot
 /public/storage
+/public/docs
 /storage/*.key
 /vendor
 /.idea

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 .env
+config/swagger-constants.php
+storage/api-docs/

--- a/app/Http/Controllers/Api/AbstractApiController.php
+++ b/app/Http/Controllers/Api/AbstractApiController.php
@@ -19,6 +19,17 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Response;
 use McCool\LaravelAutoPresenter\Facades\AutoPresenter;
 
+/**
+ * @SWG\Swagger(
+ *   schemes={"https", "http"},
+ *   host="example.com",
+ *   basePath="/api/v1",
+ *   @SWG\Info(
+ *     title="Cachet API",
+ *     version="1.0.0"
+ *   )
+ * )
+ */
 abstract class AbstractApiController extends Controller
 {
     /**

--- a/app/Http/Controllers/Api/ComponentController.php
+++ b/app/Http/Controllers/Api/ComponentController.php
@@ -34,53 +34,75 @@ class ComponentController extends AbstractApiController
      *
      * @SWG\Get(
      *   path="/components",
-     *   summary="List all components",
-     *   operationId="index",
+     *   summary="List all components.",
+     *   operationId="Component@index",
      *   tags={"Components"},
      *   produces={"application/json"}, 
      *   @SWG\Parameter(
-     *      description="ID of the component to filter",
-     *      in="query",
-     *      name="id",
-     *      required=false,
-     *      type="integer",
-     *      format="int64"
+     *     description="ID of the component to filter.",
+     *     in="query",
+     *     name="id",
+     *     required=false,
+     *     type="integer",
+     *     format="int64"
      *   ),
      *   @SWG\Parameter(
-     *      description="Name of the components to filter",
-     *      in="query",
-     *      name="name",
-     *      required=false,
-     *      type="string"
+     *     description="Name of the components to filter.",
+     *     in="query",
+     *     name="name",
+     *     required=false,
+     *     type="string"
      *   ),
      *   @SWG\Parameter(
-     *      description="Status of components to filter",
-     *      in="query",
-     *      name="status",
-     *      required=false,
-     *      type="integer",
-     *      format="int64"
+     *     description="Status of components to filter.",
+     *     in="query",
+     *     name="status",
+     *     required=false,
+     *     type="integer",
+     *     format="int64"
      *   ),
      *   @SWG\Parameter(
-     *      description="Group identifier of components to filter",
-     *      in="query",
-     *      name="group_id",
-     *      required=false,
-     *      type="integer",
-     *      format="int64"
+     *     description="Group identifier of components to filter.",
+     *     in="query",
+     *     name="group_id",
+     *     required=false,
+     *     type="integer",
+     *     format="int64"
      *   ),
      *   @SWG\Parameter(
-     *      description="If the components should be enabled or not, 1 or 0.",
-     *      in="query",
-     *      name="enabled",
-     *      required=false,
-     *      type="integer",
-     *      format="int64"
+     *     description="If the components should be enabled or not, 1 or 0.",
+     *     in="query",
+     *     name="enabled",
+     *     required=false,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Parameter(
+     *     description="The field on which sort the results.",
+     *     in="query",
+     *     name="sort",
+     *     required=false,
+     *     type="string"
+     *   ),
+     *   @SWG\Parameter(
+     *     description="The direction on which sort the results. 'asc' or 'desc'.",
+     *     in="query",
+     *     name="order",
+     *     required=false,
+     *     type="string"
+     *   ),
+     *   @SWG\Parameter(
+     *     description="The number of items to get. Default to 20.",
+     *     in="query",
+     *     name="per_page",
+     *     required=false,
+     *     type="integer",
+     *     format="int64"
      *   ),
      *   @SWG\Response(
-     *      response=200,
-     *      description="A list with all components"
-     *   ),
+     *     response=200,
+     *     description="A list with all components."
+     *   )
      * )
      *
      * @return \Illuminate\Http\JsonResponse
@@ -115,19 +137,20 @@ class ComponentController extends AbstractApiController
      *
      * @SWG\Get(
      *   path="/components/{component}",
-     *   summary="Get a single component",
+     *   summary="Get a single component.",
      *   tags={"Components"},
+     *   operationId="Component@show",
      *   @SWG\Parameter(
-     *      description="ID of component to return",
-     *      in="path",
-     *      name="component",
-     *      required=true,
-     *      type="integer",
-     *      format="int64"
+     *     description="ID of component to return.",
+     *     in="path",
+     *     name="component",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
      *  ),
      *  @SWG\Response(
-     *      response=200,
-     *      description="A single component"
+     *     response=200,
+     *     description="A single component."
      *   )
      * )
      */
@@ -145,63 +168,67 @@ class ComponentController extends AbstractApiController
      * @SWG\Post(
      *   path="/components",
      *   tags={"Components"},
-     *   operationId="store",
-     *   summary="Add a new component",
+     *   operationId="Component@store",
+     *   summary="Add a new component.",
      *   description="",
      *   consumes={"multipart/form-data"},
      *   produces={"application/json"},
      *   @SWG\Parameter(
-     *      name="name",
-     *      in="formData",
-     *      type="string",
-     *      description="Name of the component",
-     *      required=true
+     *     name="name",
+     *     in="formData",
+     *     type="string",
+     *     description="Name of the component.",
+     *     required=true
      *   ),
      *   @SWG\Parameter(
-     *      name="description",
-     *      in="formData",
-     *      type="string",
-     *      description="Description of the component",
-     *      required=true
+     *     name="description",
+     *     in="formData",
+     *     type="string",
+     *     description="Description of the component.",
+     *     required=true
      *   ),
      *   @SWG\Parameter(
-     *      name="status",
-     *      in="formData",
-     *      type="integer",
-     *      description="Status of the component (between 1 and 4)",
-     *      required=true
+     *     name="status",
+     *     in="formData",
+     *     type="integer",
+     *     description="Status of the component (between 1 and 4).",
+     *     required=true
      *   ),
      *   @SWG\Parameter(
-     *      name="link",
-     *      in="formData",
-     *      type="string",
-     *      description="A hyperlink to the component",
-     *      required=true
+     *     name="link",
+     *     in="formData",
+     *     type="string",
+     *     description="A hyperlink to the component.",
+     *     required=true
      *   ),
      *   @SWG\Parameter(
-     *      name="order",
-     *      in="formData",
-     *      type="integer",
-     *      description="Order of the component",
-     *      required=true
+     *     name="order",
+     *     in="formData",
+     *     type="integer",
+     *     description="Order of the component.",
+     *     required=true
      *   ),
      *   @SWG\Parameter(
-     *      name="group_id",
-     *      in="formData",
-     *      type="integer",
-     *      description="Group identifier of the component",
-     *      required=true
+     *     name="group_id",
+     *     in="formData",
+     *     type="integer",
+     *     description="Group identifier of the component.",
+     *     required=true
      *   ),
      *   @SWG\Parameter(
-     *      name="enabled",
-     *      in="formData",
-     *      type="integer",
-     *      description="1 if the component is enabled, 0 otherwise.",
-     *      required=false
+     *     name="enabled",
+     *     in="formData",
+     *     type="integer",
+     *     description="1 if the component is enabled, 0 otherwise.",
+     *     required=false
      *   ),
      *   @SWG\Response(
-     *      response=200,
-     *      description="Ok"
+     *     response=200,
+     *     description="The component."
+     *   ),
+     *   @SWG\Response(
+     *     response=400,
+     *     description="Invalid ccomponent."
      *   )
      * )
      *
@@ -252,63 +279,67 @@ class ComponentController extends AbstractApiController
      * @SWG\Put(
      *   path="/components/{component}",
      *   tags={"Components"},
-     *   operationId="update",
-     *   summary="Update an existing component",
+     *   operationId="Component@update",
+     *   summary="Update an existing component.",
      *   description="",
      *   consumes={"multipart/form-data"},
      *   produces={"application/json"},
      *   @SWG\Parameter(
-     *      name="component",
-     *      in="path",
-     *      type="integer",
-     *      description="Identifier of the component to update",
-     *      required=true
+     *     name="component",
+     *     in="path",
+     *     type="integer",
+     *     description="Identifier of the component to update.",
+     *     required=true
      *   ),
      *   @SWG\Parameter(
-     *      name="name",
-     *      in="formData",
-     *      type="string",
-     *      description="Name of the component",
-     *      required=true
+     *     name="name",
+     *     in="formData",
+     *     type="string",
+     *     description="Name of the component.",
+     *     required=true
      *   ),
      *   @SWG\Parameter(
-     *      name="status",
-     *      in="formData",
-     *      type="integer",
-     *      description="Status of the component (between 1 and 4)",
-     *      required=true
+     *     name="status",
+     *     in="formData",
+     *     type="integer",
+     *     description="Status of the component (between 1 and 4).",
+     *     required=true
      *   ),
      *   @SWG\Parameter(
-     *      name="link",
-     *      in="formData",
-     *      type="string",
-     *      description="A hyperlink of the component",
-     *      required=true
+     *     name="link",
+     *     in="formData",
+     *     type="string",
+     *     description="A hyperlink of the component.",
+     *     required=true
      *   ),
      *   @SWG\Parameter(
-     *      name="order",
-     *      in="formData",
-     *      type="integer",
-     *      description="The order of the component",
-     *      required=true
+     *     name="order",
+     *     in="formData",
+     *     type="integer",
+     *     description="The order of the component.",
+     *     required=true
      *   ),
      *   @SWG\Parameter(
-     *      name="group_id",
-     *      in="formData",
-     *      type="integer",
-     *      description="The group id of the component",
-     *      required=true
+     *     name="group_id",
+     *     in="formData",
+     *     type="integer",
+     *     description="The group id of the component.",
+     *     required=true
      *   ),
      *   @SWG\Parameter(
-     *      name="enabled",
-     *      in="formData",
-     *      type="integer",
-     *      description="1 to enable the component, 0 otherwise",
-     *      required=false
+     *     name="enabled",
+     *     in="formData",
+     *     type="integer",
+     *     description="1 to enable the component, 0 otherwise.",
+     *     required=false
      *   ),
      *   @SWG\Response(
-     *      response=200,
-     *      description="Ok"
+     *     response=200,
+     *     description="The component."
+     *   ),
+     *   @SWG\Response(
+     *     response=400,
+     *     description="Invalid component."
      *   )
      * )
      *
@@ -350,12 +381,6 @@ class ComponentController extends AbstractApiController
     /**
      * Delete an existing component.
      *
-     * **Path params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|------------
-     * component | int32 | Y | Component ID
-     *
      * @param \CachetHQ\Cachet\Models\Component $component
      *
      * @return \Illuminate\Http\JsonResponse
@@ -363,21 +388,21 @@ class ComponentController extends AbstractApiController
      *
      * @SWG\Delete(
      *   path="/components/{component}",
-     *   summary="Deletes a component",
+     *   summary="Deletes a component.",
      *   description="",
-     *   operationId="destroy",
+     *   operationId="Component@destroy",
      *   tags={"Components"},
      *   @SWG\Parameter(
-     *      description="Component id to delete",
-     *      in="path",
-     *      name="component",
-     *      required=true,
-     *      type="integer",
-     *      format="int64"
+     *     description="Component id to delete.",
+     *     in="path",
+     *     name="component",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
      *   ),
      *   @SWG\Response(
-     *      response=200,
-     *      description="Ok"
+     *     response=204,
+     *     description="Ok."
      *   ),
      * )
      * 

--- a/app/Http/Controllers/Api/ComponentController.php
+++ b/app/Http/Controllers/Api/ComponentController.php
@@ -228,7 +228,7 @@ class ComponentController extends AbstractApiController
      *   ),
      *   @SWG\Response(
      *     response=400,
-     *     description="Invalid ccomponent."
+     *     description="Invalid component."
      *   )
      * )
      *

--- a/app/Http/Controllers/Api/ComponentController.php
+++ b/app/Http/Controllers/Api/ComponentController.php
@@ -32,12 +32,56 @@ class ComponentController extends AbstractApiController
     /**
      * Get all components.
      *
-     * The following searchable keys are available:
-     * - `id`
-     * - `name`
-     * - `status`
-     * - `group_id`
-     * - `enabled`
+     * @SWG\Get(
+     *   path="/components",
+     *   summary="List all components",
+     *   operationId="index",
+     *   tags={"Components"},
+     *   produces={"application/json"}, 
+     *   @SWG\Parameter(
+     *      description="ID of the component to filter",
+     *      in="query",
+     *      name="id",
+     *      required=false,
+     *      type="integer",
+     *      format="int64"
+     *   ),
+     *   @SWG\Parameter(
+     *      description="Name of the components to filter",
+     *      in="query",
+     *      name="name",
+     *      required=false,
+     *      type="string"
+     *   ),
+     *   @SWG\Parameter(
+     *      description="Status of components to filter",
+     *      in="query",
+     *      name="status",
+     *      required=false,
+     *      type="integer",
+     *      format="int64"
+     *   ),
+     *   @SWG\Parameter(
+     *      description="Group identifier of components to filter",
+     *      in="query",
+     *      name="group_id",
+     *      required=false,
+     *      type="integer",
+     *      format="int64"
+     *   ),
+     *   @SWG\Parameter(
+     *      description="If the components should be enabled or not, 1 or 0.",
+     *      in="query",
+     *      name="enabled",
+     *      required=false,
+     *      type="integer",
+     *      format="int64"
+     *   ),
+     *   @SWG\Response(
+     *      response=200,
+     *      description="A list with all components"
+     *   ),
+     * )
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -65,15 +109,27 @@ class ComponentController extends AbstractApiController
     /**
      * Get a single component.
      *
-     * **Path params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|------------
-     * component | int32 | Y | The component identifier
-     *
      * @param \CachetHQ\Cachet\Models\Component $component
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Get(
+     *   path="/components/{component}",
+     *   summary="Get a single component",
+     *   tags={"Components"},
+     *   @SWG\Parameter(
+     *      description="ID of component to return",
+     *      in="path",
+     *      name="component",
+     *      required=true,
+     *      type="integer",
+     *      format="int64"
+     *  ),
+     *  @SWG\Response(
+     *      response=200,
+     *      description="A single component"
+     *   )
+     * )
      */
     public function show(Component $component)
     {
@@ -83,19 +139,73 @@ class ComponentController extends AbstractApiController
     /**
      * Create a new component.
      *
-     * **Body params:**
-     *
-     *  Name | Type | Required | Description
-     *  -----|------|------------
-     *  name | string | Y | Name of the component
-     *  description| string | Y | Description of the component
-     *  status | int32` | Y | Status of the component (Between 1 and 4)
-     *  link | string | Y | A hyperlink to the component
-     *  order | int32 | Y | Order of the component
-     *  group_id | int32 | Y | The group identifier that the component is within
-     *  enabled | boolean | N | Whether the component is enabled
-     *
      * @return \Illuminate\Http\JsonResponse
+     *
+     *
+     * @SWG\Post(
+     *   path="/components",
+     *   tags={"Components"},
+     *   operationId="store",
+     *   summary="Add a new component",
+     *   description="",
+     *   consumes={"multipart/form-data"},
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *      name="name",
+     *      in="formData",
+     *      type="string",
+     *      description="Name of the component",
+     *      required=true
+     *   ),
+     *   @SWG\Parameter(
+     *      name="description",
+     *      in="formData",
+     *      type="string",
+     *      description="Description of the component",
+     *      required=true
+     *   ),
+     *   @SWG\Parameter(
+     *      name="status",
+     *      in="formData",
+     *      type="integer",
+     *      description="Status of the component (between 1 and 4)",
+     *      required=true
+     *   ),
+     *   @SWG\Parameter(
+     *      name="link",
+     *      in="formData",
+     *      type="string",
+     *      description="A hyperlink to the component",
+     *      required=true
+     *   ),
+     *   @SWG\Parameter(
+     *      name="order",
+     *      in="formData",
+     *      type="integer",
+     *      description="Order of the component",
+     *      required=true
+     *   ),
+     *   @SWG\Parameter(
+     *      name="group_id",
+     *      in="formData",
+     *      type="integer",
+     *      description="Group identifier of the component",
+     *      required=true
+     *   ),
+     *   @SWG\Parameter(
+     *      name="enabled",
+     *      in="formData",
+     *      type="integer",
+     *      description="1 if the component is enabled, 0 otherwise.",
+     *      required=false
+     *   ),
+     *   @SWG\Response(
+     *      response=200,
+     *      description="Ok"
+     *   )
+     * )
+     *
+     *
      */
     public function store()
     {
@@ -134,26 +244,75 @@ class ComponentController extends AbstractApiController
     /**
      * Update an existing component.
      *
-     * **Path params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|------------
-     * component | int32 | Y | The identifier of the component to update
-     *
-     * **Body params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|------------
-     * name | string | Y | Name of the component
-     * status | int32 | Y | Status of the component (between 1 and 4)
-     * link | string | Y | A hyperlink to the component
-     * order | int32 | Y | Order of the component
-     * group_id | int32 | Y | The group id that the component is within
-     * enabled | boolean | N | Whether the component is enabled
-     * 
      * @param \CachetHQ\Cachet\Models\Component $component
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     *
+     * @SWG\Put(
+     *   path="/components/{component}",
+     *   tags={"Components"},
+     *   operationId="update",
+     *   summary="Update an existing component",
+     *   description="",
+     *   consumes={"multipart/form-data"},
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *      name="component",
+     *      in="path",
+     *      type="integer",
+     *      description="Identifier of the component to update",
+     *      required=true
+     *   ),
+     *   @SWG\Parameter(
+     *      name="name",
+     *      in="formData",
+     *      type="string",
+     *      description="Name of the component",
+     *      required=true
+     *   ),
+     *   @SWG\Parameter(
+     *      name="status",
+     *      in="formData",
+     *      type="integer",
+     *      description="Status of the component (between 1 and 4)",
+     *      required=true
+     *   ),
+     *   @SWG\Parameter(
+     *      name="link",
+     *      in="formData",
+     *      type="string",
+     *      description="A hyperlink of the component",
+     *      required=true
+     *   ),
+     *   @SWG\Parameter(
+     *      name="order",
+     *      in="formData",
+     *      type="integer",
+     *      description="The order of the component",
+     *      required=true
+     *   ),
+     *   @SWG\Parameter(
+     *      name="group_id",
+     *      in="formData",
+     *      type="integer",
+     *      description="The group id of the component",
+     *      required=true
+     *   ),
+     *   @SWG\Parameter(
+     *      name="enabled",
+     *      in="formData",
+     *      type="integer",
+     *      description="1 to enable the component, 0 otherwise",
+     *      required=false
+     *   ),
+     *   @SWG\Response(
+     *      response=200,
+     *      description="Ok"
+     *   )
+     * )
+     *
+     *
      */
     public function update(Component $component)
     {
@@ -200,6 +359,29 @@ class ComponentController extends AbstractApiController
      * @param \CachetHQ\Cachet\Models\Component $component
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     *
+     * @SWG\Delete(
+     *   path="/components/{component}",
+     *   summary="Deletes a component",
+     *   description="",
+     *   operationId="destroy",
+     *   tags={"Components"},
+     *   @SWG\Parameter(
+     *      description="Component id to delete",
+     *      in="path",
+     *      name="component",
+     *      required=true,
+     *      type="integer",
+     *      format="int64"
+     *   ),
+     *   @SWG\Response(
+     *      response=200,
+     *      description="Ok"
+     *   ),
+     * )
+     * 
+     * 
      */
     public function destroy(Component $component)
     {

--- a/app/Http/Controllers/Api/ComponentController.php
+++ b/app/Http/Controllers/Api/ComponentController.php
@@ -69,7 +69,7 @@ class ComponentController extends AbstractApiController
      *
      * Name | Type | Description
      * -----|------|------------
-     * component | int32 | The component identifier.
+     * component | int32 | The component identifier
      *
      * @param \CachetHQ\Cachet\Models\Component $component
      *
@@ -87,13 +87,13 @@ class ComponentController extends AbstractApiController
      *
      *  Name | Type | Description
      *  -----|------|------------
-     *  name | string | Name of the component.
-     *  description| string | Description of the component.
-     *  status | int32` | Status of the component (Between 1 and 4).
-     *  link | string | A hyperlink to the component.
-     *  order | int32 | Order of the component.
-     *  group_id | int32 | The group identifier that the component is within.
-     *  enabled | boolean | Whether the component is enabled.
+     *  name | string | Name of the component
+     *  description| string | Description of the component
+     *  status | int32` | Status of the component (Between 1 and 4)
+     *  link | string | A hyperlink to the component
+     *  order | int32 | Order of the component
+     *  group_id | int32 | The group identifier that the component is within
+     *  enabled | boolean | Whether the component is enabled
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -144,12 +144,12 @@ class ComponentController extends AbstractApiController
      *
      * Name | Type | Description
      * -----|------|------------
-     * name | string | Name of the component.
-     * status | int32 | Status of the component (between 1 and 4).
-     * link | string | A hyperlink to the component.
-     * order | int32 | Order of the component.
-     * group_id | int32 | The group id that the component is within.
-     * enabled | boolean | Whether the component is enabled.
+     * name | string | Name of the component
+     * status | int32 | Status of the component (between 1 and 4)
+     * link | string | A hyperlink to the component
+     * order | int32 | Order of the component
+     * group_id | int32 | The group id that the component is within
+     * enabled | boolean | Whether the component is enabled
      *
      * @param \CachetHQ\Cachet\Models\Component $component
      *
@@ -195,7 +195,7 @@ class ComponentController extends AbstractApiController
      *
      * Name | Type | Description
      * -----|------|------------
-     * component | int32 | Component ID.
+     * component | int32 | Component ID
      *
      * @param \CachetHQ\Cachet\Models\Component $component
      *

--- a/app/Http/Controllers/Api/ComponentController.php
+++ b/app/Http/Controllers/Api/ComponentController.php
@@ -22,10 +22,22 @@ use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
+/**
+ * The Component API controller.
+ *
+ * @resource Component
+ */
 class ComponentController extends AbstractApiController
 {
     /**
      * Get all components.
+     *
+     * The following searchable keys are available:
+     * - `id`
+     * - `name`
+     * - `status`
+     * - `group_id`
+     * - `enabled`
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -53,6 +65,12 @@ class ComponentController extends AbstractApiController
     /**
      * Get a single component.
      *
+     * **Path params:**
+     *
+     * Name | Type | Description
+     * -----|------|------------
+     * component | int32 | The component identifier.
+     *
      * @param \CachetHQ\Cachet\Models\Component $component
      *
      * @return \Illuminate\Http\JsonResponse
@@ -64,6 +82,18 @@ class ComponentController extends AbstractApiController
 
     /**
      * Create a new component.
+     *
+     * **Body params:**
+     *
+     *  Name | Type | Description
+     *  -----|------|------------
+     *  name | string | Name of the component.
+     *  description| string | Description of the component.
+     *  status | int32` | Status of the component (Between 1 and 4).
+     *  link | string | A hyperlink to the component.
+     *  order | int32 | Order of the component.
+     *  group_id | int32 | The group identifier that the component is within.
+     *  enabled | boolean | Whether the component is enabled.
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -104,6 +134,23 @@ class ComponentController extends AbstractApiController
     /**
      * Update an existing component.
      *
+     * **Path params:**
+     *
+     * Name | Type | Description
+     * -----|------|------------
+     * component | int32 | The identifier of the component to update
+     *
+     * **Body params:**
+     *
+     * Name | Type | Description
+     * -----|------|------------
+     * name | string | Name of the component.
+     * status | int32 | Status of the component (between 1 and 4).
+     * link | string | A hyperlink to the component.
+     * order | int32 | Order of the component.
+     * group_id | int32 | The group id that the component is within.
+     * enabled | boolean | Whether the component is enabled.
+     *
      * @param \CachetHQ\Cachet\Models\Component $component
      *
      * @return \Illuminate\Http\JsonResponse
@@ -143,6 +190,12 @@ class ComponentController extends AbstractApiController
 
     /**
      * Delete an existing component.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Description
+     * -----|------|------------
+     * component | int32 | Component ID.
      *
      * @param \CachetHQ\Cachet\Models\Component $component
      *

--- a/app/Http/Controllers/Api/ComponentController.php
+++ b/app/Http/Controllers/Api/ComponentController.php
@@ -67,9 +67,9 @@ class ComponentController extends AbstractApiController
      *
      * **Path params:**
      *
-     * Name | Type | Description
+     * Name | Type | Required | Description
      * -----|------|------------
-     * component | int32 | The component identifier
+     * component | int32 | Y | The component identifier
      *
      * @param \CachetHQ\Cachet\Models\Component $component
      *
@@ -85,15 +85,15 @@ class ComponentController extends AbstractApiController
      *
      * **Body params:**
      *
-     *  Name | Type | Description
+     *  Name | Type | Required | Description
      *  -----|------|------------
-     *  name | string | Name of the component
-     *  description| string | Description of the component
-     *  status | int32` | Status of the component (Between 1 and 4)
-     *  link | string | A hyperlink to the component
-     *  order | int32 | Order of the component
-     *  group_id | int32 | The group identifier that the component is within
-     *  enabled | boolean | Whether the component is enabled
+     *  name | string | Y | Name of the component
+     *  description| string | Y | Description of the component
+     *  status | int32` | Y | Status of the component (Between 1 and 4)
+     *  link | string | Y | A hyperlink to the component
+     *  order | int32 | Y | Order of the component
+     *  group_id | int32 | Y | The group identifier that the component is within
+     *  enabled | boolean | N | Whether the component is enabled
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -136,21 +136,21 @@ class ComponentController extends AbstractApiController
      *
      * **Path params:**
      *
-     * Name | Type | Description
+     * Name | Type | Required | Description
      * -----|------|------------
-     * component | int32 | The identifier of the component to update
+     * component | int32 | Y | The identifier of the component to update
      *
      * **Body params:**
      *
-     * Name | Type | Description
+     * Name | Type | Required | Description
      * -----|------|------------
-     * name | string | Name of the component
-     * status | int32 | Status of the component (between 1 and 4)
-     * link | string | A hyperlink to the component
-     * order | int32 | Order of the component
-     * group_id | int32 | The group id that the component is within
-     * enabled | boolean | Whether the component is enabled
-     *
+     * name | string | Y | Name of the component
+     * status | int32 | Y | Status of the component (between 1 and 4)
+     * link | string | Y | A hyperlink to the component
+     * order | int32 | Y | Order of the component
+     * group_id | int32 | Y | The group id that the component is within
+     * enabled | boolean | N | Whether the component is enabled
+     * 
      * @param \CachetHQ\Cachet\Models\Component $component
      *
      * @return \Illuminate\Http\JsonResponse
@@ -193,9 +193,9 @@ class ComponentController extends AbstractApiController
      *
      * **Path params:**
      *
-     * Name | Type | Description
+     * Name | Type | Required | Description
      * -----|------|------------
-     * component | int32 | Component ID
+     * component | int32 | Y | Component ID
      *
      * @param \CachetHQ\Cachet\Models\Component $component
      *

--- a/app/Http/Controllers/Api/ComponentGroupController.php
+++ b/app/Http/Controllers/Api/ComponentGroupController.php
@@ -86,9 +86,9 @@ class ComponentGroupController extends AbstractApiController
      *
      * **Path params:**
      * 
-     * Name | Type | Description
+     * Name | Type | Required | Description
      * -----|------|------------
-     * group | int32 | Component group identifier
+     * group | int32 | Y | Component group identifier
      *
      * @param \CachetHQ\Cachet\Models\ComponentGroup $group
      *
@@ -104,11 +104,12 @@ class ComponentGroupController extends AbstractApiController
      *
      * **Body params:**
      *
-     * Name | Type | Description
+     * Name | Type | Required | Description
      * -----|------|------------
-     * name | string | Name of the component group
-     * order | int32 | Order of the component group
-     * collapsed | int32 | Collapse the group? 0 = No. 1 = Yes. 2 = If a component is not Operational
+     * name | string | Y | Name of the component group
+     * order | int32 | N | Order of the component group
+     * collapsed | int32 | N | Collapse the group? 0 = No. 1 = Yes. 2 = If a component is not Operational
+     * visible | int32 | N | Whether the component is visible
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -133,17 +134,18 @@ class ComponentGroupController extends AbstractApiController
      *
      * **Path params:**
      *
-     * Name | Type | Description
+     * Name | Type | Required | Description
      * -----|------|------------
-     * group | string | Component group ID
+     * group | string | Y | Component group ID
      *
      * **Body params:**
      *
-     * Name | Type | Description
+     * Name | Type | Required | Description
      * -----|------|------------
-     * name | string | Name of the component group
-     * order | int32 | Order of the component group
-     * collapsed | int32 | Collapse the group? 0 = No. 1 = Yes. 2 = If a component is not Operational
+     * name | string | Y | Name of the component group
+     * order | int32 | Y | Order of the component group
+     * collapsed | int32 | Y | Collapse the group? 0 = No. 1 = Yes. 2 = If a component is not Operational
+     * visible | int32 | Y | Whether the component should be visible
      *
      * @param \CachetHQ\Cachet\Models\ComponentGroup $group
      *
@@ -171,8 +173,8 @@ class ComponentGroupController extends AbstractApiController
      *
      * **Path params:**
      *
-     * Name | Type | Description
-     * group | int32 | Component group ID
+     * Name | Type | Required | Description
+     * group | int32 | Y | Component group ID
      *
      * @param \CachetHQ\Cachet\Models\ComponentGroup $group
      *

--- a/app/Http/Controllers/Api/ComponentGroupController.php
+++ b/app/Http/Controllers/Api/ComponentGroupController.php
@@ -53,13 +53,73 @@ class ComponentGroupController extends AbstractApiController
     /**
      * Get all groups.
      *
-     * The following searche keys are available:
-     * - `id`
-     * - `name`
-     * - `collapsed`
-     * - `visible`
-     *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Get(
+     *   path="/components/groups",
+     *   summary="Get all component groups.",
+     *   tags={"Component groups"},
+     *   description="",
+     *   operationId="ComponentGroup@index",
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     name="id",
+     *     in="query",
+     *     description="Id of the component groups to filter.",
+     *     required=false,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Parameter(
+     *     name="name",
+     *     in="query",
+     *     description="Name of the component groups to filter.",
+     *     required=false,
+     *     type="string"
+     *   ),
+     *   @SWG\Parameter(
+     *     name="collapsed",
+     *     in="query",
+     *     description="1 if the component groups to filter are collapsed, 0 otherwise.",
+     *     required=false,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Parameter(
+     *     name="visible",
+     *     in="query",
+     *     description="1 if the component groups to filter are visible, 0 otherwise.",
+     *     required=false,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Parameter(
+     *     description="The field on which sort the results.",
+     *     in="query",
+     *     name="sort",
+     *     required=false,
+     *     type="string"
+     *   ),
+     *   @SWG\Parameter(
+     *     description="The direction on which sort the results. 'asc' or 'desc'. Default 'asc'.",
+     *     in="query",
+     *     name="order",
+     *     required=false,
+     *     type="string"
+     *   ),
+     *   @SWG\Parameter(
+     *     description="The number of items to get. Default to 20.",
+     *     in="query",
+     *     name="per_page",
+     *     required=false,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="A list of component groups."
+     *   ),
+     * )
      */
     public function index()
     {
@@ -84,15 +144,34 @@ class ComponentGroupController extends AbstractApiController
     /**
      * Get a single group.
      *
-     * **Path params:**
-     * 
-     * Name | Type | Required | Description
-     * -----|------|------------
-     * group | int32 | Y | Component group identifier
-     *
      * @param \CachetHQ\Cachet\Models\ComponentGroup $group
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Get(
+     *   path="/components/groups/{component_group}",
+     *   summary="Get a single component group.",
+     *   tags={"Component groups"},
+     *   description="",
+     *   operationId="ComponentGroup@show",
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     name="component_group",
+     *     in="path",
+     *     description="Component group to filter.",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="The component group."
+     *   ),
+     *   @SWG\Response(
+     *     response="404",
+     *     description="Component group not found.",
+     *   ),
+     * )
      */
     public function show(ComponentGroup $group)
     {
@@ -102,16 +181,56 @@ class ComponentGroupController extends AbstractApiController
     /**
      * Create a new component group.
      *
-     * **Body params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|------------
-     * name | string | Y | Name of the component group
-     * order | int32 | N | Order of the component group
-     * collapsed | int32 | N | Collapse the group? 0 = No. 1 = Yes. 2 = If a component is not Operational
-     * visible | int32 | N | Whether the component is visible
-     *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Post(
+     *   path="/components/groups",
+     *   tags={"Component groups"},
+     *   operationId="ComponentGroup@store",
+     *   summary="Create a new component group.",
+     *   description="",
+     *   consumes={"application/x-www-form-urlencoded"},
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     name="name",
+     *     in="formData",
+     *     type="string",
+     *     description="Name of the component group.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="order",
+     *     in="formData",
+     *     type="integer",
+     *     format="int64",
+     *     description="Order of the component group. Default to 0.",
+     *     required=false
+     *   ),
+     *   @SWG\Parameter(
+     *     name="collapsed",
+     *     in="formData",
+     *     type="integer",
+     *     format="int64",
+     *     description="1 of the component group should be collapsed, 0 otherwise. Default to 0.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="visible",
+     *     in="formData",
+     *     type="integer",
+     *     format="int64",
+     *     description="If the component should be visible or not. Default to visible only for authenticated.",
+     *     required=true
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="The component group.",
+     *   ),
+     *   @SWG\Response(
+     *     response=400,
+     *     description="Component group invalid.",
+     *   )
+     * )
      */
     public function store()
     {
@@ -132,24 +251,66 @@ class ComponentGroupController extends AbstractApiController
     /**
      * Update an existing group.
      *
-     * **Path params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|------------
-     * group | string | Y | Component group ID
-     *
-     * **Body params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|------------
-     * name | string | Y | Name of the component group
-     * order | int32 | Y | Order of the component group
-     * collapsed | int32 | Y | Collapse the group? 0 = No. 1 = Yes. 2 = If a component is not Operational
-     * visible | int32 | Y | Whether the component should be visible
-     *
      * @param \CachetHQ\Cachet\Models\ComponentGroup $group
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Put(
+     *   path="/components/groups/{component_group}",
+     *   tags={"Component groups"},
+     *   operationId="ComponentGroup@update",
+     *   summary="Update an existing component group.",
+     *   description="",
+     *   consumes={"application/x-www-form-urlencoded"},
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     name="component_group",
+     *     in="path",
+     *     type="integer",
+     *     format="int64",
+     *     description="The identifier of the component group to update.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="name",
+     *     in="formData",
+     *     type="string",
+     *     description="The component group to update.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="order",
+     *     in="formData",
+     *     type="integer",
+     *     format="int64",
+     *     description="The order of the component group to update.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="collapsed",
+     *     in="formData",
+     *     type="integer",
+     *     format="int64",
+     *     description="1 of the component group should be collapsed, 0 otherwise.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="visible",
+     *     in="formData",
+     *     type="integer",
+     *     format="int64",
+     *     description="1 of the component group should be visible, 0 otherwise.",
+     *     required=true
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="The component group."
+     *   ),
+     *   @SWG\Response(
+     *     response=400,
+     *     description="Component group invalid."
+     *   )
+     * )
      */
     public function update(ComponentGroup $group)
     {
@@ -171,14 +332,29 @@ class ComponentGroupController extends AbstractApiController
     /**
      * Delete an existing group.
      *
-     * **Path params:**
-     *
-     * Name | Type | Required | Description
-     * group | int32 | Y | Component group ID
-     *
      * @param \CachetHQ\Cachet\Models\ComponentGroup $group
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Delete(
+     *   path="/components/groups/{component_group}",
+     *   summary="Delete a component group.",
+     *   description="",
+     *   operationId="ComponentGroup@destroy",
+     *   tags={"Component groups"},
+     *   @SWG\Parameter(
+     *     description="Component group id to delete.",
+     *     in="path",
+     *     name="component_group",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Response(
+     *     response=204,
+     *     description="Ok."
+     *   )
+     * )
      */
     public function destroy(ComponentGroup $group)
     {

--- a/app/Http/Controllers/Api/ComponentGroupController.php
+++ b/app/Http/Controllers/Api/ComponentGroupController.php
@@ -22,11 +22,14 @@ use Illuminate\Support\Facades\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
+ *
  * This is the component group controller.
  *
  * @author James Brooks <james@alt-three.com>
  * @author Graham Campbell <graham@alt-three.com>
  * @author Joseph Cohen <joe@alt-three.com>
+ *
+ * @resource ComponentGroup
  */
 class ComponentGroupController extends AbstractApiController
 {
@@ -49,6 +52,12 @@ class ComponentGroupController extends AbstractApiController
 
     /**
      * Get all groups.
+     *
+     * The following searche keys are available:
+     * - `id`
+     * - `name`
+     * - `collapsed`
+     * - `visible`
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -75,6 +84,12 @@ class ComponentGroupController extends AbstractApiController
     /**
      * Get a single group.
      *
+     * **Path params:**
+     * 
+     * Name | Type | Description
+     * -----|------|------------
+     * group | int32 | Component group identifier
+     *
      * @param \CachetHQ\Cachet\Models\ComponentGroup $group
      *
      * @return \Illuminate\Http\JsonResponse
@@ -86,6 +101,14 @@ class ComponentGroupController extends AbstractApiController
 
     /**
      * Create a new component group.
+     *
+     * **Body params:**
+     *
+     * Name | Type | Description
+     * -----|------|------------
+     * name | string | Name of the component group
+     * order | int32 | Order of the component group
+     * collapsed | int32 | Collapse the group? 0 = No. 1 = Yes. 2 = If a component is not Operational
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -107,6 +130,20 @@ class ComponentGroupController extends AbstractApiController
 
     /**
      * Update an existing group.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Description
+     * -----|------|------------
+     * group | string | Component group ID
+     *
+     * **Body params:**
+     *
+     * Name | Type | Description
+     * -----|------|------------
+     * name | string | Name of the component group
+     * order | int32 | Order of the component group
+     * collapsed | int32 | Collapse the group? 0 = No. 1 = Yes. 2 = If a component is not Operational
      *
      * @param \CachetHQ\Cachet\Models\ComponentGroup $group
      *
@@ -131,6 +168,11 @@ class ComponentGroupController extends AbstractApiController
 
     /**
      * Delete an existing group.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Description
+     * group | int32 | Component group ID
      *
      * @param \CachetHQ\Cachet\Models\ComponentGroup $group
      *

--- a/app/Http/Controllers/Api/GeneralController.php
+++ b/app/Http/Controllers/Api/GeneralController.php
@@ -18,11 +18,13 @@ use CachetHQ\Cachet\Integrations\Contracts\System;
  * This is the general api controller.
  *
  * @author James Brooks <james@bluebaytravel.co.uk>
+ *
+ * @resource General
  */
 class GeneralController extends AbstractApiController
 {
     /**
-     * Ping endpoint allows API consumers to check the version.
+     * Test that the API is responding to your requests.
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -32,7 +34,7 @@ class GeneralController extends AbstractApiController
     }
 
     /**
-     * Endpoint to show the Cachet version.
+     * Get the Cachet version.
      *
      * @return \Illuminate\Http\JsonResponse
      */

--- a/app/Http/Controllers/Api/GeneralController.php
+++ b/app/Http/Controllers/Api/GeneralController.php
@@ -27,6 +27,19 @@ class GeneralController extends AbstractApiController
      * Test that the API is responding to your requests.
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Get(
+     *   path="/ping",
+     *   summary="Test that the API is responding to your requests.",
+     *   description="",
+     *   operationId="General@ping",
+     *   produces={"application/json"},
+     *   tags={"General"},
+     *   @SWG\Response(
+     *     response=200,
+     *     description="Ok.",
+     *   )
+     * )
      */
     public function ping()
     {
@@ -37,6 +50,19 @@ class GeneralController extends AbstractApiController
      * Get the Cachet version.
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Get(
+     *   path="/version",
+     *   summary="Get the Cachet version.",
+     *   description="",
+     *   operationId="General@version",
+     *   produces={"application/json"},
+     *   tags={"General"},
+     *   @SWG\Response(
+     *     response=200,
+     *     description="Ok.",
+     *   )
+     * )
      */
     public function version()
     {
@@ -52,6 +78,19 @@ class GeneralController extends AbstractApiController
      * Get the system status message.
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Get(
+     *   path="/status",
+     *   summary="Get the system status message.",
+     *   description="",
+     *   operationId="General@status",
+     *   produces={"application/json"},
+     *   tags={"General"},
+     *   @SWG\Response(
+     *     response=200,
+     *     description="Ok.",
+     *   )
+     * )
      */
     public function status()
     {

--- a/app/Http/Controllers/Api/IncidentController.php
+++ b/app/Http/Controllers/Api/IncidentController.php
@@ -321,7 +321,7 @@ class IncidentController extends AbstractApiController
      *   @SWG\Parameter(
      *     name="occured_at",
      *     in="formData",
-     *     type="date",
+     *     type="string",
      *     description="The date when the incident occured.",
      *     required=true
      *   ),
@@ -356,7 +356,8 @@ class IncidentController extends AbstractApiController
      *   @SWG\Parameter(
      *     name="vars",
      *     in="formData",
-     *     type="string[]",
+     *     type="array",
+     *     items="string",
      *     description="The variables to give to the template.",
      *     required=false
      *   ),

--- a/app/Http/Controllers/Api/IncidentController.php
+++ b/app/Http/Controllers/Api/IncidentController.php
@@ -31,14 +31,49 @@ class IncidentController extends AbstractApiController
     /**
      * Get all incidents.
      *
-     * The following searchable keys are available:
-     * - `id`
-     * - `component_id`
-     * - `name`
-     * - `status`
-     * - `visible`
-     *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Get(
+     *   path="/incidents",
+     *   summary="List all incidents.",
+     *   operationId="Incident@index",
+     *   tags={"Incidents"},
+     *   produces={"application/json"}, 
+     *   @SWG\Parameter(
+     *     description="Minimum visibility of the incidents.",
+     *     in="query",
+     *     name="visible",
+     *     required=false,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Parameter(
+     *     description="The field on which sort the results.",
+     *     in="query",
+     *     name="sort",
+     *     required=false,
+     *     type="string"
+     *   ),
+     *   @SWG\Parameter(
+     *     description="The direction on which sort the results. 'asc' or 'desc'.",
+     *     in="query",
+     *     name="order",
+     *     required=false,
+     *     type="string"
+     *   ),
+     *   @SWG\Parameter(
+     *     description="The number of items to get. Default to 20.",
+     *     in="query",
+     *     name="per_page",
+     *     required=false,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="A list with all incidents."
+     *   )
+     * )
      */
     public function index()
     {
@@ -62,15 +97,34 @@ class IncidentController extends AbstractApiController
     /**
      * Get a single incident.
      *
-     * **Path Params:**
-     * 
-     * Name | Type | Required | Description
-     * -----|------|------------|---------
-     * incident | int32 | Y | ID of the incident
-     *
      * @param \CachetHQ\Cachet\Models\Incident $incident
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Get(
+     *   path="/incidents/{incident}",
+     *   summary="Get a single incident.",
+     *   description="",
+     *   operationId="Incident@show",
+     *   produces={"application/json"},
+     *   tags={"Incidents"},
+     *   @SWG\Parameter(
+     *     name="incident",
+     *     in="path",
+     *     description="The incident identifier.",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="The incident."
+     *   ),
+     *   @SWG\Response(
+     *     response="404",
+     *     description="Incident not found."
+     *   )
+     * )
      */
     public function show(Incident $incident)
     {
@@ -80,23 +134,108 @@ class IncidentController extends AbstractApiController
     /**
      * Create a new incident.
      *
-     * **Body params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|------------|----------
-     * name | string | Y | Name of the incident
-     * message | string | Y | A message (supporting Markdown) to explain more
-     * status | int32 | Y | Status of the incident
-     * component_id | int32 | Y | Component to update (required with component_status)
-     * component_status | int32 | Y | The status to update the given component with
-     * visible | int32 | N | Whether the incident is publicly visible
-     * notify | boolean | N | Whether to notify subscribers
-     * stickied | boolean | N |Should the incident be stickied
-     * template | string | The template slug to use
-     * vars | string[] | N | The variables to pass to the template
-     * meta | string[] | N | The meta
-     *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Post(
+     *   path="/incidents",
+     *   tags={"Incidents"},
+     *   operationId="Incident@store",
+     *   summary="Add a new incident.",
+     *   description="",
+     *   consumes={"multipart/form-data"},
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     name="name",
+     *     in="formData",
+     *     type="string",
+     *     description="Name of the incident.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="message",
+     *     in="formData",
+     *     type="string",
+     *     description="A message (supporting Markdown) to explain more.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="status",
+     *     in="formData",
+     *     type="integer",
+     *     description="Status of the incident.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="component_id",
+     *     in="formData",
+     *     type="integer",
+     *     description="Component to update.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="component_status",
+     *     in="formData",
+     *     type="integer",
+     *     description="The status to update the given component with.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="occured_at",
+     *     in="formData",
+     *     type="string",
+     *     description="The date/time when the incident occured.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="template",
+     *     in="formData",
+     *     type="string",
+     *     description="The templace slug to use.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="notify",
+     *     in="formData",
+     *     type="boolean",
+     *     description="Whether to notify subscribers. Default true.",
+     *     required=false
+     *   ),
+     *   @SWG\Parameter(
+     *     name="stickied",
+     *     in="formData",
+     *     type="integer",
+     *     description="Should the incident be stickied? Default false.",
+     *     required=false
+     *   ),
+     *   @SWG\Parameter(
+     *     name="vars",
+     *     in="formData",
+     *     type="array",
+     *     description="",
+     *     required=false,
+     *     @SWG\Items(
+     *       type="string"
+     *     )
+     *   ),
+     *   @SWG\Parameter(
+     *     name="meta",
+     *     in="formData",
+     *     type="array",
+     *     description="",
+     *     required=false,
+     *     @SWG\Items(
+     *       type="string"
+     *     )
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="The incident."
+     *   ),
+     *   @SWG\Response(
+     *     response=400,
+     *     description="Invalid incident."
+     *   )
+     * )
      */
     public function store()
     {
@@ -125,31 +264,112 @@ class IncidentController extends AbstractApiController
     /**
      * Update an existing incident.
      *
-     * **Path params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|----------|------------
-     * incident | int32 | Y | ID of the incident
-     *
-     * **Body params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|----------|------------
-     * name | string | Y | Name of the incident
-     * message | string | Y | A message (supporting Markdown) to explain more
-     * status | int32 | Y | Status of the incident
-     * component_id | int32 | Y | Component to update (required for component_status)
-     * component_status | int32 | Y | The status to update the given component with
-     * occured_at | date | Y | When the incident occured
-     * template | int32 | Y | The template ID
-     * visible | int32 | N |Whether the incident is publicly visible
-     * notify | boolean | N | Whether to notify subscribers
-     * stickied | boolean | N | Whether the incident should be stikied
-     * vars | string[] | N | The variables to pass to the template
-     *
      * @param \CachetHQ\Cachet\Models\Incident $incident
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Put(
+     *   path="/incidents/{incident}",
+     *   tags={"Incidents"},
+     *   operationId="Incident@update",
+     *   summary="Update an existing incident.",
+     *   description="",
+     *   consumes={"multipart/form-data"},
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     name="incident",
+     *     in="path",
+     *     type="integer",
+     *     description="Identifier of the incident to update.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="name",
+     *     in="formData",
+     *     type="string",
+     *     description="Name of the incident.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *      name="message",
+     *      in="formData",
+     *      type="string",
+     *      description="A message (supporting Markdown) to explain more",
+     *      required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="status",
+     *     in="formData",
+     *     type="integer",
+     *     description="Status of the incident.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="component_id",
+     *     in="formData",
+     *     type="integer",
+     *     description="The ID of the component to update.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="component_status",
+     *     in="formData",
+     *     type="integer",
+     *     description="The status to update the component with.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="occured_at",
+     *     in="formData",
+     *     type="date",
+     *     description="The date when the incident occured.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="template",
+     *     in="formData",
+     *     type="integer",
+     *     description="The template identifier",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="visible",
+     *     in="formData",
+     *     type="integer",
+     *     description="Whether the incident should be visible.",
+     *     required=false
+     *   ),
+     *   @SWG\Parameter(
+     *     name="notify",
+     *     in="formData",
+     *     type="boolean",
+     *     description="Whether to notify the subscribers.",
+     *     required=false
+     *   ),
+     *   @SWG\Parameter(
+     *     name="stickied",
+     *     in="formData",
+     *     type="boolean",
+     *     description="Whether the incident should be stickied.",
+     *     required=false
+     *   ),
+     *   @SWG\Parameter(
+     *     name="vars",
+     *     in="formData",
+     *     type="string[]",
+     *     description="The variables to give to the template.",
+     *     required=false
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="The incident."
+     *   ),
+     *   @SWG\Response(
+     *     response=400,
+     *     description="Invalid incident."
+     *   )
+     * )
+
      */
     public function update(Incident $incident)
     {
@@ -178,15 +398,29 @@ class IncidentController extends AbstractApiController
     /**
      * Delete an existing incident.
      *
-     * **Path params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|---------|-------------
-     * incident | int32 | Y | Incident ID
-     *
      * @param \CachetHQ\Cachet\Models\Incident $incident
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Delete(
+     *   path="/incidents/{incident}",
+     *   summary="Deletes an incident.",
+     *   description="",
+     *   operationId="Incident@destroy",
+     *   tags={"Incidents"},
+     *   @SWG\Parameter(
+     *     description="Incident id to delete.",
+     *     in="path",
+     *     name="incident",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Response(
+     *     response=204,
+     *     description="Ok."
+     *   ),
+     * )
      */
     public function destroy(Incident $incident)
     {

--- a/app/Http/Controllers/Api/IncidentController.php
+++ b/app/Http/Controllers/Api/IncidentController.php
@@ -21,10 +21,23 @@ use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
+/**
+ * The incident API controller.
+ *
+ * @resource Incident
+ */
 class IncidentController extends AbstractApiController
 {
     /**
      * Get all incidents.
+     *
+     * The following searchable keys are available:
+     * - `id`
+     * - `component_id`
+     * - `name`
+     * - `status`
+     * - `visible`
+     * - 
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -50,6 +63,12 @@ class IncidentController extends AbstractApiController
     /**
      * Get a single incident.
      *
+     * **Path Params:**
+     * 
+     * Name | Type | Required | Description
+     * -----|------|------------
+     * incident | int32 | Y | ID of the incident
+     *
      * @param \CachetHQ\Cachet\Models\Incident $incident
      *
      * @return \Illuminate\Http\JsonResponse
@@ -61,6 +80,22 @@ class IncidentController extends AbstractApiController
 
     /**
      * Create a new incident.
+     *
+     * **Body params:**
+     *
+     * Name | Type | Required | Description
+     * -----|------|------------
+     * name | string | Y | Name of the incident
+     * message | string | Y | A message (supporting Markdown) to explain more
+     * status | int32 | Y | Status of the incident
+     * component_id | int32 | Y | Component to update (required with component_status)
+     * component_status | int32 | Y | The status to update the given component with
+     * visible | int32 | N | Whether the incident is publicly visible
+     * notify | boolean | N | Whether to notify subscribers
+     * stickied | boolean | N |Should the incident be stickied
+     * template | string | The template slug to use
+     * vars | string[] | N | The variables to pass to the template
+     * meta | string[] | N | The meta
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -90,6 +125,26 @@ class IncidentController extends AbstractApiController
 
     /**
      * Update an existing incident.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * incident | int32 | Y | ID of the incident
+     *
+     * **Body params:**
+     *
+     * Name | Type | Required | Description
+     * name | string | Y | Name of the incident
+     * message | string | Y | A message (supporting Markdown) to explain more
+     * status | int32 | Y | Status of the incident
+     * component_id | int32 | Y | Component to update (required for component_status)
+     * component_status | int32 | Y | The status to update the given component with
+     * occured_at | date | Y | When the incident occured
+     * template | int32 | Y | The template ID
+     * visible | int32 | N |Whether the incident is publicly visible
+     * notify | boolean | N | Whether to notify subscribers
+     * stickied | boolean | N | Whether the incident should be stikied
+     * vars | string[] | N | The variables to pass to the template
      *
      * @param \CachetHQ\Cachet\Models\Incident $incident
      *
@@ -121,6 +176,11 @@ class IncidentController extends AbstractApiController
 
     /**
      * Delete an existing incident.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * incident | int32 | Y | Incident ID
      *
      * @param \CachetHQ\Cachet\Models\Incident $incident
      *

--- a/app/Http/Controllers/Api/IncidentController.php
+++ b/app/Http/Controllers/Api/IncidentController.php
@@ -37,7 +37,6 @@ class IncidentController extends AbstractApiController
      * - `name`
      * - `status`
      * - `visible`
-     * - 
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -66,7 +65,7 @@ class IncidentController extends AbstractApiController
      * **Path Params:**
      * 
      * Name | Type | Required | Description
-     * -----|------|------------
+     * -----|------|------------|---------
      * incident | int32 | Y | ID of the incident
      *
      * @param \CachetHQ\Cachet\Models\Incident $incident
@@ -84,7 +83,7 @@ class IncidentController extends AbstractApiController
      * **Body params:**
      *
      * Name | Type | Required | Description
-     * -----|------|------------
+     * -----|------|------------|----------
      * name | string | Y | Name of the incident
      * message | string | Y | A message (supporting Markdown) to explain more
      * status | int32 | Y | Status of the incident
@@ -129,11 +128,13 @@ class IncidentController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * incident | int32 | Y | ID of the incident
      *
      * **Body params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * name | string | Y | Name of the incident
      * message | string | Y | A message (supporting Markdown) to explain more
      * status | int32 | Y | Status of the incident
@@ -180,6 +181,7 @@ class IncidentController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|---------|-------------
      * incident | int32 | Y | Incident ID
      *
      * @param \CachetHQ\Cachet\Models\Incident $incident

--- a/app/Http/Controllers/Api/IncidentUpdateController.php
+++ b/app/Http/Controllers/Api/IncidentUpdateController.php
@@ -36,6 +36,7 @@ class IncidentUpdateController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * incident | int32 | Y | Incident ID
      *
      * @param \CachetHQ\Cachet\Models\Incident $incident
@@ -63,6 +64,7 @@ class IncidentUpdateController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|-------------
      * incident | int32 | Y | Incident ID
      * update | int32 | Y | Incident update ID
      *
@@ -82,11 +84,13 @@ class IncidentUpdateController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * incident | int32 | Y | Incident ID
      *
      * **Query params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * status | int32 | Y | Incident status level
      * message | string | Y | Incident update text
      * component_id | int32 | Y | Component id
@@ -120,12 +124,14 @@ class IncidentUpdateController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * incident | int32 | Y | The incident the update belongs to
      * update | int32 | Y | The incident update id
      *
      * **Query params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * status | int32 | Y | The incident status flag
      * message | string | Y | The update message
      *
@@ -156,6 +162,7 @@ class IncidentUpdateController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * incident | int32 | Y | Incident the update belongs to
      * update | int32 | Y | The incident update ID to delete
      *

--- a/app/Http/Controllers/Api/IncidentUpdateController.php
+++ b/app/Http/Controllers/Api/IncidentUpdateController.php
@@ -26,11 +26,17 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  * This is the incident update controller.
  *
  * @author James Brooks <james@alt-three.com>
+ * @resource IncidentUpdate
  */
 class IncidentUpdateController extends AbstractApiController
 {
     /**
-     * Return all updates on the incident.
+     * Return all updates for the incident.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * incident | int32 | Y | Incident ID
      *
      * @param \CachetHQ\Cachet\Models\Incident $incident
      *
@@ -54,6 +60,12 @@ class IncidentUpdateController extends AbstractApiController
     /**
      * Return a single incident update.
      *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * incident | int32 | Y | Incident ID
+     * update | int32 | Y | Incident update ID
+     *
      * @param \CachetHQ\Cachet\Models\Incident       $incident
      * @param \CachetHQ\Cachet\Models\IncidentUpdate $update
      *
@@ -66,6 +78,19 @@ class IncidentUpdateController extends AbstractApiController
 
     /**
      * Create a new incident update.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * incident | int32 | Y | Incident ID
+     *
+     * **Query params:**
+     *
+     * Name | Type | Required | Description
+     * status | int32 | Y | Incident status level
+     * message | string | Y | Incident update text
+     * component_id | int32 | Y | Component id
+     * component_status | int32 | Y | Component status
      *
      * @param \CachetHQ\Cachet\Models\Incident $incident
      *
@@ -92,6 +117,18 @@ class IncidentUpdateController extends AbstractApiController
     /**
      * Update an incident update.
      *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * incident | int32 | Y | The incident the update belongs to
+     * update | int32 | Y | The incident update id
+     *
+     * **Query params:**
+     *
+     * Name | Type | Required | Description
+     * status | int32 | Y | The incident status flag
+     * message | string | Y | The update message
+     *
      * @param \CachetHQ\Cachet\Models\Incident       $incident
      * @param \CachetHQ\Cachet\Models\IncidentUpdate $update
      *
@@ -115,6 +152,12 @@ class IncidentUpdateController extends AbstractApiController
 
     /**
      * Create a new incident update.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * incident | int32 | Y | Incident the update belongs to
+     * update | int32 | Y | The incident update ID to delete
      *
      * @param \CachetHQ\Cachet\Models\Incident       $incident
      * @param \CachetHQ\Cachet\Models\IncidentUpdate $update

--- a/app/Http/Controllers/Api/IncidentUpdateController.php
+++ b/app/Http/Controllers/Api/IncidentUpdateController.php
@@ -33,15 +33,29 @@ class IncidentUpdateController extends AbstractApiController
     /**
      * Return all updates for the incident.
      *
-     * **Path params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|----------|------------
-     * incident | int32 | Y | Incident ID
-     *
      * @param \CachetHQ\Cachet\Models\Incident $incident
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Get(
+     *   path="/incidents/{incident}/updates",
+     *   summary="List all updates for a component.",
+     *   operationId="IncidentUpdates@index",
+     *   tags={"IncidentUpdates"},
+     *   produces={"application/json"}, 
+     *   @SWG\Parameter(
+     *     description="ID of the incident to filter the updates.",
+     *     in="path",
+     *     name="incident",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="A list with all incident updates for the given incident."
+     *   )
+     * )
      */
     public function index(Incident $incident)
     {
@@ -61,17 +75,37 @@ class IncidentUpdateController extends AbstractApiController
     /**
      * Return a single incident update.
      *
-     * **Path params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|----------|-------------
-     * incident | int32 | Y | Incident ID
-     * update | int32 | Y | Incident update ID
-     *
      * @param \CachetHQ\Cachet\Models\Incident       $incident
      * @param \CachetHQ\Cachet\Models\IncidentUpdate $update
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Get(
+     *   path="/incidents/{incident}/updates/{update}",
+     *   summary="Get a single incident update.",
+     *   tags={"IncidentUpdates"},
+     *   operationId="IncidentUpdates@show",
+     *   @SWG\Parameter(
+     *     description="ID of incident.",
+     *     in="path",
+     *     name="incident",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
+     *  ),
+     *  @SWG\Parameter(
+     *     description="ID of update.",
+     *     in="path",
+     *     name="update",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
+     *  ),
+     *  @SWG\Response(
+     *     response=200,
+     *     description="A single incident update."
+     *   )
+     * )
      */
     public function show(Incident $incident, IncidentUpdate $update)
     {
@@ -81,24 +115,62 @@ class IncidentUpdateController extends AbstractApiController
     /**
      * Create a new incident update.
      *
-     * **Path params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|----------|------------
-     * incident | int32 | Y | Incident ID
-     *
-     * **Query params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|----------|------------
-     * status | int32 | Y | Incident status level
-     * message | string | Y | Incident update text
-     * component_id | int32 | Y | Component id
-     * component_status | int32 | Y | Component status
-     *
      * @param \CachetHQ\Cachet\Models\Incident $incident
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Post(
+     *   path="/incidents/{incident}",
+     *   tags={"IncidentUpdates"},
+     *   operationId="IncidentUpdates@store",
+     *   summary="Add a new incident update.",
+     *   description="",
+     *   consumes={"multipart/form-data"},
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     name="incident",
+     *     in="path",
+     *     type="integer",
+     *     description="ID of the incident.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="status",
+     *     in="formData",
+     *     type="integer",
+     *     description="Incident status level.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="message",
+     *     in="formData",
+     *     type="string",
+     *     description="Incident update text.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="component_id",
+     *     in="formData",
+     *     type="integer",
+     *     description="The ID of the component to update.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="component_status",
+     *     in="formData",
+     *     type="integer",
+     *     description="The component status.",
+     *     required=true
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="The incident update."
+     *   ),
+     *   @SWG\Response(
+     *     response=400,
+     *     description="Invalid incident update."
+     *   )
+     * )
      */
     public function store(Incident $incident)
     {
@@ -121,24 +193,56 @@ class IncidentUpdateController extends AbstractApiController
     /**
      * Update an incident update.
      *
-     * **Path params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|----------|------------
-     * incident | int32 | Y | The incident the update belongs to
-     * update | int32 | Y | The incident update id
-     *
-     * **Query params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|----------|------------
-     * status | int32 | Y | The incident status flag
-     * message | string | Y | The update message
-     *
      * @param \CachetHQ\Cachet\Models\Incident       $incident
      * @param \CachetHQ\Cachet\Models\IncidentUpdate $update
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Put(
+     *   path="/incidents/{incident}/updates/{update}",
+     *   tags={"IncidentUpdates"},
+     *   operationId="IncidentUpdates@update",
+     *   summary="Update an existing incident update.",
+     *   description="",
+     *   consumes={"multipart/form-data"},
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     name="incident",
+     *     in="path",
+     *     type="integer",
+     *     description="Identifier of the incident.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="update",
+     *     in="path",
+     *     type="integer",
+     *     description="Identifier of the update.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="status",
+     *     in="formData",
+     *     type="string",
+     *     description="The incident status flag.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="message",
+     *     in="formData",
+     *     type="string",
+     *     description="The incident update text.",
+     *     required=true
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="The incident update."
+     *   ),
+     *   @SWG\Response(
+     *     response=400,
+     *     description="Invalid incident update."
+     *   )
+     * )
      */
     public function update(Incident $incident, IncidentUpdate $update)
     {
@@ -159,17 +263,38 @@ class IncidentUpdateController extends AbstractApiController
     /**
      * Create a new incident update.
      *
-     * **Path params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|----------|------------
-     * incident | int32 | Y | Incident the update belongs to
-     * update | int32 | Y | The incident update ID to delete
-     *
      * @param \CachetHQ\Cachet\Models\Incident       $incident
      * @param \CachetHQ\Cachet\Models\IncidentUpdate $update
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Delete(
+     *   path="/incidents/{incident}/updates/{update}",
+     *   summary="Deletes an incident update.",
+     *   description="",
+     *   operationId="IncidentUpdates@destroy",
+     *   tags={"IncidentUpdates"},
+     *   @SWG\Parameter(
+     *     description="Incident id.",
+     *     in="path",
+     *     name="incident",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Parameter(
+     *     description="Incident update to delete.",
+     *     in="path",
+     *     name="update",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Response(
+     *     response=204,
+     *     description="Ok."
+     *   ),
+     * )
      */
     public function destroy(Incident $incident, IncidentUpdate $update)
     {

--- a/app/Http/Controllers/Api/MetricController.php
+++ b/app/Http/Controllers/Api/MetricController.php
@@ -31,6 +31,34 @@ class MetricController extends AbstractApiController
      * Get all metrics.
      *
      * @return \Illuminate\Database\Eloquent\Collection
+     *
+     * @SWG\Get(
+     *   path="/metrics",
+     *   summary="List all metrics.",
+     *   operationId="Metric@index",
+     *   tags={"Metrics"},
+     *   produces={"application/json"}, 
+     *   @SWG\Parameter(
+     *     description="Attribute name on which apply 'order'.",
+     *     in="query",
+     *     name="sort",
+     *     required=false,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Parameter(
+     *     description="Order in which order the results, ASC or DESC.",
+     *     in="query",
+     *     name="order",
+     *     required=false,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="A list with all metrics."
+     *   )
+     * )
      */
     public function index()
     {
@@ -50,15 +78,28 @@ class MetricController extends AbstractApiController
     /**
      * Get a single metric.
      *
-     * **Path params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|----------|------------
-     * metric | int32 | Y | Metric ID
-     *
      * @param \CachetHQ\Cachet\Models\Metric $metric
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Get(
+     *   path="/metrics/{metric}",
+     *   summary="Get a single metric.",
+     *   tags={"Metrics"},
+     *   operationId="Metric@show",
+     *   @SWG\Parameter(
+     *     description="ID of metric to return.",
+     *     in="path",
+     *     name="metric",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
+     *  ),
+     *  @SWG\Response(
+     *     response=200,
+     *     description="A single metric."
+     *   )
+     * )
      */
     public function show(Metric $metric)
     {
@@ -68,22 +109,95 @@ class MetricController extends AbstractApiController
     /**
      * Create a new metric.
      *
-     * **Body params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|----------|------------
-     * name | string | Y | Name of metric
-     * suffix | string | Y | Measurments in
-     * description | string | Y | Description of what the metric is measuring
-     * default_value | int32 | Y | The default value to use when a point is added
-     * display_chart | int32 | Y | Whether to display the chart on the status page
-     * calc_type | int32 | N | The calc type. 0 for sum, 1 for average
-     * default_view | int32 | N | The default view
-     * threshold | int32 | N | The threshold
-     * order | int32 | N | The order
-     * visible | int32 | N | Whether the graph should be visible
-     *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Post(
+     *   path="/metrics",
+     *   tags={"Metrics"},
+     *   operationId="Metric@store",
+     *   summary="Add a new metric.",
+     *   description="",
+     *   consumes={"multipart/form-data"},
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     name="name",
+     *     in="formData",
+     *     type="string",
+     *     description="Name of the metric.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="suffix",
+     *     in="formData",
+     *     type="string",
+     *     description="Measurments in. Usually '%', 'ms' for example.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="description",
+     *     in="formData",
+     *     type="string",
+     *     description="Description of the metric.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="default_value",
+     *     in="formData",
+     *     type="integer",
+     *     description="The default value when a point is added.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="display_chart",
+     *     in="formData",
+     *     type="integer",
+     *     description="Whether to display the chart on the status page.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="calc_type",
+     *     in="formData",
+     *     type="integer",
+     *     description="The calc type. 0 for sum, 1 for average. Default 0.",
+     *     required=false
+     *   ),
+     *   @SWG\Parameter(
+     *     name="default_view",
+     *     in="formData",
+     *     type="integer",
+     *     description="The default view (24h, week, ...). Default 24h.",
+     *     required=false
+     *   ),
+     *   @SWG\Parameter(
+     *     name="threshold",
+     *     in="formData",
+     *     type="integer",
+     *     description="The threshold. Default 5.",
+     *     required=false
+     *   ),
+     *   @SWG\Parameter(
+     *     name="order",
+     *     in="formData",
+     *     type="integer",
+     *     description="The order.",
+     *     required=false
+     *   ),
+     *   @SWG\Parameter(
+     *     name="visible",
+     *     in="formData",
+     *     type="integer",
+     *     description="Whether the graph should be visible. Default visible.",
+     *     required=false
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="The metric."
+     *   ),
+     *   @SWG\Response(
+     *     response=400,
+     *     description="Invalid metric."
+     *   )
+     * )
      */
     public function store()
     {
@@ -111,31 +225,97 @@ class MetricController extends AbstractApiController
     /**
      * Update an existing metric.
      *
-     * **Path params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|----------|------------
-     * metric | int32 | Y | Metric ID
-     *
-     * **Body params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|----------|------------
-     * name | string | Y | Name of metric
-     * suffix | string | Y | Measurments in
-     * description | string | Y | Description of what the metric is measuring
-     * default_value | int32 | Y | The default value to use when a point is added
-     * display_chart | int32 | Y | Whether to display the chart on the status page
-     * calc_type | int32 | Y | Metric type. 0 for sum, 1 for average
-     * places | int32 | Y | Decimal places
-     * threshold | int32 | Y | Number of minutes of threshold between metric points
-     * order | int32 | Y | The order of the metric
-     * visible | int32 | Y | Whether the metrics should be visible on the status page
-     * default_view | int32 | N | The default view
-     *
      * @param \CachetHQ\Cachet\Models\Metric $metric
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Put(
+     *   path="/metrics/{metric}",
+     *   tags={"Metrics"},
+     *   operationId="Metric@update",
+     *   summary="update a metric.",
+     *   description="",
+     *   consumes={"multipart/form-data"},
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     name="name",
+     *     in="formData",
+     *     type="string",
+     *     description="Name of the metric.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="suffix",
+     *     in="formData",
+     *     type="string",
+     *     description="Measurments in. Usually '%', 'ms' for example.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="description",
+     *     in="formData",
+     *     type="string",
+     *     description="Description of the metric.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="default_value",
+     *     in="formData",
+     *     type="integer",
+     *     description="The default value when a point is added.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="display_chart",
+     *     in="formData",
+     *     type="integer",
+     *     description="Whether to display the chart on the status page.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="calc_type",
+     *     in="formData",
+     *     type="integer",
+     *     description="The calc type. 0 for sum, 1 for average.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="default_view",
+     *     in="formData",
+     *     type="integer",
+     *     description="The default view (24h, week, ...). Default 24h.",
+     *     required=false
+     *   ),
+     *   @SWG\Parameter(
+     *     name="threshold",
+     *     in="formData",
+     *     type="integer",
+     *     description="The threshold.",
+     *     required=true
+     *   ),
+     *   @SWG\Parameter(
+     *     name="order",
+     *     in="formData",
+     *     type="integer",
+     *     description="The order.",
+     *     required=false
+     *   ),
+     *   @SWG\Parameter(
+     *     name="visible",
+     *     in="formData",
+     *     type="integer",
+     *     description="Whether the graph should be visible.",
+     *     required=true
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="The metric."
+     *   ),
+     *   @SWG\Response(
+     *     response=400,
+     *     description="Invalid metric."
+     *   )
+     * )
      */
     public function update(Metric $metric)
     {
@@ -164,15 +344,29 @@ class MetricController extends AbstractApiController
     /**
      * Delete an existing metric.
      *
-     * **Path params:**
-     *
-     * Name | Type | Required | Description
-     * -----|------|----------|------------
-     * metric | int32 | Required | int32
-     *
      * @param \CachetHQ\Cachet\Models\Metric $metric
      *
      * @return \Illuminate\Http\JsonResponse
+     *
+     * @SWG\Delete(
+     *   path="/metrics/{metric}",
+     *   summary="Deletes a metric.",
+     *   description="",
+     *   operationId="Metric@destroy",
+     *   tags={"Metrics"},
+     *   @SWG\Parameter(
+     *     description="Metric ID to delete.",
+     *     in="path",
+     *     name="metric",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Response(
+     *     response=204,
+     *     description="Ok."
+     *   ),
+     * )
      */
     public function destroy(Metric $metric)
     {

--- a/app/Http/Controllers/Api/MetricController.php
+++ b/app/Http/Controllers/Api/MetricController.php
@@ -53,6 +53,7 @@ class MetricController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * metric | int32 | Y | Metric ID
      *
      * @param \CachetHQ\Cachet\Models\Metric $metric
@@ -70,6 +71,7 @@ class MetricController extends AbstractApiController
      * **Body params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * name | string | Y | Name of metric
      * suffix | string | Y | Measurments in
      * description | string | Y | Description of what the metric is measuring
@@ -112,11 +114,13 @@ class MetricController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * metric | int32 | Y | Metric ID
      *
      * **Body params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * name | string | Y | Name of metric
      * suffix | string | Y | Measurments in
      * description | string | Y | Description of what the metric is measuring
@@ -163,6 +167,7 @@ class MetricController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * metric | int32 | Required | int32
      *
      * @param \CachetHQ\Cachet\Models\Metric $metric

--- a/app/Http/Controllers/Api/MetricController.php
+++ b/app/Http/Controllers/Api/MetricController.php
@@ -20,6 +20,11 @@ use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
+/**
+ * The Metric API controller.
+ *
+ * @resource Metric
+ */
 class MetricController extends AbstractApiController
 {
     /**
@@ -45,6 +50,11 @@ class MetricController extends AbstractApiController
     /**
      * Get a single metric.
      *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * metric | int32 | Y | Metric ID
+     *
      * @param \CachetHQ\Cachet\Models\Metric $metric
      *
      * @return \Illuminate\Http\JsonResponse
@@ -56,6 +66,20 @@ class MetricController extends AbstractApiController
 
     /**
      * Create a new metric.
+     *
+     * **Body params:**
+     *
+     * Name | Type | Required | Description
+     * name | string | Y | Name of metric
+     * suffix | string | Y | Measurments in
+     * description | string | Y | Description of what the metric is measuring
+     * default_value | int32 | Y | The default value to use when a point is added
+     * display_chart | int32 | Y | Whether to display the chart on the status page
+     * calc_type | int32 | N | The calc type. 0 for sum, 1 for average
+     * default_view | int32 | N | The default view
+     * threshold | int32 | N | The threshold
+     * order | int32 | N | The order
+     * visible | int32 | N | Whether the graph should be visible
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -84,6 +108,26 @@ class MetricController extends AbstractApiController
 
     /**
      * Update an existing metric.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * metric | int32 | Y | Metric ID
+     *
+     * **Body params:**
+     *
+     * Name | Type | Required | Description
+     * name | string | Y | Name of metric
+     * suffix | string | Y | Measurments in
+     * description | string | Y | Description of what the metric is measuring
+     * default_value | int32 | Y | The default value to use when a point is added
+     * display_chart | int32 | Y | Whether to display the chart on the status page
+     * calc_type | int32 | Y | Metric type. 0 for sum, 1 for average
+     * places | int32 | Y | Decimal places
+     * threshold | int32 | Y | Number of minutes of threshold between metric points
+     * order | int32 | Y | The order of the metric
+     * visible | int32 | Y | Whether the metrics should be visible on the status page
+     * default_view | int32 | N | The default view
      *
      * @param \CachetHQ\Cachet\Models\Metric $metric
      *
@@ -115,6 +159,11 @@ class MetricController extends AbstractApiController
 
     /**
      * Delete an existing metric.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * metric | int32 | Required | int32
      *
      * @param \CachetHQ\Cachet\Models\Metric $metric
      *

--- a/app/Http/Controllers/Api/MetricPointController.php
+++ b/app/Http/Controllers/Api/MetricPointController.php
@@ -21,10 +21,20 @@ use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
+/**
+ * The MetricPoint API controller.
+ *
+ * @resource MetricPoint
+ */
 class MetricPointController extends AbstractApiController
 {
     /**
-     * Get a single metric point.
+     * Get all point for a metric.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * metric | int32 | Y | Metric ID
      *
      * @param \CachetHQ\Cachet\Models\Metric      $metric
      * @param \CachetHQ\Cachet\Models\MetricPoint $metricPoint
@@ -40,6 +50,17 @@ class MetricPointController extends AbstractApiController
 
     /**
      * Create a new metric point.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * metric | int32 | Y | Metric ID
+     *
+     * **Body params:**
+     *
+     * Name | Type | Required | Description
+     * value | double | Y | Value to plot on the metric graph
+     * timestamp | string | Y | Unix timestamp of when the point was measured
      *
      * @param \CachetHQ\Cachet\Models\Metric $metric
      *
@@ -63,6 +84,18 @@ class MetricPointController extends AbstractApiController
     /**
      * Updates a metric point.
      *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * metric | int32 | Y | Metric ID
+     * metric_point | int32 | Y | Metric point ID
+     *
+     * **Body params:**
+     *
+     * Name | Type | Required | Description
+     * value | double | Y | The value to plot on the metric graph
+     * timestamp | string | Y | Unix timestamp of when the point was measured
+     *
      * @param \CachetHQ\Cachet\Models\Metric      $metric
      * @param \CachetHQ\Cachet\Models\MetircPoint $metricPoint
      *
@@ -82,6 +115,12 @@ class MetricPointController extends AbstractApiController
 
     /**
      * Destroys a metric point.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * metric | int32 | Y | Metric ID
+     * point | int32 | Y | Metric point ID
      *
      * @param \CachetHQ\Cachet\Models\Metric      $metric
      * @param \CachetHQ\Cachet\Models\MetricPoint $metricPoint

--- a/app/Http/Controllers/Api/MetricPointController.php
+++ b/app/Http/Controllers/Api/MetricPointController.php
@@ -34,6 +34,7 @@ class MetricPointController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * metric | int32 | Y | Metric ID
      *
      * @param \CachetHQ\Cachet\Models\Metric      $metric
@@ -54,11 +55,13 @@ class MetricPointController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * metric | int32 | Y | Metric ID
      *
      * **Body params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * value | double | Y | Value to plot on the metric graph
      * timestamp | string | Y | Unix timestamp of when the point was measured
      *
@@ -87,12 +90,14 @@ class MetricPointController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * metric | int32 | Y | Metric ID
      * metric_point | int32 | Y | Metric point ID
      *
      * **Body params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * value | double | Y | The value to plot on the metric graph
      * timestamp | string | Y | Unix timestamp of when the point was measured
      *
@@ -119,6 +124,7 @@ class MetricPointController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * metric | int32 | Y | Metric ID
      * point | int32 | Y | Metric point ID
      *

--- a/app/Http/Controllers/Api/ScheduleController.php
+++ b/app/Http/Controllers/Api/ScheduleController.php
@@ -21,9 +21,11 @@ use Illuminate\Support\Facades\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
- * This is the schedule controller.
+ * This is the schedule API controller.
  *
  * @author James Brooks <james@alt-three.com>
+ * 
+ * @resource Schedule
  */
 class ScheduleController extends AbstractApiController
 {
@@ -50,6 +52,11 @@ class ScheduleController extends AbstractApiController
     /**
      * Return a single schedule.
      *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * schedule | int32 | Y | Schedule ID
+     *
      * @param \CachetHQ\Cachet\Models\Schedule $schedule
      *
      * @return \Illuminate\Http\JsonResponse
@@ -61,6 +68,16 @@ class ScheduleController extends AbstractApiController
 
     /**
      * Create a new schedule.
+     *
+     * **Body params:**
+     *
+     * Name | Type | Required | Description
+     * name | string | Y | Schedule name
+     * message | string | Y | Schedule message
+     * status | int32 | Y | Schedule status
+     * scheduled_at | date | Y | Date of the schedule
+     * completed_at | date | Y | Date when the scheduled is completed
+     * components | int[] | N | Components concerned by schedule
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -84,6 +101,21 @@ class ScheduleController extends AbstractApiController
 
     /**
      * Update a schedule.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * schedule | int32 | Y | Schedule ID
+     *
+     * **Body params:**
+     *
+     * Name | Type | Required  | Description
+     * name | string | Y | Schedule name 
+     * message | string | Y | Schedule message
+     * status | int32 | Y | Schedule status
+     * scheduled_at |  date | Y | Schedule date
+     * completed_at | date | Y | Date when the schedule is completed
+     * components | int32 | N |Components concerned by the schedule
      *
      * @param \CachetHQ\Cachet\Models\Schedule $schedule
      *
@@ -110,6 +142,11 @@ class ScheduleController extends AbstractApiController
 
     /**
      * Delete a schedule.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * schedule | int32 | Y | Schedule ID
      *
      * @param \CachetHQ\Cachet\Models\Schedule $schedule
      *

--- a/app/Http/Controllers/Api/ScheduleController.php
+++ b/app/Http/Controllers/Api/ScheduleController.php
@@ -55,6 +55,7 @@ class ScheduleController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * schedule | int32 | Y | Schedule ID
      *
      * @param \CachetHQ\Cachet\Models\Schedule $schedule
@@ -72,6 +73,7 @@ class ScheduleController extends AbstractApiController
      * **Body params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * name | string | Y | Schedule name
      * message | string | Y | Schedule message
      * status | int32 | Y | Schedule status
@@ -105,11 +107,13 @@ class ScheduleController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * schedule | int32 | Y | Schedule ID
      *
      * **Body params:**
      *
-     * Name | Type | Required  | Description
+     * Name | Type | Required | Description
+     * -----|------|----------|------------
      * name | string | Y | Schedule name 
      * message | string | Y | Schedule message
      * status | int32 | Y | Schedule status
@@ -146,6 +150,7 @@ class ScheduleController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * schedule | int32 | Y | Schedule ID
      *
      * @param \CachetHQ\Cachet\Models\Schedule $schedule

--- a/app/Http/Controllers/Api/SubscriberController.php
+++ b/app/Http/Controllers/Api/SubscriberController.php
@@ -43,6 +43,13 @@ class SubscriberController extends AbstractApiController
     /**
      * Create a new subscriber.
      *
+     * **Body params:**
+     *
+     * Name | Type | Required | Description
+     * email | string | Y | The email to subscribe
+     * verify | boolean | N | Whether it's needed to verify the email
+     * components | int[] | N | The components the email is subscribing
+     *
      * @return \Illuminate\Http\JsonResponse
      */
     public function store()
@@ -60,6 +67,11 @@ class SubscriberController extends AbstractApiController
 
     /**
      * Delete a subscriber.
+     *
+     * **Path params:**
+     *
+     * Name | Type | Required | Description
+     * subscriber | int32 | Y | Subscriber ID
      *
      * @param \CachetHQ\Cachet\Models\Subscriber $subscriber
      *

--- a/app/Http/Controllers/Api/SubscriberController.php
+++ b/app/Http/Controllers/Api/SubscriberController.php
@@ -25,6 +25,8 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  *
  * @author James Brooks <james@alt-three.com>
  * @author Graham Campbell <graham@alt-three.com>
+ *
+ * @resource Subscriber
  */
 class SubscriberController extends AbstractApiController
 {
@@ -46,6 +48,7 @@ class SubscriberController extends AbstractApiController
      * **Body params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * email | string | Y | The email to subscribe
      * verify | boolean | N | Whether it's needed to verify the email
      * components | int[] | N | The components the email is subscribing
@@ -71,6 +74,7 @@ class SubscriberController extends AbstractApiController
      * **Path params:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * subscriber | int32 | Y | Subscriber ID
      *
      * @param \CachetHQ\Cachet\Models\Subscriber $subscriber

--- a/app/Http/Controllers/Api/SubscriptionController.php
+++ b/app/Http/Controllers/Api/SubscriptionController.php
@@ -18,6 +18,8 @@ use CachetHQ\Cachet\Models\Subscription;
  * This is the subscription controller class.
  *
  * @author James Brooks <james@alt-three.com>
+ *
+ * @resource Subscription
  */
 class SubscriptionController extends AbstractApiController
 {
@@ -27,6 +29,7 @@ class SubscriptionController extends AbstractApiController
      * **Path param:**
      *
      * Name | Type | Required | Description
+     * -----|------|----------|------------
      * subscription | int32 | Y | Subscribtion ID
      *
      * @param \CachetHQ\Cachet\Models\Subscription $subscription

--- a/app/Http/Controllers/Api/SubscriptionController.php
+++ b/app/Http/Controllers/Api/SubscriptionController.php
@@ -24,6 +24,11 @@ class SubscriptionController extends AbstractApiController
     /**
      * Delete a subscription.
      *
+     * **Path param:**
+     *
+     * Name | Type | Required | Description
+     * subscription | int32 | Y | Subscribtion ID
+     *
      * @param \CachetHQ\Cachet\Models\Subscription $subscription
      *
      * @return \Illuminate\Http\JsonResponse

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "aws/aws-sdk-php": "^3.7",
         "backup-manager/laravel": "dev-master#df53f9c9d8c6be5d7a2638f45d54b8fb7bc51e2b",
         "barryvdh/laravel-cors": "^0.8",
+        "darkaonline/l5-swagger": "~4.0",
         "doctrine/dbal": "2.5.13",
         "fideloper/proxy": "^3.1",
         "graham-campbell/binput": "^3.5",
@@ -48,13 +49,11 @@
         "laravel/framework": "^5.4",
         "laravel/tinker": "^1.0",
         "laravolt/avatar": "^1.8",
-        "mccool/laravel-auto-presenter": "^5.0",
         "nexmo/client": "@beta",
         "pragmarx/google2fa": "^0.7.1",
         "predis/predis": "^1.1",
         "roumen/feed": "^2.10",
-        "twig/twig": "^1.26.1",
-        "mpociot/laravel-apidoc-generator": "2.0"
+        "twig/twig": "^1.26.1"
     },
     "require-dev": {
         "ext-sqlite3": "*",

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
         "pragmarx/google2fa": "^0.7.1",
         "predis/predis": "^1.1",
         "roumen/feed": "^2.10",
-        "twig/twig": "^1.26.1"
+        "twig/twig": "^1.26.1",
+        "mpociot/laravel-apidoc-generator": "2.0"
     },
     "require-dev": {
         "ext-sqlite3": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -805,6 +805,37 @@
             "time": "2016-05-05T11:49:03+00:00"
         },
         {
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "homepage": "https://github.com/container-interop/container-interop",
+            "time": "2017-02-14T19:40:03+00:00"
+        },
+        {
             "name": "danielstjules/stringy",
             "version": "2.4.0",
             "source": {
@@ -1465,6 +1496,56 @@
                 "trusted proxy"
             ],
             "time": "2017-06-15T17:19:42+00:00"
+        },
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "^4.0 || ^5.0",
+                "squizlabs/php_codesniffer": "^1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2017-08-15T16:48:10+00:00"
         },
         {
             "name": "graham-campbell/binput",
@@ -2704,6 +2785,85 @@
             "time": "2017-01-01T12:52:59+00:00"
         },
         {
+            "name": "mnapoli/front-yaml",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mnapoli/FrontYAML.git",
+                "reference": "24070ace8b741247bb3161cbb38ecc541268b296"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mnapoli/FrontYAML/zipball/24070ace8b741247bb3161cbb38ecc541268b296",
+                "reference": "24070ace8b741247bb3161cbb38ecc541268b296",
+                "shasum": ""
+            },
+            "require": {
+                "erusev/parsedown": "~1.0",
+                "php": ">=5.4.0",
+                "symfony/yaml": "~2.1|^3.0|^4.0"
+            },
+            "require-dev": {
+                "league/commonmark": "~0.7",
+                "phpunit/phpunit": "~4.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Mni\\FrontYAML\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "time": "2017-10-29T19:29:55+00:00"
+        },
+        {
+            "name": "mnapoli/silly",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mnapoli/silly.git",
+                "reference": "807df4a844972ac74d07518c3a0aa9cb575b470b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mnapoli/silly/zipball/807df4a844972ac74d07518c3a0aa9cb575b470b",
+                "reference": "807df4a844972ac74d07518c3a0aa9cb575b470b",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "~1.0",
+                "php": ">=5.5",
+                "php-di/invoker": "~1.2",
+                "symfony/console": "~2.6|~3.0"
+            },
+            "require-dev": {
+                "mnapoli/phpunit-easymock": "~0.1.0",
+                "phpunit/phpunit": "~4.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Silly\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Silly CLI micro-framework based on Symfony Console",
+            "keywords": [
+                "cli",
+                "console",
+                "framework",
+                "micro-framework",
+                "silly"
+            ],
+            "time": "2016-09-16T11:44:03+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "1.23.0",
             "source": {
@@ -2780,6 +2940,156 @@
                 "psr-3"
             ],
             "time": "2017-06-19T01:22:40+00:00"
+        },
+        {
+            "name": "mpociot/documentarian",
+            "version": "0.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mpociot/documentarian.git",
+                "reference": "477f67a975f4ee6a496455938b5558d9f2a3cceb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mpociot/documentarian/zipball/477f67a975f4ee6a496455938b5558d9f2a3cceb",
+                "reference": "477f67a975f4ee6a496455938b5558d9f2a3cceb",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/view": "5.*",
+                "mnapoli/front-yaml": "^1.5",
+                "mnapoli/silly": "~1.0",
+                "php": ">=5.5.9",
+                "windwalker/renderer": "3.*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8"
+            },
+            "bin": [
+                "documentarian"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "includes/helpers.php"
+                ],
+                "psr-4": {
+                    "Mpociot\\Documentarian\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache 2"
+            ],
+            "authors": [
+                {
+                    "name": "Marcel Pociot",
+                    "email": "m.pociot@gmail.com"
+                }
+            ],
+            "time": "2016-08-26T21:14:19+00:00"
+        },
+        {
+            "name": "mpociot/laravel-apidoc-generator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mpociot/laravel-apidoc-generator.git",
+                "reference": "d66f5e81ac40f72063053e1c0a4d5717f4dd6897"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mpociot/laravel-apidoc-generator/zipball/d66f5e81ac40f72063053e1c0a4d5717f4dd6897",
+                "reference": "d66f5e81ac40f72063053e1c0a4d5717f4dd6897",
+                "shasum": ""
+            },
+            "require": {
+                "fzaninotto/faker": "~1.0",
+                "laravel/framework": "~5.4",
+                "mpociot/documentarian": "^0.2.0",
+                "mpociot/reflection-docblock": "^1.0",
+                "php": ">=5.5.0",
+                "ramsey/uuid": "^3.0"
+            },
+            "require-dev": {
+                "dingo/api": "1.0.*@dev",
+                "mockery/mockery": "^0.9.5",
+                "orchestra/testbench": "~3.0",
+                "phpunit/phpunit": "~4.0 || ~5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Mpociot\\ApiDoc": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marcel Pociot",
+                    "email": "m.pociot@gmail.com"
+                }
+            ],
+            "description": "Generate beautiful API documentation from your Laravel application",
+            "homepage": "http://github.com/mpociot/laravel-apidoc-generator",
+            "keywords": [
+                "api",
+                "documentation",
+                "laravel"
+            ],
+            "time": "2017-01-29T21:07:34+00:00"
+        },
+        {
+            "name": "mpociot/reflection-docblock",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mpociot/reflection-docblock.git",
+                "reference": "c8b2e2b1f5cebbb06e2b5ccbf2958f2198867587"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mpociot/reflection-docblock/zipball/c8b2e2b1f5cebbb06e2b5ccbf2958f2198867587",
+                "reference": "c8b2e2b1f5cebbb06e2b5ccbf2958f2198867587",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "dflydev/markdown": "~1.0",
+                "erusev/parsedown": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mpociot": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                }
+            ],
+            "time": "2016-06-20T20:53:12+00:00"
         },
         {
             "name": "mtdowling/cron-expression",
@@ -3077,6 +3387,49 @@
             "time": "2018-06-08T15:26:40+00:00"
         },
         {
+            "name": "php-di/invoker",
+            "version": "1.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-DI/Invoker.git",
+                "reference": "1f4ca63b9abc66109e53b255e465d0ddb5c2e3f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-DI/Invoker/zipball/1f4ca63b9abc66109e53b255e465d0ddb5c2e3f7",
+                "reference": "1f4ca63b9abc66109e53b255e465d0ddb5c2e3f7",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "~1.1"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "phpunit/phpunit": "~4.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Invoker\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Generic and extensible callable invoker",
+            "homepage": "https://github.com/PHP-DI/Invoker",
+            "keywords": [
+                "callable",
+                "dependency",
+                "dependency-injection",
+                "injection",
+                "invoke",
+                "invoker"
+            ],
+            "time": "2016-07-14T13:09:58+00:00"
+        },
+        {
             "name": "php-http/guzzle6-adapter",
             "version": "v1.1.1",
             "source": {
@@ -3345,6 +3698,55 @@
                 "redis"
             ],
             "time": "2016-06-16T16:22:20+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/http-message",
@@ -4784,6 +5186,111 @@
             "time": "2016-09-01T10:05:43+00:00"
         },
         {
+            "name": "windwalker/renderer",
+            "version": "3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ventoviro/windwalker-renderer.git",
+                "reference": "acae480fe98211999278eec49f3e95ecf3476630"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ventoviro/windwalker-renderer/zipball/acae480fe98211999278eec49f3e95ecf3476630",
+                "reference": "acae480fe98211999278eec49f3e95ecf3476630",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "windwalker/structure": "~3.0"
+            },
+            "require-dev": {
+                "illuminate/view": "5.2.*",
+                "league/plates": "3.*",
+                "mustache/mustache": "2.*",
+                "twig/twig": "1.*",
+                "windwalker/dom": "~3.0",
+                "windwalker/filesystem": "~3.0",
+                "windwalker/test": "~3.0"
+            },
+            "suggest": {
+                "illuminate/view": "Install 5.* if you require Laravel Blade engine.",
+                "league/plates": "Install 3.* if you require Plates template engine.",
+                "mustache/mustache": "Install 2.* if you require Mustache engine.",
+                "twig/twig": "Install 1.* if you require Twig engine."
+            },
+            "type": "windwalker-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Windwalker\\Renderer\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.0-or-later"
+            ],
+            "description": "Windwalker Renderer package",
+            "homepage": "https://github.com/ventoviro/windwalker-renderer",
+            "keywords": [
+                "framework",
+                "renderer",
+                "windwalker"
+            ],
+            "time": "2018-02-20T08:15:16+00:00"
+        },
+        {
+            "name": "windwalker/structure",
+            "version": "3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ventoviro/windwalker-structure.git",
+                "reference": "c827c27616fb363458c831682a125fa654efcc6e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ventoviro/windwalker-structure/zipball/c827c27616fb363458c831682a125fa654efcc6e",
+                "reference": "c827c27616fb363458c831682a125fa654efcc6e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "symfony/yaml": "3.*",
+                "windwalker/test": "~3.0"
+            },
+            "suggest": {
+                "symfony/yaml": "Install 3.* if you require YAML support."
+            },
+            "type": "windwalker-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Windwalker\\Structure\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.0-or-later"
+            ],
+            "description": "Windwalker Structure package",
+            "homepage": "https://github.com/ventoviro/windwalker-structure",
+            "keywords": [
+                "framework",
+                "structure",
+                "windwalker"
+            ],
+            "time": "2018-02-20T08:15:16+00:00"
+        },
+        {
             "name": "zendframework/zend-diactoros",
             "version": "1.7.2",
             "source": {
@@ -5064,56 +5571,6 @@
                 "whoops"
             ],
             "time": "2018-03-03T17:56:25+00:00"
-        },
-        {
-            "name": "fzaninotto/faker",
-            "version": "v1.7.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
-                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "ext-intl": "*",
-                "phpunit/phpunit": "^4.0 || ^5.0",
-                "squizlabs/php_codesniffer": "^1.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.8-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Faker\\": "src/Faker/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "François Zaninotto"
-                }
-            ],
-            "description": "Faker is a PHP library that generates fake data for you.",
-            "keywords": [
-                "data",
-                "faker",
-                "fixtures"
-            ],
-            "time": "2017-08-15T16:48:10+00:00"
         },
         {
             "name": "graham-campbell/testbench-core",

--- a/composer.lock
+++ b/composer.lock
@@ -625,6 +625,11 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.0-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "BackupManager\\Laravel\\Laravel55ServiceProvider"
+                    ]
                 }
             },
             "autoload": {
@@ -649,7 +654,7 @@
                 }
             ],
             "description": "Database backup manager seamlessly integrated with Laravel 4 or 5 with user-definable procedures and support for S3, Dropbox, FTP, SFTP, and more.",
-            "time": "2017-07-01T09:35:25+00:00"
+            "time": "2018-02-12T12:59:36+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -805,37 +810,6 @@
             "time": "2016-05-05T11:49:03+00:00"
         },
         {
-            "name": "container-interop/container-interop",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "shasum": ""
-            },
-            "require": {
-                "psr/container": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Container\\": "src/Interop/Container/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "homepage": "https://github.com/container-interop/container-interop",
-            "time": "2017-02-14T19:40:03+00:00"
-        },
-        {
             "name": "danielstjules/stringy",
             "version": "2.4.0",
             "source": {
@@ -890,6 +864,55 @@
                 "utils"
             ],
             "time": "2017-03-02T20:43:29+00:00"
+        },
+        {
+            "name": "darkaonline/l5-swagger",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DarkaOnLine/L5-Swagger.git",
+                "reference": "9ec908fedf2fa911f2a11456adb88f0aeaa317a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DarkaOnLine/L5-Swagger/zipball/9ec908fedf2fa911f2a11456adb88f0aeaa317a2",
+                "reference": "9ec908fedf2fa911f2a11456adb88f0aeaa317a2",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": "5.4.*",
+                "php": ">=5.6.4",
+                "zircote/swagger-php": "~2.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "~0.1",
+                "mockery/mockery": "0.9.*",
+                "orchestra/testbench": "~3.4",
+                "phpunit/phpunit": "~5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "L5Swagger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Darius Matulionis",
+                    "email": "darius@matulionis.lt"
+                }
+            ],
+            "description": "Swagger integration to Laravel 5",
+            "keywords": [
+                "api",
+                "laravel",
+                "swagger"
+            ],
+            "time": "2017-02-03T06:21:26+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -1496,56 +1519,6 @@
                 "trusted proxy"
             ],
             "time": "2017-06-15T17:19:42+00:00"
-        },
-        {
-            "name": "fzaninotto/faker",
-            "version": "v1.7.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
-                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "ext-intl": "*",
-                "phpunit/phpunit": "^4.0 || ^5.0",
-                "squizlabs/php_codesniffer": "^1.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.8-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Faker\\": "src/Faker/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "François Zaninotto"
-                }
-            ],
-            "description": "Faker is a PHP library that generates fake data for you.",
-            "keywords": [
-                "data",
-                "faker",
-                "fixtures"
-            ],
-            "time": "2017-08-15T16:48:10+00:00"
         },
         {
             "name": "graham-campbell/binput",
@@ -2723,147 +2696,6 @@
             "time": "2018-05-07T08:44:23+00:00"
         },
         {
-            "name": "mccool/laravel-auto-presenter",
-            "version": "5.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel-auto-presenter/laravel-auto-presenter.git",
-                "reference": "150afe842a973e5c6ad1db9f6878d096d7c5cf1e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel-auto-presenter/laravel-auto-presenter/zipball/150afe842a973e5c6ad1db9f6878d096d7c5cf1e",
-                "reference": "150afe842a973e5c6ad1db9f6878d096d7c5cf1e",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/container": "5.1.*|5.2.*|5.3.*|5.4.*",
-                "illuminate/contracts": "5.1.*|5.2.*|5.3.*|5.4.*",
-                "illuminate/events": "5.1.*|5.2.*|5.3.*|5.4.*",
-                "illuminate/pagination": "5.1.*|5.2.*|5.3.*|5.4.*",
-                "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*",
-                "illuminate/view": "5.1.*|5.2.*|5.3.*|5.4.*",
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "graham-campbell/testbench": "^3.1",
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.8|^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "McCool\\LaravelAutoPresenter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Shawn McCool",
-                    "email": "shawn@heybigname.com"
-                },
-                {
-                    "name": "Graham Campbell",
-                    "email": "graham@alt-three.com"
-                }
-            ],
-            "description": "A system for auto-decorating models with presenter objects.",
-            "keywords": [
-                "eloquent",
-                "laravel",
-                "lpm",
-                "presenter"
-            ],
-            "time": "2017-01-01T12:52:59+00:00"
-        },
-        {
-            "name": "mnapoli/front-yaml",
-            "version": "1.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mnapoli/FrontYAML.git",
-                "reference": "24070ace8b741247bb3161cbb38ecc541268b296"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mnapoli/FrontYAML/zipball/24070ace8b741247bb3161cbb38ecc541268b296",
-                "reference": "24070ace8b741247bb3161cbb38ecc541268b296",
-                "shasum": ""
-            },
-            "require": {
-                "erusev/parsedown": "~1.0",
-                "php": ">=5.4.0",
-                "symfony/yaml": "~2.1|^3.0|^4.0"
-            },
-            "require-dev": {
-                "league/commonmark": "~0.7",
-                "phpunit/phpunit": "~4.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Mni\\FrontYAML\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "time": "2017-10-29T19:29:55+00:00"
-        },
-        {
-            "name": "mnapoli/silly",
-            "version": "1.5.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mnapoli/silly.git",
-                "reference": "807df4a844972ac74d07518c3a0aa9cb575b470b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mnapoli/silly/zipball/807df4a844972ac74d07518c3a0aa9cb575b470b",
-                "reference": "807df4a844972ac74d07518c3a0aa9cb575b470b",
-                "shasum": ""
-            },
-            "require": {
-                "container-interop/container-interop": "~1.0",
-                "php": ">=5.5",
-                "php-di/invoker": "~1.2",
-                "symfony/console": "~2.6|~3.0"
-            },
-            "require-dev": {
-                "mnapoli/phpunit-easymock": "~0.1.0",
-                "phpunit/phpunit": "~4.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Silly\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Silly CLI micro-framework based on Symfony Console",
-            "keywords": [
-                "cli",
-                "console",
-                "framework",
-                "micro-framework",
-                "silly"
-            ],
-            "time": "2016-09-16T11:44:03+00:00"
-        },
-        {
             "name": "monolog/monolog",
             "version": "1.23.0",
             "source": {
@@ -2940,156 +2772,6 @@
                 "psr-3"
             ],
             "time": "2017-06-19T01:22:40+00:00"
-        },
-        {
-            "name": "mpociot/documentarian",
-            "version": "0.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mpociot/documentarian.git",
-                "reference": "477f67a975f4ee6a496455938b5558d9f2a3cceb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mpociot/documentarian/zipball/477f67a975f4ee6a496455938b5558d9f2a3cceb",
-                "reference": "477f67a975f4ee6a496455938b5558d9f2a3cceb",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/view": "5.*",
-                "mnapoli/front-yaml": "^1.5",
-                "mnapoli/silly": "~1.0",
-                "php": ">=5.5.9",
-                "windwalker/renderer": "3.*"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8"
-            },
-            "bin": [
-                "documentarian"
-            ],
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "includes/helpers.php"
-                ],
-                "psr-4": {
-                    "Mpociot\\Documentarian\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache 2"
-            ],
-            "authors": [
-                {
-                    "name": "Marcel Pociot",
-                    "email": "m.pociot@gmail.com"
-                }
-            ],
-            "time": "2016-08-26T21:14:19+00:00"
-        },
-        {
-            "name": "mpociot/laravel-apidoc-generator",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mpociot/laravel-apidoc-generator.git",
-                "reference": "d66f5e81ac40f72063053e1c0a4d5717f4dd6897"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mpociot/laravel-apidoc-generator/zipball/d66f5e81ac40f72063053e1c0a4d5717f4dd6897",
-                "reference": "d66f5e81ac40f72063053e1c0a4d5717f4dd6897",
-                "shasum": ""
-            },
-            "require": {
-                "fzaninotto/faker": "~1.0",
-                "laravel/framework": "~5.4",
-                "mpociot/documentarian": "^0.2.0",
-                "mpociot/reflection-docblock": "^1.0",
-                "php": ">=5.5.0",
-                "ramsey/uuid": "^3.0"
-            },
-            "require-dev": {
-                "dingo/api": "1.0.*@dev",
-                "mockery/mockery": "^0.9.5",
-                "orchestra/testbench": "~3.0",
-                "phpunit/phpunit": "~4.0 || ~5.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Mpociot\\ApiDoc": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marcel Pociot",
-                    "email": "m.pociot@gmail.com"
-                }
-            ],
-            "description": "Generate beautiful API documentation from your Laravel application",
-            "homepage": "http://github.com/mpociot/laravel-apidoc-generator",
-            "keywords": [
-                "api",
-                "documentation",
-                "laravel"
-            ],
-            "time": "2017-01-29T21:07:34+00:00"
-        },
-        {
-            "name": "mpociot/reflection-docblock",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mpociot/reflection-docblock.git",
-                "reference": "c8b2e2b1f5cebbb06e2b5ccbf2958f2198867587"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mpociot/reflection-docblock/zipball/c8b2e2b1f5cebbb06e2b5ccbf2958f2198867587",
-                "reference": "c8b2e2b1f5cebbb06e2b5ccbf2958f2198867587",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "dflydev/markdown": "~1.0",
-                "erusev/parsedown": "~1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Mpociot": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
-                }
-            ],
-            "time": "2016-06-20T20:53:12+00:00"
         },
         {
             "name": "mtdowling/cron-expression",
@@ -3698,55 +3380,6 @@
                 "redis"
             ],
             "time": "2016-06-16T16:22:20+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/http-message",
@@ -5186,111 +4819,6 @@
             "time": "2016-09-01T10:05:43+00:00"
         },
         {
-            "name": "windwalker/renderer",
-            "version": "3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ventoviro/windwalker-renderer.git",
-                "reference": "acae480fe98211999278eec49f3e95ecf3476630"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ventoviro/windwalker-renderer/zipball/acae480fe98211999278eec49f3e95ecf3476630",
-                "reference": "acae480fe98211999278eec49f3e95ecf3476630",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9",
-                "windwalker/structure": "~3.0"
-            },
-            "require-dev": {
-                "illuminate/view": "5.2.*",
-                "league/plates": "3.*",
-                "mustache/mustache": "2.*",
-                "twig/twig": "1.*",
-                "windwalker/dom": "~3.0",
-                "windwalker/filesystem": "~3.0",
-                "windwalker/test": "~3.0"
-            },
-            "suggest": {
-                "illuminate/view": "Install 5.* if you require Laravel Blade engine.",
-                "league/plates": "Install 3.* if you require Plates template engine.",
-                "mustache/mustache": "Install 2.* if you require Mustache engine.",
-                "twig/twig": "Install 1.* if you require Twig engine."
-            },
-            "type": "windwalker-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Windwalker\\Renderer\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-2.0-or-later"
-            ],
-            "description": "Windwalker Renderer package",
-            "homepage": "https://github.com/ventoviro/windwalker-renderer",
-            "keywords": [
-                "framework",
-                "renderer",
-                "windwalker"
-            ],
-            "time": "2018-02-20T08:15:16+00:00"
-        },
-        {
-            "name": "windwalker/structure",
-            "version": "3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ventoviro/windwalker-structure.git",
-                "reference": "c827c27616fb363458c831682a125fa654efcc6e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ventoviro/windwalker-structure/zipball/c827c27616fb363458c831682a125fa654efcc6e",
-                "reference": "c827c27616fb363458c831682a125fa654efcc6e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "symfony/yaml": "3.*",
-                "windwalker/test": "~3.0"
-            },
-            "suggest": {
-                "symfony/yaml": "Install 3.* if you require YAML support."
-            },
-            "type": "windwalker-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Windwalker\\Structure\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-2.0-or-later"
-            ],
-            "description": "Windwalker Structure package",
-            "homepage": "https://github.com/ventoviro/windwalker-structure",
-            "keywords": [
-                "framework",
-                "structure",
-                "windwalker"
-            ],
-            "time": "2018-02-20T08:15:16+00:00"
-        },
-        {
             "name": "zendframework/zend-diactoros",
             "version": "1.7.2",
             "source": {
@@ -5342,6 +4870,68 @@
                 "psr-7"
             ],
             "time": "2018-05-29T16:53:08+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "2.0.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "8b42fdc3d8c5a5e0d1f8d344aa359822c9f085e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/8b42fdc3d8c5a5e0d1f8d344aa359822c9f085e0",
+                "reference": "8b42fdc3d8c5a5e0d1f8d344aa359822c9f085e0",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "*",
+                "php": ">=5.6",
+                "symfony/finder": ">=2.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4.8.35 <=5.6",
+                "squizlabs/php_codesniffer": ">=2.7",
+                "zendframework/zend-form": "<2.8"
+            },
+            "bin": [
+                "bin/swagger"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Swagger\\": "src"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache2"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com",
+                    "homepage": "http://www.zircote.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "http://bfanger.nl"
+                }
+            ],
+            "description": "Swagger-PHP - Generate interactive documentation for your RESTful API using phpdoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php/",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "time": "2017-12-01T09:22:05+00:00"
         }
     ],
     "packages-dev": [
@@ -5571,6 +5161,56 @@
                 "whoops"
             ],
             "time": "2018-03-03T17:56:25+00:00"
+        },
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "^4.0 || ^5.0",
+                "squizlabs/php_codesniffer": "^1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2017-08-15T16:48:10+00:00"
         },
         {
             "name": "graham-campbell/testbench-core",

--- a/config/app.php
+++ b/config/app.php
@@ -192,6 +192,7 @@ return [
         McCool\LaravelAutoPresenter\AutoPresenterServiceProvider::class,
         PragmaRX\Google2FA\Vendor\Laravel\ServiceProvider::class,
         Roumen\Feed\FeedServiceProvider::class,
+        Mpociot\ApiDoc\ApiDocGeneratorServiceProvider::class,
 
         /*
          * Application Service Providers...

--- a/config/app.php
+++ b/config/app.php
@@ -189,10 +189,9 @@ return [
         Jenssegers\Date\DateServiceProvider::class,
         Laravel\Tinker\TinkerServiceProvider::class,
         Laravolt\Avatar\ServiceProvider::class,
-        McCool\LaravelAutoPresenter\AutoPresenterServiceProvider::class,
         PragmaRX\Google2FA\Vendor\Laravel\ServiceProvider::class,
         Roumen\Feed\FeedServiceProvider::class,
-        Mpociot\ApiDoc\ApiDocGeneratorServiceProvider::class,
+        L5Swagger\L5SwaggerServiceProvider::class,
 
         /*
          * Application Service Providers...

--- a/config/swagger-constants.php.dist
+++ b/config/swagger-constants.php.dist
@@ -1,0 +1,3 @@
+<?php
+
+define('API_HOST', 'status.mycompany.com');


### PR DESCRIPTION
The [online documentation](https://docs.cachethq.io/reference) seems to be out of date and as a developer it is difficult to think about update the online documentation at the same time as developing an API method. An other problem with the online documentation is that it is required to have an Internet connection to view it, so when developing in a train or something it's not possible to see the documentation. The documentation is the subject of #2903 
The ideal would be to be able to generate the documentation when we need it. Doing so, we will be able to generate our own documentation on our local machine during development, and it doesn't prevent an online documentation that may be updated more frequently and more easily.

To do so I've included the [mpociot/laravel-apidoc-generator](https://github.com/mpociot/laravel-apidoc-generator) package that generates the API documentation using the routes and the doc blocks. So, a developer updating the API only has to update the doc block.

To generate the documentation you can execute the command
`php artisan api:generate --routePrefix="api/v1/*"`