### PR TITLE
Redirect to setting page on image uploading error

### DIFF
--- a/app/Http/Controllers/Dashboard/SettingsController.php
+++ b/app/Http/Controllers/Dashboard/SettingsController.php
@@ -397,6 +397,7 @@ class SettingsController extends Controller
     protected function handleUpdateBanner(Repository $setting)
     {
         $file = Binput::file('app_banner');
+        $redirectUrl = $this->subMenu['theme']['url'];
 
         // Image Validation.
         // Image size in bytes.


### PR DESCRIPTION
In the settings we can upload an image as banner. There are some
verifications that are done on the file to check that it's a valid
image.
If the file is not valid, a redirection is done to the theme page with
an error message.

When redirecting to the theme page because of an error on the file, the
controller redirects to an URL set in a variable. The problem was this
variable '$redirectUrl' was undefined, so the controller thrown an
error. The problem occured only if there was an error on the file, but
it worked well if the file was a valid image.

In the controller's constructor a 'submenu' field is set with panel
items and url, so the variable '$redirectUrl' is set to the theme
page URL. Now if there is an error with the file, the user is well
redirected and the error is displayed.

See: CachetHQ/Cachet#2956