### PR TITLE
Don't check stylesheet with Binput

### DIFF
--- a/app/Http/Controllers/Dashboard/SettingsController.php
+++ b/app/Http/Controllers/Dashboard/SettingsController.php
@@ -357,6 +357,14 @@ class SettingsController extends Controller
             }
         }
 
+        if (isset($parameters['stylesheet'])) {
+            if ($stylesheet = Binput::get('stylesheet', null, false, false)) {
+                $setting->set('stylesheet', $stylesheet);
+            } else {
+                $setting->delete('stylesheet');
+            }
+        }
+
         if (Binput::hasFile('app_banner')) {
             $this->handleUpdateBanner($setting);
         }
@@ -367,6 +375,7 @@ class SettingsController extends Controller
             'remove_banner',
             'header',
             'footer',
+            'stylesheet',
         ];
 
         try {


### PR DESCRIPTION
The custom stylesheet gets verified by Binput after the upload. This is bad because some css features are broken afterwards.
For example a data URIs get removed, see: #2453 

This PR should fix this behavior by treating the stylesheet header exactly like a custom header or footer.