### PR TITLE
Fix trailing default metric points

### DIFF
--- a/app/Repositories/Metric/MetricRepository.php
+++ b/app/Repositories/Metric/MetricRepository.php
@@ -63,7 +63,7 @@ class MetricRepository
         $pointKey = $dateTime->format('Y-m-d H:i');
         $points = $this->repository->getPointsSinceMinutes($metric, 60)->pluck('value', 'key')->take(60);
 
-        for ($i = 0; $i <= 60; $i++) {
+        for ($i = 0; $i < 60; $i++) {
             if (!$points->has($pointKey)) {
                 $points->put($pointKey, $metric->default_value);
             }

--- a/app/Repositories/Metric/MetricRepository.php
+++ b/app/Repositories/Metric/MetricRepository.php
@@ -61,11 +61,19 @@ class MetricRepository
     {
         $dateTime = $this->dates->make();
         $pointKey = $dateTime->format('Y-m-d H:i');
-        $points = $this->repository->getPointsSinceMinutes($metric, 60)->pluck('value', 'key')->take(60);
+        $nrOfMinutes = 61;
+        $points = $this->repository->getPointsSinceMinutes($metric, $nrOfMinutes + $metric->threshold)->pluck('value', 'key')->take(-$nrOfMinutes);
 
-        for ($i = 0; $i < 60; $i++) {
+        $timeframe = $nrOfMinutes;
+        for ($i = 0; $i < $timeframe; $i++) {
             if (!$points->has($pointKey)) {
-                $points->put($pointKey, $metric->default_value);
+                if ($i >= $metric->threshold) {
+                    $points->put($pointKey, $metric->default_value);
+                } else {
+                    // The point not found is still within the threshold, so it is ignored and
+                    // the timeframe is shifted by one minute
+                    $timeframe++;
+                }
             }
 
             $pointKey = $dateTime->sub(new DateInterval('PT1M'))->format('Y-m-d H:i');


### PR DESCRIPTION
Fixes #2539.

The last hour view now shifts to an earlier time frame by one minute for each missing or currently unavailable metric point per minute until the threshold is reached, after which default metric points are used.

In addition to taking into account the threshold this also retrieves the correct number of minutes for the last hour, 61 instead of 60 to allow even steps in the x-axis without any unnecessary leading or trailing default metric points.