### PR TITLE
Fix metric point counting within threshold

### DIFF
--- a/app/Bus/Handlers/Commands/Metric/CreateMetricPointCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Metric/CreateMetricPointCommandHandler.php
@@ -79,7 +79,7 @@ class CreateMetricPointCommandHandler
      */
     protected function findOrCreatePoint(CreateMetricPointCommand $command)
     {
-        $buffer = Carbon::now()->subMinutes($command->metric->threshold);
+        $buffer = Carbon::now()->subMinutes($command->metric->threshold - 1)->startOfMinute();
 
         if ($point = MetricPoint::where('metric_id', '=', $command->metric->id)->where('value', '=', $command->value)->where('created_at', '>=', $buffer)->first()) {
             return $point;


### PR DESCRIPTION
The threshold is based on minutes, so a metric point with the same value as an existing metric point should only increment the counter if the existing metric point was created within the same minute, not within the last 60 seconds.