### PR TITLE
Always take "days of incidents to show" into account

### DIFF
--- a/app/Http/Controllers/StatusPageController.php
+++ b/app/Http/Controllers/StatusPageController.php
@@ -67,6 +67,10 @@ class StatusPageController extends AbstractApiController
 
             $allIncidentDays = Incident::where('visible', '>=', (int) !Auth::check())
                                        ->select('occurred_at')
+                                       ->whereBetween('occurred_at', [
+                                           $endDate->format('Y-m-d').' 00:00:00',
+                                           $startDate->format('Y-m-d').' 23:59:59',
+                                       ])
                                        ->distinct()
                                        ->orderBy('occurred_at', 'desc')
                                        ->get()


### PR DESCRIPTION
No need to select everything when looking at past incidents, date range should always be taken into account as a global rule for frontend.