### PR TITLE
Use the table prefix on metric_points

### DIFF
--- a/app/Repositories/Metric/AbstractMetricRepository.php
+++ b/app/Repositories/Metric/AbstractMetricRepository.php
@@ -48,16 +48,37 @@ abstract class AbstractMetricRepository
     }
 
     /**
+     * Get the table names prefix.
+     *
+     * @return  string
+     */
+    protected function getPrefix()
+    {
+        $driver = $this->config->get('database.default');
+        $connection = $this->config->get('database.connections.'.$driver);
+        $prefix = $connection['prefix'];
+        return $prefix;
+    }
+
+    /**
      * Get the metrics table name.
      *
      * @return string
      */
     protected function getTableName()
     {
-        $driver = $this->config->get('database.default');
-        $connection = $this->config->get('database.connections.'.$driver);
-        $prefix = $connection['prefix'];
-
+        $prefix = $this->getPrefix();
         return $prefix.'metrics';
+    }
+
+    /**
+     * Get the metric points table name.
+     *
+     * @return  string
+     */
+    protected function getMetricPointsTableName()
+    {
+        $prefix = $this->getPrefix();
+        return $prefix.'metric_points';
     }
 }

--- a/app/Repositories/Metric/MySqlRepository.php
+++ b/app/Repositories/Metric/MySqlRepository.php
@@ -36,6 +36,8 @@ class MySqlRepository extends AbstractMetricRepository implements MetricInterfac
     {
         $dateTime = (new Date())->sub(new DateInterval('PT'.$hour.'H'))->sub(new DateInterval('PT'.$minute.'M'));
         $timeInterval = $dateTime->format('YmdHi');
+        $metricPointsTableName = $this->getMetricPointsTableName();
+
 
         if (!isset($metric->calc_type) || $metric->calc_type == Metric::CALC_SUM) {
             $queryType = 'SUM(mp.`value` * mp.`counter`) AS `value`';
@@ -45,7 +47,7 @@ class MySqlRepository extends AbstractMetricRepository implements MetricInterfac
 
         $value = 0;
 
-        $points = DB::select("SELECT {$queryType} FROM {$this->getTableName()} m INNER JOIN metric_points mp ON m.id = mp.metric_id WHERE m.id = :metricId AND DATE_FORMAT(mp.`created_at`, '%Y%m%d%H%i') = :timeInterval GROUP BY HOUR(mp.`created_at`), MINUTE(mp.`created_at`)", [
+        $points = DB::select("SELECT {$queryType} FROM {$this->getTableName()} m INNER JOIN $metricPointsTableName mp ON m.id = mp.metric_id WHERE m.id = :metricId AND DATE_FORMAT(mp.`created_at`, '%Y%m%d%H%i') = :timeInterval GROUP BY HOUR(mp.`created_at`), MINUTE(mp.`created_at`)", [
             'metricId'     => $metric->id,
             'timeInterval' => $timeInterval,
         ]);
@@ -73,6 +75,7 @@ class MySqlRepository extends AbstractMetricRepository implements MetricInterfac
     {
         $dateTime = (new Date())->sub(new DateInterval('PT'.$hour.'H'));
         $hourInterval = $dateTime->format('YmdH');
+        $metricPointsTableName = $this->getMetricPointsTableName();
 
         if (!isset($metric->calc_type) || $metric->calc_type == Metric::CALC_SUM) {
             $queryType = 'SUM(mp.`value` * mp.`counter`) AS `value`';
@@ -82,7 +85,7 @@ class MySqlRepository extends AbstractMetricRepository implements MetricInterfac
 
         $value = 0;
 
-        $points = DB::select("SELECT {$queryType} FROM {$this->getTableName()} m INNER JOIN metric_points mp ON m.id = mp.metric_id WHERE m.id = :metricId AND DATE_FORMAT(mp.`created_at`, '%Y%m%d%H') = :hourInterval GROUP BY HOUR(mp.`created_at`)", [
+        $points = DB::select("SELECT {$queryType} FROM {$this->getTableName()} m INNER JOIN $metricPointsTableName mp ON m.id = mp.metric_id WHERE m.id = :metricId AND DATE_FORMAT(mp.`created_at`, '%Y%m%d%H') = :hourInterval GROUP BY HOUR(mp.`created_at`)", [
             'metricId'     => $metric->id,
             'hourInterval' => $hourInterval,
         ]);
@@ -108,6 +111,7 @@ class MySqlRepository extends AbstractMetricRepository implements MetricInterfac
     public function getPointsForDayInWeek(Metric $metric, $day)
     {
         $dateTime = (new Date())->sub(new DateInterval('P'.$day.'D'));
+        $metricPointsTableName = $this->getMetricPointsTableName();
 
         if (!isset($metric->calc_type) || $metric->calc_type == Metric::CALC_SUM) {
             $queryType = 'SUM(mp.`value` * mp.`counter`) AS `value`';
@@ -117,7 +121,7 @@ class MySqlRepository extends AbstractMetricRepository implements MetricInterfac
 
         $value = 0;
 
-        $points = DB::select("SELECT {$queryType} FROM {$this->getTableName()} m INNER JOIN metric_points mp ON m.id = mp.metric_id WHERE m.id = :metricId AND mp.`created_at` BETWEEN DATE_SUB(mp.`created_at`, INTERVAL 1 WEEK) AND DATE_ADD(NOW(), INTERVAL 1 DAY) AND DATE_FORMAT(mp.`created_at`, '%Y%m%d') = :timeInterval GROUP BY DATE_FORMAT(mp.`created_at`, '%Y%m%d')", [
+        $points = DB::select("SELECT {$queryType} FROM {$this->getTableName()} m INNER JOIN $metricPointsTableName mp ON m.id = mp.metric_id WHERE m.id = :metricId AND mp.`created_at` BETWEEN DATE_SUB(mp.`created_at`, INTERVAL 1 WEEK) AND DATE_ADD(NOW(), INTERVAL 1 DAY) AND DATE_FORMAT(mp.`created_at`, '%Y%m%d') = :timeInterval GROUP BY DATE_FORMAT(mp.`created_at`, '%Y%m%d')", [
             'metricId'     => $metric->id,
             'timeInterval' => $dateTime->format('Ymd'),
         ]);

--- a/app/Repositories/Metric/SqliteRepository.php
+++ b/app/Repositories/Metric/SqliteRepository.php
@@ -30,18 +30,19 @@ class SqliteRepository extends AbstractMetricRepository implements MetricInterfa
     public function getPointsLastHour(Metric $metric, $hour, $minute)
     {
         $dateTime = (new Date())->sub(new DateInterval('PT'.$hour.'H'))->sub(new DateInterval('PT'.$minute.'M'));
+        $metricPointsTableName = $this->getMetricPointsTableName();
 
         // Default metrics calculations.
         if (!isset($metric->calc_type) || $metric->calc_type == Metric::CALC_SUM) {
-            $queryType = 'sum(metric_points.value * metric_points.counter)';
+            $queryType = "sum($metricPointsTableName.value * $metricPointsTableName.counter)";
         } elseif ($metric->calc_type == Metric::CALC_AVG) {
-            $queryType = 'avg(metric_points.value * metric_points.counter)';
+            $queryType = "avg($metricPointsTableName.value * $metricPointsTableName.counter)";
         } else {
-            $queryType = 'sum(metric_points.value * metric_points.counter)';
+            $queryType = "sum($metricPointsTableName.value * $metricPointsTableName.counter)";
         }
 
         $value = 0;
-        $query = DB::select("select {$queryType} as value FROM {$this->getTableName()} m JOIN metric_points ON metric_points.metric_id = m.id WHERE m.id = :metricId AND strftime('%Y%m%d%H%M', metric_points.created_at) = :timeInterval GROUP BY strftime('%H%M', metric_points.created_at)", [
+        $query = DB::select("select {$queryType} as value FROM {$this->getTableName()} m JOIN $metricPointsTableName ON $metricPointsTableName.metric_id = m.id WHERE m.id = :metricId AND strftime('%Y%m%d%H%M', $metricPointsTableName.created_at) = :timeInterval GROUP BY strftime('%H%M', $metricPointsTableName.created_at)", [
             'metricId'     => $metric->id,
             'timeInterval' => $dateTime->format('YmdHi'),
         ]);
@@ -68,18 +69,19 @@ class SqliteRepository extends AbstractMetricRepository implements MetricInterfa
     public function getPointsByHour(Metric $metric, $hour)
     {
         $dateTime = (new Date())->sub(new DateInterval('PT'.$hour.'H'));
+        $metricPointsTableName = $this->getMetricPointsTableName();
 
         // Default metrics calculations.
         if (!isset($metric->calc_type) || $metric->calc_type == Metric::CALC_SUM) {
-            $queryType = 'sum(metric_points.value * metric_points.counter)';
+            $queryType = "sum($metricPointsTableName.value * $metricPointsTableName.counter)";
         } elseif ($metric->calc_type == Metric::CALC_AVG) {
-            $queryType = 'avg(metric_points.value * metric_points.counter)';
+            $queryType = "avg($metricPointsTableName.value * $metricPointsTableName.counter)";
         } else {
-            $queryType = 'sum(metric_points.value * metric_points.counter)';
+            $queryType = "sum($metricPointsTableName.value * $metricPointsTableName.counter)";
         }
 
         $value = 0;
-        $query = DB::select("select {$queryType} as value FROM {$this->getTableName()} m JOIN metric_points ON metric_points.metric_id = m.id WHERE m.id = :metricId AND strftime('%Y%m%d%H', metric_points.created_at) = :timeInterval GROUP BY strftime('%H', metric_points.created_at)", [
+        $query = DB::select("select {$queryType} as value FROM {$this->getTableName()} m JOIN $metricPointsTableName ON $metricPointsTableName.metric_id = m.id WHERE m.id = :metricId AND strftime('%Y%m%d%H', $metricPointsTableName.created_at) = :timeInterval GROUP BY strftime('%H', $metricPointsTableName.created_at)", [
             'metricId'     => $metric->id,
             'timeInterval' => $dateTime->format('YmdH'),
         ]);
@@ -105,18 +107,19 @@ class SqliteRepository extends AbstractMetricRepository implements MetricInterfa
     public function getPointsForDayInWeek(Metric $metric, $day)
     {
         $dateTime = (new Date())->sub(new DateInterval('P'.$day.'D'));
+        $metricPointsTableName = $this->getMetricPointsTableName();
 
         // Default metrics calculations.
         if (!isset($metric->calc_type) || $metric->calc_type == Metric::CALC_SUM) {
-            $queryType = 'sum(metric_points.value * metric_points.counter)';
+            $queryType = "sum($metricPointsTableName.value * $metricPointsTableName.counter)";
         } elseif ($metric->calc_type == Metric::CALC_AVG) {
-            $queryType = 'avg(metric_points.value * metric_points.counter)';
+            $queryType = "avg($metricPointsTableName.value * $metricPointsTableName.counter)";
         } else {
-            $queryType = 'sum(metric_points.value * metric_points.counter)';
+            $queryType = "sum($metricPointsTableName.value * $metricPointsTableName.counter)";
         }
 
         $value = 0;
-        $query = DB::select("select {$queryType} as value FROM {$this->getTableName()} m JOIN metric_points ON metric_points.metric_id = m.id WHERE m.id = :metricId AND metric_points.created_at > date('now', '-7 day') AND strftime('%Y%m%d', metric_points.created_at) = :timeInterval GROUP BY strftime('%Y%m%d', metric_points.created_at)", [
+        $query = DB::select("select {$queryType} as value FROM {$this->getTableName()} m JOIN $metricPointsTableName ON $metricPointsTableName.metric_id = m.id WHERE m.id = :metricId AND $metricPointsTableName.created_at > date('now', '-7 day') AND strftime('%Y%m%d', $metricPointsTableName.created_at) = :timeInterval GROUP BY strftime('%Y%m%d', $metricPointsTableName.created_at)", [
             'metricId'     => $metric->id,
             'timeInterval' => $dateTime->format('Ymd'),
         ]);


### PR DESCRIPTION
In the '.env' file, a 'DB_PREFIX' sets the prefix that should be used
on every table name. When writing an SQL query the 'DB_PREFIX' value
has to be prefixed to the table name.

The repositories PgSqlRepository, MySqlRepository and SqliteRepository,
located in 'app/Repositories/Metric/' did not apply this prefix on
the 'metric_points' table. The problem occured only when we set a
'DB_PREFIX' not null, the rest of the application worked correctly but
the part about 'metric_points' couldn't work, saying the table was
inexistant.

A method was added in the repository AbstractMetricRepository to get
the 'metric_points' table name with the prefix if there is one.
This method is used in the three repositories to get the right table
name.

Note: This problem was present in 2.3, but was already fixed in 2.4 so
there is no need to apply this commit on the 2.4 branch.

See: CachetHQ/Cachet/#2955