### PR TITLE
Fix SQLite metric points retrieval datetime

### DIFF
--- a/app/Repositories/Metric/SqliteRepository.php
+++ b/app/Repositories/Metric/SqliteRepository.php
@@ -37,8 +37,8 @@ class SqliteRepository extends AbstractMetricRepository implements MetricInterfa
             "FROM {$this->getMetricsTable()} ".
             "INNER JOIN {$this->getMetricPointsTable()} ON {$this->getMetricsTable()}.id = {$this->getMetricPointsTable()}.metric_id ".
             "WHERE {$this->getMetricsTable()}.id = :metricId ".
-            "AND {$this->getMetricPointsTable()}.`created_at` >= datetime('now', '-{$minutes} minutes') ".
-            "AND {$this->getMetricPointsTable()}.`created_at` <= datetime('now') ".
+            "AND {$this->getMetricPointsTable()}.`created_at` >= datetime('now', 'localtime', '-{$minutes} minutes') ".
+            "AND {$this->getMetricPointsTable()}.`created_at` <= datetime('now', 'localtime') ".
             "GROUP BY strftime('%H', {$this->getMetricPointsTable()}.`created_at`), strftime('%M', {$this->getMetricPointsTable()}.`created_at`) ".
             "ORDER BY {$this->getMetricPointsTable()}.`created_at`", [
             'metricId' => $metric->id,
@@ -61,8 +61,8 @@ class SqliteRepository extends AbstractMetricRepository implements MetricInterfa
         $points = DB::select("SELECT strftime('%Y-%m-%d %H:00', {$this->getMetricPointsTable()}.`created_at`) AS `key`, {$queryType} ".
             "FROM {$this->getMetricsTable()} INNER JOIN {$this->getMetricPointsTable()} ON {$this->getMetricsTable()}.id = {$this->getMetricPointsTable()}.metric_id ".
             "WHERE {$this->getMetricsTable()}.id = :metricId ".
-            "AND {$this->getMetricPointsTable()}.`created_at` >= datetime('now', '-{$hour} hours') ".
-            "AND {$this->getMetricPointsTable()}.`created_at` <= datetime('now') ".
+            "AND {$this->getMetricPointsTable()}.`created_at` >= datetime('now', 'localtime', '-{$hour} hours') ".
+            "AND {$this->getMetricPointsTable()}.`created_at` <= datetime('now', 'localtime') ".
             "GROUP BY strftime('%H', {$this->getMetricPointsTable()}.`created_at`) ORDER BY {$this->getMetricPointsTable()}.`created_at`", [
             'metricId' => $metric->id,
         ]);
@@ -84,8 +84,8 @@ class SqliteRepository extends AbstractMetricRepository implements MetricInterfa
         $points = DB::select("SELECT strftime('%Y-%m-%d', {$this->getMetricPointsTable()}.`created_at`) AS `key`, {$queryType} ".
             "FROM {$this->getMetricsTable()} INNER JOIN {$this->getMetricPointsTable()} ON {$this->getMetricsTable()}.id = {$this->getMetricPointsTable()}.metric_id ".
             "WHERE {$this->getMetricsTable()}.id = :metricId ".
-            "AND {$this->getMetricPointsTable()}.`created_at` >= datetime('now', '-{$day} days') ".
-            "AND {$this->getMetricPointsTable()}.`created_at` <= datetime('now') ".
+            "AND {$this->getMetricPointsTable()}.`created_at` >= datetime('now', 'localtime', '-{$day} days') ".
+            "AND {$this->getMetricPointsTable()}.`created_at` <= datetime('now', 'localtime') ".
             "GROUP BY DATE({$this->getMetricPointsTable()}.`created_at`) ".
             "ORDER BY {$this->getMetricPointsTable()}.`created_at`", [
             'metricId' => $metric->id,


### PR DESCRIPTION
This fixes the timezone issues with the retrieval of the metric points for the graphs.

Adding 'localtime' as a modifier to the ``datetime`` function in the ``SqliteRepository`` ensures equivalence to the use of ``NOW``, which uses the system timezone by default, in the ``MySqlRepository``.