### PR TITLE
Add rate setting for major outage

### DIFF
--- a/app/Integrations/Core/System.php
+++ b/app/Integrations/Core/System.php
@@ -64,7 +64,8 @@ class System implements SystemContract
 
         $totalComponents = Component::enabled()->authenticated($includePrivate)->count();
         $majorOutages = Component::enabled()->authenticated($includePrivate)->status(4)->count();
-        $isMajorOutage = $totalComponents ? ($majorOutages / $totalComponents) >= 0.5 : false;
+        $majorOutageRate = (int) $this->config->get('setting.major_outage_rate', '50');
+        $isMajorOutage = $totalComponents ? ($majorOutages / $totalComponents)*100 >= $majorOutageRate : false;
 
         // Default data
         $status = [

--- a/resources/lang/en/forms.php
+++ b/resources/lang/en/forms.php
@@ -154,6 +154,7 @@ return [
             'about-this-page'                       => 'About this page',
             'days-of-incidents'                     => 'How many days of incidents to show?',
             'time_before_refresh'                   => 'Status page refresh rate (in seconds)',
+            'major_outage_rate'                     => 'Major outage threshold (in %)',
             'banner'                                => 'Banner Image',
             'banner-help'                           => "It's recommended that you upload files no bigger than 930px wide",
             'subscribers'                           => 'Allow people to signup to email notifications?',

--- a/resources/views/dashboard/settings/app-setup.blade.php
+++ b/resources/views/dashboard/settings/app-setup.blade.php
@@ -59,6 +59,14 @@
                         </div>
                         <div class="row">
                             <div class="col-xs-12">
+                                <div class="form-group">
+                                    <label>{{ trans('forms.settings.app-setup.major_outage_rate') }}</label>
+                                    <input type="number" name="major_outage_rate" class="form-control" value="{{ Config::get('setting.major_outage_rate', 50) }}" placeholder="{{ trans('forms.settings.app-setup.major_outage_rate') }}">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-xs-12">
                                 <div class="checkbox">
                                     <label>
                                         <input type="hidden" value="0" name="enable_subscribers">


### PR DESCRIPTION
Major outage criteria depends on required service level.
Default value keeps 50% because it had been fixed to 50%.