### PR TITLE
Cast status to int on update component command

### DIFF
--- a/app/Bus/Commands/Component/UpdateComponentCommand.php
+++ b/app/Bus/Commands/Component/UpdateComponentCommand.php
@@ -123,7 +123,7 @@ final class UpdateComponentCommand
         $this->component = $component;
         $this->name = $name;
         $this->description = $description;
-        $this->status = $status;
+        $this->status = (int) $status;
         $this->link = $link;
         $this->order = $order;
         $this->group_id = $group_id;


### PR DESCRIPTION
Currently the `status` is a `string` but is need to be a `int`. Due this the check if the component `status` has changed on creation of a new incident will always be `false` in `SendComponentUpdateEmailNotificationHandler`, and it will notify all subscribers.