### PR TITLE
Implement 99th percentile metric calculation

### DIFF
--- a/app/Bus/Commands/Metric/UpdateMetricCommand.php
+++ b/app/Bus/Commands/Metric/UpdateMetricCommand.php
@@ -109,7 +109,7 @@ final class UpdateMetricCommand
         'suffix'        => 'nullable|string',
         'description'   => 'nullable|string',
         'default_value' => 'nullable|numeric',
-        'calc_type'     => 'nullable|int|in:0,1',
+        'calc_type'     => 'nullable|int|between:0,2',
         'display_chart' => 'nullable|int',
         'places'        => 'nullable|numeric|between:0,4',
         'default_view'  => 'nullable|numeric|between:0,4',

--- a/app/Models/Metric.php
+++ b/app/Models/Metric.php
@@ -39,6 +39,13 @@ class Metric extends Model implements HasPresenter
     const CALC_AVG = 1;
 
     /**
+     * The calculation type of the 99th percentile.
+     *
+     * @var int
+     */
+    const CALC_PERCENTILE = 2;
+
+    /**
      * Viewable only authenticated users.
      *
      * @var int

--- a/app/Repositories/Metric/AbstractMetricRepository.php
+++ b/app/Repositories/Metric/AbstractMetricRepository.php
@@ -86,10 +86,19 @@ abstract class AbstractMetricRepository
             return "sum({$this->getMetricPointsTable()}.value * {$this->getMetricPointsTable()}.counter) AS value";
         } elseif ($metric->calc_type == Metric::CALC_AVG) {
             return "avg({$this->getMetricPointsTable()}.value) AS value";
+        } elseif ($metric->calc_type == Metric::CALC_PERCENTILE) {
+            return $this->getPercentileQuery();
         } else {
             return "sum({$this->getMetricPointsTable()}.value * {$this->getMetricPointsTable()}.counter) AS value";
         }
     }
+
+    /**
+     * Return the percentile query.
+     *
+     * @return string
+     */
+    abstract protected function getPercentileQuery();
 
     /**
      * Map the result set.

--- a/app/Repositories/Metric/MySqlRepository.php
+++ b/app/Repositories/Metric/MySqlRepository.php
@@ -94,4 +94,19 @@ class MySqlRepository extends AbstractMetricRepository implements MetricInterfac
 
         return $this->mapResults($metric, $points);
     }
+
+    /**
+     * Return the percentile query.
+     *
+     * @return string
+     */
+    protected function getPercentileQuery()
+    {
+        return 'SUBSTRING_INDEX('.
+            'SUBSTRING_INDEX('.
+                "GROUP_CONCAT({$this->getMetricPointsTable()}.value ORDER BY {$this->getMetricPointsTable()}.value SEPARATOR ','),".
+                "',', 99/100 * COUNT(*) + 1),".
+            "',', -1)".
+        'AS value ';
+    }
 }

--- a/app/Repositories/Metric/PgSqlRepository.php
+++ b/app/Repositories/Metric/PgSqlRepository.php
@@ -92,4 +92,14 @@ class PgSqlRepository extends AbstractMetricRepository implements MetricInterfac
 
         return $this->mapResults($metric, $points);
     }
+
+    /**
+     * Return the percentile query.
+     *
+     * @return string
+     */
+    protected function getPercentileQuery()
+    {
+        return "percentile_disc(0.99) WITHIN GROUP (ORDER BY {$this->getMetricPointsTable()}.value) ";
+    }
 }

--- a/resources/lang/en/forms.php
+++ b/resources/lang/en/forms.php
@@ -131,6 +131,7 @@ return [
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',
+        'type_percentile'          => '99th percentile',
         'places'                   => 'Decimal places',
         'default_view'             => 'Default view',
         'threshold'                => 'How many minutes of threshold between metric points?',

--- a/resources/lang/nl-NL/forms.php
+++ b/resources/lang/nl-NL/forms.php
@@ -131,6 +131,7 @@ return [
         'calc_type'                => 'Berekening van de metingen',
         'type_sum'                 => 'Som',
         'type_avg'                 => 'Gemiddelde',
+        'type_percentile'          => '99ste percentiel',
         'places'                   => 'Decimalen',
         'default_view'             => 'Standaardweergave',
         'threshold'                => 'Hoeveel minuten tussen de metrische punten?',

--- a/resources/lang/nl/forms.php
+++ b/resources/lang/nl/forms.php
@@ -87,6 +87,7 @@ return [
         'default-value'    => 'Standaardwaarde',
         'calc_type'        => 'Berekening van de metingen',
         'type_sum'         => 'Som',
+        'type_percentile'  => '99ste percentiel',
         'type_avg'         => 'Gemiddelde',
         'places'           => 'Decimalen',
         'default_view'     => 'Standaardweergave',

--- a/resources/views/dashboard/metrics/add.blade.php
+++ b/resources/views/dashboard/metrics/add.blade.php
@@ -36,6 +36,7 @@
                         <select name="metric[calc_type]" class="form-control" required>
                             <option value="0" selected>{{ trans('forms.metrics.type_sum') }}</option>
                             <option value="1">{{ trans('forms.metrics.type_avg') }}</option>
+                            <option value="2">{{ trans('forms.metrics.type_percentile') }}</option>
                         </select>
                     </div>
                     <div class="form-group">

--- a/resources/views/dashboard/metrics/edit.blade.php
+++ b/resources/views/dashboard/metrics/edit.blade.php
@@ -36,6 +36,7 @@
                         <select name="calc_type" class="form-control" required>
                             <option value="0" {{ $metric->calc_type === 0 ? "selected" : null }}>{{ trans('forms.metrics.type_sum') }}</option>
                             <option value="1" {{ $metric->calc_type === 1 ? "selected" : null }}>{{ trans('forms.metrics.type_avg') }}</option>
+                            <option value="2" {{ $metric->calc_type === 2 ? "selected" : null }}>{{ trans('forms.metrics.type_percentile') }}</option>
                         </select>
                     </div>
                     <div class="form-group">


### PR DESCRIPTION
I think it would be nice to have 99th percentile metric calculation. If this is not the case, please say so!

Unfortunately I ran into performance problems for SQLite. Currently a query is executed to calculate the 99th percentile for each point on the metric chart.

Required:

- [x] Implement 99th percentile metric calculation for MySQL, PostgreSQL and SQLite
- [x] Refactor SQLite metric points since retrieval
- [x] Test both MySQL and SQLite 99th percentile calculation
- [x] Add English translation for calculation type
- [ ] Test PostgreSQL 99th percentile calculation

Nice to have:

- [ ] Refactor MySQL and PostgreSQL metric points since retrieval
- [ ] Parameterized percentile (support for any percentile)
- [ ] Solve performance problems for SQLite