### PR TITLE
Add perma-link to each scheduled maintenance

### DIFF
--- a/resources/views/partials/schedule.blade.php
+++ b/resources/views/partials/schedule.blade.php
@@ -7,6 +7,7 @@
             @foreach($scheduled_maintenance as $schedule)
             <div class="list-group-item" id="scheduled-{{ $schedule->id }}">
                 <strong>{{ $schedule->name }}</strong> <small class="date"><abbr class="timeago" data-toggle="tooltip" data-placement="right" title="{{ $schedule->scheduled_at_formatted }}" data-timeago="{{ $schedule->scheduled_at_iso }}"></abbr></small>
+                <div class="pull-right"><a href="#scheduled-{{ $schedule->id }}"><i class="ion ion-link"></i></a></div>
                 <div class="markdown-body">
                     {!! $schedule->formatted_message !!}
                 </div>


### PR DESCRIPTION
PR #2912 adds scheduled maintenance ID to overview HTML.
This patch introduces permanent link and icon image by the ID.