### PR TITLE
Corrected link component tag : morphMany => morphToMany cf.#3004

### DIFF
--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -147,11 +147,11 @@ class Component extends Model implements HasPresenter
     /**
      * Get the tags relation.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
     public function tags()
     {
-        return $this->morphMany(Taggable::class, 'taggable');
+        return $this->morphToMany(Taggable::class, 'taggable');
     }
 
     /**


### PR DESCRIPTION
The relation between component and tag should be morphToMany rather than morphMany, else we get the error described in #3004