### PR TITLE
Fix superfluous metric point

### DIFF
--- a/app/Repositories/Metric/MetricRepository.php
+++ b/app/Repositories/Metric/MetricRepository.php
@@ -63,7 +63,7 @@ class MetricRepository
         $pointKey = $dateTime->format('Y-m-d H:i');
         $points = $this->repository->getPointsSinceMinutes($metric, 60)->pluck('value', 'key')->take(60);
 
-        for ($i = 0; $i <= 60; $i++) {
+        for ($i = 0; $i < 60; $i++) {
             if (!$points->has($pointKey)) {
                 $points->put($pointKey, $metric->default_value);
             }


### PR DESCRIPTION
Previously a metric point with the default value would always be added, because there were only 60 metric points retrieved while the loop to fill in gaps with default values executed 61 times.