### PR TITLE
Cleanup tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,6 @@
         "filp/whoops": "^2.1",
         "fzaninotto/faker": "^1.6",
         "graham-campbell/testbench-core": "^1.1",
-        "laravel/browser-kit-testing": "^2.0",
         "mockery/mockery": "0.9.9",
         "nikic/php-parser": "^3.0",
         "phpunit/phpunit": "5.7.20",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "83a7fb073c9dd90ffa9b6ddb056ab7e9",
+    "content-hash": "902bc48c3a37a1d269f457d015b1f06a",
     "packages": [
         {
             "name": "alt-three/badger",
@@ -5219,53 +5219,6 @@
                 "test"
             ],
             "time": "2015-05-11T14:41:42+00:00"
-        },
-        {
-            "name": "laravel/browser-kit-testing",
-            "version": "v2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/browser-kit-testing.git",
-                "reference": "23f1a7eefcbca0797305b236600aa5426c9528f2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel/browser-kit-testing/zipball/23f1a7eefcbca0797305b236600aa5426c9528f2",
-                "reference": "23f1a7eefcbca0797305b236600aa5426c9528f2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9",
-                "symfony/css-selector": "~3.1",
-                "symfony/dom-crawler": "~3.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laravel\\BrowserKitTesting\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "Provides backwards compatibility for BrowserKit testing in Laravel 5.4.",
-            "keywords": [
-                "laravel",
-                "testing"
-            ],
-            "time": "2017-05-26T12:46:48+00:00"
         },
         {
             "name": "maximebf/debugbar",

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -15,7 +15,7 @@ use CachetHQ\Cachet\Models\User;
 use CachetHQ\Cachet\Settings\Cache;
 use CachetHQ\Cachet\Settings\Repository;
 use Illuminate\Contracts\Console\Kernel;
-use Laravel\BrowserKitTesting\TestCase;
+use Illuminate\Foundation\Testing\TestCase;
 
 /**
  * This is the abstract test case class.

--- a/tests/Api/AbstractApiTestCase.php
+++ b/tests/Api/AbstractApiTestCase.php
@@ -28,12 +28,16 @@ abstract class AbstractApiTestCase extends AbstractTestCase
     /**
      * Become a user.
      *
-     * @return void
+     * @return $this
      */
     protected function beUser()
     {
-        $this->user = factory(User::class)->create();
+        $this->user = factory(User::class)->create([
+            'username' => 'cachet-test',
+        ]);
 
         $this->be($this->user);
+
+        return $this;
     }
 }

--- a/tests/Api/ComponentGroupTest.php
+++ b/tests/Api/ComponentGroupTest.php
@@ -25,109 +25,145 @@ class ComponentGroupTest extends AbstractApiTestCase
     const COMPONENT_GROUP_1_NAME = 'Component Group 1';
     const COMPONENT_GROUP_2_NAME = 'Component Group 2';
 
-    public function testGetGroups()
+    public function test_can_get_all_component_groups()
     {
-        $groups = factory('CachetHQ\Cachet\Models\ComponentGroup', 3)
+        $groups = factory(ComponentGroup::class, 2)
             ->create(['visible' => ComponentGroup::VISIBLE_GUEST]);
 
-        $this->get('/api/v1/components/groups');
-        $this->seeJsonContains(['id' => $groups[0]->id]);
-        $this->seeJsonContains(['id' => $groups[1]->id]);
-        $this->seeJsonContains(['id' => $groups[2]->id]);
-        $this->assertResponseOk();
+        $response = $this->json('GET', '/api/v1/components/groups');
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            [
+                'id'                        => $groups[0]->id,
+                'name'                      => $groups[0]->name,
+                'created_at'                => (string) $groups[0]->created_at,
+                'updated_at'                => (string) $groups[0]->updated_at,
+                'order'                     => $groups[0]->order,
+                'collapsed'                 => $groups[0]->collapsed,
+                'visible'                   => $groups[0]->visible,
+                'enabled_components'        => $groups[0]->enabled_components,
+                'enabled_components_lowest' => $groups[0]->enabled_components_lowest,
+                'lowest_human_status'       => $groups[0]->lowest_human_status,
+            ]
+        ]);
+        $response->assertJsonFragment([
+            [
+                'id'                        => $groups[1]->id,
+                'name'                      => $groups[1]->name,
+                'created_at'                => (string) $groups[1]->created_at,
+                'updated_at'                => (string) $groups[1]->updated_at,
+                'order'                     => $groups[1]->order,
+                'collapsed'                 => $groups[1]->collapsed,
+                'visible'                   => $groups[1]->visible,
+                'enabled_components'        => $groups[1]->enabled_components,
+                'enabled_components_lowest' => $groups[1]->enabled_components_lowest,
+                'lowest_human_status'       => $groups[1]->lowest_human_status,
+            ]
+        ]);
     }
 
-    public function testGetInvalidGroup()
+    public function test_cannot_get_invalid_component_group()
     {
-        $this->get('/api/v1/components/groups/1');
-        $this->assertResponseStatus(404);
+        $response = $this->json('GET', '/api/v1/components/groups/1');
+
+        $response->assertStatus(404);
     }
 
-    public function testPostGroupUnauthorized()
+    public function test_cannot_create_component_group_without_authorization()
     {
-        $this->post('/api/v1/components/groups');
+        $response = $this->json('POST', '/api/v1/components/groups');
 
-        $this->assertResponseStatus(401);
+        $response->assertStatus(401);
     }
 
-    public function testPostGroupNoData()
+    public function test_cannot_create_component_group_without_data()
     {
         $this->beUser();
 
-        $this->post('/api/v1/components/groups');
-        $this->assertResponseStatus(400);
+        $response = $this->json('POST', '/api/v1/components/groups');
+
+        $response->assertStatus(400);
     }
 
-    public function testPostGroup()
+    public function test_can_create_new_component_group()
     {
         $this->beUser();
 
-        $this->post('/api/v1/components/groups', [
+        $response = $this->json('POST', '/api/v1/components/groups', [
             'name'      => 'Foo',
             'order'     => 1,
             'collapsed' => 1,
             'visible'   => ComponentGroup::VISIBLE_GUEST,
         ]);
-        $this->seeJsonContains(['name' => 'Foo', 'order' => 1, 'collapsed' => 1, 'visible' => ComponentGroup::VISIBLE_GUEST]);
-        $this->assertResponseOk();
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'name'      => 'Foo',
+            'order'     => 1,
+            'collapsed' => 1,
+            'visible'   => ComponentGroup::VISIBLE_GUEST,
+        ]);
     }
 
-    public function testGetNewGroup()
+    public function test_can_get_single_component_group()
     {
-        $group = factory('CachetHQ\Cachet\Models\ComponentGroup')->create();
+        $group = factory(ComponentGroup::class)->create();
 
-        $this->get('/api/v1/components/groups/1');
-        $this->seeJsonContains(['name' => $group->name]);
-        $this->assertResponseOk();
+        $response = $this->json('GET', '/api/v1/components/groups/1');
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => $group->name]);
     }
 
-    public function testPutGroup()
+    public function test_can_update_component_group()
     {
         $this->beUser();
-        $group = factory('CachetHQ\Cachet\Models\ComponentGroup')->create();
+        $group = factory(ComponentGroup::class)->create();
 
-        $this->put('/api/v1/components/groups/1', [
+        $response = $this->json('PUT', '/api/v1/components/groups/1', [
             'name' => 'Lorem Ipsum Groupous',
         ]);
-        $this->seeJsonContains(['name' => 'Lorem Ipsum Groupous']);
-        $this->assertResponseOk();
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => 'Lorem Ipsum Groupous']);
     }
 
-    public function testDeleteGroup()
+    public function test_can_delete_component_group()
     {
         $this->beUser();
-        $group = factory('CachetHQ\Cachet\Models\ComponentGroup')->create();
+        $group = factory(ComponentGroup::class)->create();
 
-        $this->delete('/api/v1/components/groups/1');
-        $this->assertResponseStatus(204);
+        $response = $this->json('DELETE', '/api/v1/components/groups/1');
+
+        $response->assertStatus(204);
     }
 
-    /** @test */
-    public function only_public_component_groups_are_shown_for_a_guest()
+    public function test_only_public_component_groups_are_shown_for_a_guest()
     {
         $this->createComponentGroups();
 
-        $this->get('/api/v1/components/groups')
-            ->seeJsonContains(['name' => self::COMPONENT_GROUP_1_NAME]);
-        $this->assertResponseOk();
+        $response = $this->json('GET', '/api/v1/components/groups');
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => self::COMPONENT_GROUP_1_NAME]);
     }
 
-    /** @test */
-    public function all_component_groups_are_displayed_for_loggedin_users()
+    public function test_all_component_groups_are_displayed_for_logged_in_users()
     {
         $this->createComponentGroups()
             ->signIn();
 
-        $this->get('/api/v1/components/groups')
-            ->seeJsonContains(['name' => self::COMPONENT_GROUP_1_NAME])
-            ->seeJsonContains(['name' => self::COMPONENT_GROUP_2_NAME]);
-        $this->assertResponseOk();
+        $response = $this->json('GET', '/api/v1/components/groups');
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => self::COMPONENT_GROUP_1_NAME]);
     }
 
     /**
      * Set up the needed data for the tests.
      *
-     * @return TestCase
+     * @return $this
      */
     protected function createComponentGroups()
     {
@@ -139,13 +175,13 @@ class ComponentGroupTest extends AbstractApiTestCase
 
     /**
      * Create a component group.
-     * Also attaches a creator if any given as a parameter
-     * or exists in the test class.
+     *
+     * Also attaches a creator if any given as a parameter or exists in the test class.
      *
      * @param string $name
      * @param string $visible
      *
-     * @return AbstractApiTestCase
+     * @return $this
      */
     protected function createComponentGroup($name, $visible)
     {

--- a/tests/Api/ComponentGroupTest.php
+++ b/tests/Api/ComponentGroupTest.php
@@ -45,7 +45,7 @@ class ComponentGroupTest extends AbstractApiTestCase
                 'enabled_components'        => $groups[0]->enabled_components,
                 'enabled_components_lowest' => $groups[0]->enabled_components_lowest,
                 'lowest_human_status'       => $groups[0]->lowest_human_status,
-            ]
+            ],
         ]);
         $response->assertJsonFragment([
             [
@@ -59,7 +59,7 @@ class ComponentGroupTest extends AbstractApiTestCase
                 'enabled_components'        => $groups[1]->enabled_components,
                 'enabled_components_lowest' => $groups[1]->enabled_components_lowest,
                 'lowest_human_status'       => $groups[1]->lowest_human_status,
-            ]
+            ],
         ]);
     }
 

--- a/tests/Api/ComponentTest.php
+++ b/tests/Api/ComponentTest.php
@@ -11,6 +11,8 @@
 
 namespace CachetHQ\Tests\Cachet\Api;
 
+use CachetHQ\Cachet\Models\Component;
+
 /**
  * This is the component test class.
  *
@@ -19,43 +21,46 @@ namespace CachetHQ\Tests\Cachet\Api;
  */
 class ComponentTest extends AbstractApiTestCase
 {
-    public function testGetComponents()
+    public function test_can_get_all_components()
     {
-        $components = factory('CachetHQ\Cachet\Models\Component', 3)->create();
+        $components = factory(Component::class, 3)->create();
 
-        $this->get('/api/v1/components');
-        $this->seeJsonContains(['id' => $components[0]->id]);
-        $this->seeJsonContains(['id' => $components[1]->id]);
-        $this->seeJsonContains(['id' => $components[2]->id]);
-        $this->assertResponseOk();
+        $response = $this->json('GET', '/api/v1/components');
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['id' => $components[0]->id]);
+        $response->assertJsonFragment(['id' => $components[1]->id]);
+        $response->assertJsonFragment(['id' => $components[2]->id]);
     }
 
-    public function testGetInvalidComponent()
+    public function test_cannot_get_invalid_component()
     {
-        $this->get('/api/v1/components/1');
-        $this->assertResponseStatus(404);
+        $response = $this->json('GET', '/api/v1/components/1');
+
+        $response->assertStatus(404);
     }
 
-    public function testPostComponentUnauthorized()
+    public function test_cannot_create_component_without_authorization()
     {
-        $this->post('/api/v1/components');
+        $response = $this->json('POST', '/api/v1/components');
 
-        $this->assertResponseStatus(401);
+        $response->assertStatus(401);
     }
 
-    public function testPostComponentNoData()
+    public function test_cannot_create_component_without_data()
     {
         $this->beUser();
 
-        $this->post('/api/v1/components');
-        $this->assertResponseStatus(400);
+        $response = $this->json('POST', '/api/v1/components');
+
+        $response->assertStatus(400);
     }
 
-    public function testPostComponent()
+    public function test_can_create_component()
     {
         $this->beUser();
 
-        $this->post('/api/v1/components', [
+        $response = $this->json('POST', '/api/v1/components', [
             'name'        => 'Foo',
             'description' => 'Bar',
             'status'      => 1,
@@ -64,15 +69,16 @@ class ComponentTest extends AbstractApiTestCase
             'group_id'    => 1,
             'enabled'     => true,
         ]);
-        $this->seeJsonContains(['name' => 'Foo']);
-        $this->assertResponseOk();
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => 'Foo']);
     }
 
-    public function testPostComponentWithoutEnabledField()
+    public function test_can_create_component_without_enabled_field()
     {
         $this->beUser();
 
-        $this->post('/api/v1/components', [
+        $response = $this->json('POST', '/api/v1/components', [
             'name'        => 'Foo',
             'description' => 'Bar',
             'status'      => 1,
@@ -80,15 +86,16 @@ class ComponentTest extends AbstractApiTestCase
             'order'       => 1,
             'group_id'    => 1,
         ]);
-        $this->seeJsonContains(['name' => 'Foo', 'enabled' => true]);
-        $this->assertResponseOk();
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => 'Foo', 'enabled' => true]);
     }
 
-    public function testPostComponentWithMetaData()
+    public function test_can_create_component_with_meta_data()
     {
         $this->beUser();
 
-        $this->post('/api/v1/components', [
+        $response = $this->json('POST', '/api/v1/components', [
             'name'        => 'Foo',
             'description' => 'Bar',
             'status'      => 1,
@@ -101,19 +108,21 @@ class ComponentTest extends AbstractApiTestCase
             ],
         ]);
 
-        $this->seeJsonContains([
-            'meta' => [
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'name'   => 'Foo',
+            'status' => 1,
+            'meta'   => [
                 'uuid' => '172ff3fb-41f7-49d3-8bcd-f57b53627fa0',
             ],
         ]);
-        $this->assertResponseOk();
     }
 
-    public function testPostDisabledComponent()
+    public function test_can_create_disabled_component()
     {
         $this->beUser();
 
-        $this->post('/api/v1/components', [
+        $response = $this->json('POST', '/api/v1/components', [
             'name'        => 'Foo',
             'description' => 'Bar',
             'status'      => 1,
@@ -122,62 +131,65 @@ class ComponentTest extends AbstractApiTestCase
             'group_id'    => 1,
             'enabled'     => 0,
         ]);
-        $this->seeJsonContains(['name' => 'Foo', 'enabled' => false]);
-        $this->assertResponseOk();
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => 'Foo', 'enabled' => false]);
     }
 
-    public function testGetNewComponent()
+    public function test_can_get_newly_created_component()
     {
-        $component = factory('CachetHQ\Cachet\Models\Component')->create();
+        $component = factory(Component::class)->create();
 
-        $this->get('/api/v1/components/1');
-        $this->seeJsonContains(['name' => $component->name]);
-        $this->assertResponseOk();
+        $response = $this->json('GET', '/api/v1/components/1');
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => $component->name]);
     }
 
-    public function testPutComponent()
+    public function test_can_update_component()
     {
         $this->beUser();
-        $component = factory('CachetHQ\Cachet\Models\Component')->create();
+        $component = factory(Component::class)->create();
 
-        $this->put('/api/v1/components/1', [
+        $response = $this->json('PUT', '/api/v1/components/1', [
             'name' => 'Foo',
         ]);
-        $this->seeJsonContains(['name' => 'Foo']);
-        $this->assertResponseOk();
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => 'Foo']);
     }
 
-    public function testPutComponentWithMetaData()
+    public function test_can_update_component_with_meta_data()
     {
         $this->beUser();
-        $component = factory('CachetHQ\Cachet\Models\Component')->create([
+        $component = factory(Component::class)->create([
             'meta' => [
                 'uuid' => '172ff3fb-41f7-49d3-8bcd-f57b53627fa0',
             ],
         ]);
 
-        $this->put('/api/v1/components/1', [
+        $response = $this->json('PUT', '/api/v1/components/1', [
             'meta' => [
                 'uuid' => '172ff3fb-41f7-49d3-8bcd-f57b53627fa0',
                 'foo'  => 'bar',
             ],
         ]);
 
-        $this->seeJsonContains([
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
             'meta' => [
                 'uuid' => '172ff3fb-41f7-49d3-8bcd-f57b53627fa0',
                 'foo'  => 'bar',
             ],
         ]);
-        $this->assertResponseOk();
     }
 
-    public function testDeleteComponent()
+    public function test_can_delete_component()
     {
         $this->beUser();
-        $component = factory('CachetHQ\Cachet\Models\Component')->create();
+        $component = factory(Component::class)->create();
 
-        $this->delete('/api/v1/components/1');
-        $this->assertResponseStatus(204);
+        $response = $this->delete('/api/v1/components/1');
+        $response->assertStatus(204);
     }
 }

--- a/tests/Api/GeneralTest.php
+++ b/tests/Api/GeneralTest.php
@@ -19,26 +19,27 @@ namespace CachetHQ\Tests\Cachet\Api;
  */
 class GeneralTest extends AbstractApiTestCase
 {
-    public function testGetPing()
+    public function test_can_ping()
     {
-        $this->get('/api/v1/ping');
-        $this->seeJsonContains(['data' => 'Pong!']);
-        $this->assertResponseOk();
-        $this->seeHeader('Content-Type', 'application/json');
+        $response = $this->json('GET', '/api/v1/ping');
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'application/json');
+        $response->assertJsonFragment(['data' => 'Pong!']);
     }
 
-    public function testErrorPage()
+    public function test_see_error_page_for_unknown_endpoint()
     {
-        $this->get('/api/v1/not-found');
+        $response = $this->json('GET', '/api/v1/not-found');
 
-        $this->assertResponseStatus(404);
-        $this->seeHeader('Content-Type', 'application/json');
+        $response->assertStatus(404);
+        $response->assertHeader('Content-Type', 'application/json');
     }
 
-    public function testNotAcceptableContentType()
+    public function test_non_acceptable_content_type()
     {
-        $this->get('/api/v1/ping', ['HTTP_Accept' => 'text/html']);
+        $response = $this->json('GET', '/api/v1/ping', [], ['HTTP_Accept' => 'text/html']);
 
-        $this->assertResponseStatus(406);
+        $response->assertStatus(406);
     }
 }

--- a/tests/Api/IncidentTest.php
+++ b/tests/Api/IncidentTest.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Tests\Cachet\Api;
 
+use CachetHQ\Cachet\Models\Component;
 use CachetHQ\Cachet\Models\Incident;
 use CachetHQ\Cachet\Models\IncidentTemplate;
 
@@ -76,7 +77,7 @@ class IncidentTest extends AbstractApiTestCase
 
     public function test_can_create_incident_with_component_status()
     {
-        $component = factory('CachetHQ\Cachet\Models\Component')->create();
+        $component = factory(Component::class)->create();
 
         $this->beUser();
 

--- a/tests/Api/IncidentTest.php
+++ b/tests/Api/IncidentTest.php
@@ -11,6 +11,9 @@
 
 namespace CachetHQ\Tests\Cachet\Api;
 
+use CachetHQ\Cachet\Models\Incident;
+use CachetHQ\Cachet\Models\IncidentTemplate;
+
 /**
  * This is the incident test class.
  *
@@ -19,59 +22,65 @@ namespace CachetHQ\Tests\Cachet\Api;
  */
 class IncidentTest extends AbstractApiTestCase
 {
-    public function testGetIncidents()
+    public function test_can_get_all_incidents()
     {
-        $incidents = factory('CachetHQ\Cachet\Models\Incident', 3)->create();
+        $incidents = factory(Incident::class, 3)->create();
 
-        $this->get('/api/v1/incidents');
-        $this->seeJsonContains(['id' => $incidents[0]->id]);
-        $this->seeJsonContains(['id' => $incidents[1]->id]);
-        $this->seeJsonContains(['id' => $incidents[2]->id]);
-        $this->assertResponseOk();
+        $response = $this->json('GET', '/api/v1/incidents');
+
+        $response->assertStatus(200);
+
+        $response->assertJsonFragment(['id' => $incidents[0]->id]);
+        $response->assertJsonFragment(['id' => $incidents[1]->id]);
+        $response->assertJsonFragment(['id' => $incidents[2]->id]);
     }
 
-    public function testGetInvalidIncident()
+    public function test_cannot_get_invalid_component()
     {
-        $this->get('/api/v1/incidents/0');
-        $this->assertResponseStatus(404);
+        $response = $this->json('GET', '/api/v1/incidents/0');
+
+        $response->assertStatus(404);
     }
 
-    public function testPostIncidentUnauthorized()
+    public function test_cannot_create_incident_without_authorization()
     {
-        $this->post('/api/v1/incidents');
-        $this->assertResponseStatus(401);
+        $response = $this->json('POST', '/api/v1/incidents');
+
+        $response->assertStatus(401);
     }
 
-    public function testPostIncidentNoData()
+    public function test_cannot_create_incident_with_missing_data()
     {
         $this->beUser();
 
-        $this->post('/api/v1/incidents');
-        $this->assertResponseStatus(400);
+        $response = $this->json('POST', '/api/v1/incidents');
+
+        $response->assertStatus(400);
     }
 
-    public function testPostIncident()
+    public function test_can_create_incident()
     {
         $this->beUser();
 
-        $this->post('/api/v1/incidents', [
+        $response = $this->json('POST', '/api/v1/incidents', [
             'name'     => 'Foo',
             'message'  => 'Lorem ipsum dolor sit amet',
             'status'   => 1,
             'visible'  => 1,
             'stickied' => false,
         ]);
-        $this->seeJsonContains(['name' => 'Foo']);
-        $this->assertResponseOk();
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => 'Foo']);
     }
 
-    public function testPostIncidentWithComponentStatus()
+    public function test_can_create_incident_with_component_status()
     {
         $component = factory('CachetHQ\Cachet\Models\Component')->create();
 
         $this->beUser();
 
-        $this->post('/api/v1/incidents', [
+        $response = $this->json('POST', '/api/v1/incidents', [
             'name'             => 'Foo',
             'message'          => 'Lorem ipsum dolor sit amet',
             'status'           => 1,
@@ -80,16 +89,17 @@ class IncidentTest extends AbstractApiTestCase
             'visible'          => 1,
             'stickied'         => false,
         ]);
-        $this->seeJsonContains(['name' => 'Foo']);
-        $this->assertResponseOk();
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => 'Foo']);
     }
 
-    public function testCreateIncidentWithTemplate()
+    public function test_can_create_incident_with_template()
     {
-        $template = factory('CachetHQ\Cachet\Models\IncidentTemplate')->create();
+        $template = factory(IncidentTemplate::class)->create();
         $this->beUser();
 
-        $this->post('/api/v1/incidents', [
+        $response = $this->json('POST', '/api/v1/incidents', [
             'name'     => 'Foo',
             'status'   => 1,
             'visible'  => 1,
@@ -100,66 +110,72 @@ class IncidentTest extends AbstractApiTestCase
                 'message' => 'Hello there this is a foo!',
             ],
         ]);
-        $this->seeJsonContains([
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
             'name'    => 'Foo',
             'message' => "Name: Foo,\nMessage: Hello there this is a foo!",
         ]);
     }
 
-    public function testGetNewIncident()
+    public function test_can_get_newly_created_incident()
     {
-        $incident = factory('CachetHQ\Cachet\Models\Incident')->create();
+        $incident = factory(Incident::class)->create();
 
-        $this->get('/api/v1/incidents/1');
-        $this->seeJsonContains(['name' => $incident->name]);
-        $this->assertResponseOk();
+        $response = $this->json('GET', '/api/v1/incidents/1');
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => $incident->name]);
     }
 
-    public function testPutIncident()
+    public function test_can_update_incident()
     {
         $this->beUser();
-        $component = factory('CachetHQ\Cachet\Models\Incident')->create();
+        $component = factory(Incident::class)->create();
 
-        $this->put('/api/v1/incidents/1', [
+        $response = $this->json('PUT', '/api/v1/incidents/1', [
             'name' => 'Foo',
         ]);
-        $this->seeJsonContains(['name' => 'Foo']);
-        $this->assertResponseOk();
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => 'Foo']);
     }
 
-    public function testPutIncidentWithTemplate()
+    public function test_can_update_incident_with_template()
     {
         $this->beUser();
-        $template = factory('CachetHQ\Cachet\Models\IncidentTemplate')->create([
+        $template = factory(IncidentTemplate::class)->create([
             'template' => 'Hello there this is a foo in my {{ incident.name }}!',
         ]);
-        $component = factory('CachetHQ\Cachet\Models\Incident')->create();
+        $component = factory(Incident::class)->create();
 
-        $this->put('/api/v1/incidents/1', [
+        $response = $this->json('PUT', '/api/v1/incidents/1', [
             'name'     => 'Foo',
             'template' => $template->slug,
         ]);
-        $this->seeJsonContains([
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
             'name'    => 'Foo',
             'message' => 'Hello there this is a foo in my Foo!',
         ]);
-        $this->assertResponseOk();
     }
 
-    public function testDeleteIncident()
+    public function test_can_delete_incident()
     {
         $this->beUser();
-        $component = factory('CachetHQ\Cachet\Models\Incident')->create();
+        $component = factory(Incident::class)->create();
 
-        $this->delete('/api/v1/incidents/1');
-        $this->assertResponseStatus(204);
+        $response = $this->json('DELETE', '/api/v1/incidents/1');
+
+        $response->assertStatus(204);
     }
 
-    public function testCreateIncidentWithMeta()
+    public function test_can_create_incident_with_meta_data()
     {
         $this->beUser();
 
-        $this->post('/api/v1/incidents', [
+        $response = $this->json('POST', '/api/v1/incidents', [
             'name'    => 'Foo',
             'message' => 'Lorem ipsum dolor sit amet',
             'status'  => 1,
@@ -167,11 +183,12 @@ class IncidentTest extends AbstractApiTestCase
                 'id' => 123456789,
             ],
         ]);
-        $this->seeJsonContains([
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
             'meta' => [
                 'id' => 123456789,
             ],
         ]);
-        $this->assertResponseOk();
     }
 }

--- a/tests/Api/IncidentUpdateTest.php
+++ b/tests/Api/IncidentUpdateTest.php
@@ -11,6 +11,9 @@
 
 namespace CachetHQ\Tests\Cachet\Api;
 
+use CachetHQ\Cachet\Models\Incident;
+use CachetHQ\Cachet\Models\IncidentUpdate;
+
 /**
  * This is the incident update test class.
  *
@@ -18,85 +21,84 @@ namespace CachetHQ\Tests\Cachet\Api;
  */
 class IncidentUpdateTest extends AbstractApiTestCase
 {
-    public function testGetIncidentUpdates()
+    public function test_can_get_all_incident_updates()
     {
-        $incident = factory('CachetHQ\Cachet\Models\Incident')->create();
-        $updates = factory('CachetHQ\Cachet\Models\IncidentUpdate', 3)->create([
+        $incident = factory(Incident::class)->create();
+        $updates = factory(IncidentUpdate::class, 3)->create([
             'incident_id' => $incident->id,
         ]);
 
-        $this->get("/api/v1/incidents/{$incident->id}/updates");
+        $response = $this->json('GET', "/api/v1/incidents/{$incident->id}/updates");
 
-        $this->assertResponseOk();
+        $response->assertStatus(200);
 
-        $this->seeJsonContains(['id' => $updates[0]->id]);
-        $this->seeJsonContains(['id' => $updates[1]->id]);
-        $this->seeJsonContains(['id' => $updates[2]->id]);
+        $response->assertJsonFragment(['id' => $updates[0]->id]);
+        $response->assertJsonFragment(['id' => $updates[1]->id]);
+        $response->assertJsonFragment(['id' => $updates[2]->id]);
     }
 
-    public function testGetInvalidIncidentUpdate()
+    public function test_cannot_get_invalid_incident_update()
     {
-        $this->get('/api/v1/incidents/1/updates/1');
+        $response = $this->json('GET', '/api/v1/incidents/1/updates/1');
 
-        $this->assertResponseStatus(404);
+        $response->assertStatus(404);
     }
 
-    public function testPostIncidentUpdateUnauthorized()
+    public function test_cannot_create_incident_update_without_authorization()
     {
-        $incident = factory('CachetHQ\Cachet\Models\Incident')->create();
-        $this->post("/api/v1/incidents/{$incident->id}/updates");
+        $incident = factory(Incident::class)->create();
 
-        $this->assertResponseStatus(401);
+        $response = $this->json('POST', "/api/v1/incidents/{$incident->id}/updates");
+
+        $response->assertStatus(401);
     }
 
-    public function testPostIncidentUpdateNoData()
-    {
-        $this->beUser();
-        $incident = factory('CachetHQ\Cachet\Models\Incident')->create();
-
-        $this->post("/api/v1/incidents/{$incident->id}/updates");
-
-        $this->assertResponseStatus(400);
-    }
-
-    public function testPostIncidentUpdate()
+    public function test_cannot_create_incident_update_without_data()
     {
         $this->beUser();
-        $incident = factory('CachetHQ\Cachet\Models\Incident')->create();
+        $incident = factory(Incident::class)->create();
 
-        $this->post("/api/v1/incidents/{$incident->id}/updates", [
+        $response = $this->json('POST', "/api/v1/incidents/{$incident->id}/updates");
+
+        $response->assertStatus(400);
+    }
+
+    public function test_can_create_incident_update()
+    {
+        $this->beUser();
+        $incident = factory(Incident::class)->create();
+
+        $response = $this->json('POST', "/api/v1/incidents/{$incident->id}/updates", [
             'status'  => 4,
             'message' => 'Incident fixed!',
         ]);
 
-        $this->assertResponseOk();
-
-        $this->seeJsonContains(['incident_id' => $incident->id]);
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['incident_id' => $incident->id]);
     }
 
-    public function testPutIncidentUpdate()
+    public function test_can_update_incident_update()
     {
         $this->beUser();
-        $incident = factory('CachetHQ\Cachet\Models\Incident')->create();
-        $update = factory('CachetHQ\Cachet\Models\IncidentUpdate')->create();
+        $incident = factory(Incident::class)->create();
+        $update = factory(IncidentUpdate::class)->create();
 
-        $this->put("/api/v1/incidents/{$incident->id}/updates/{$update->id}", [
+        $response = $this->json('PUT', "/api/v1/incidents/{$incident->id}/updates/{$update->id}", [
             'message' => 'Message updated :smile:',
         ]);
 
-        $this->assertResponseOk();
-
-        $this->seeJsonContains(['message' => 'Message updated :smile:']);
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['message' => 'Message updated :smile:']);
     }
 
-    public function testDeleteIncidentUpdate()
+    public function test_can_delete_incident_update()
     {
         $this->beUser();
-        $incident = factory('CachetHQ\Cachet\Models\Incident')->create();
-        $update = factory('CachetHQ\Cachet\Models\IncidentUpdate')->create();
+        $incident = factory(Incident::class)->create();
+        $update = factory(IncidentUpdate::class)->create();
 
-        $this->delete("/api/v1/incidents/{$incident->id}/updates/{$update->id}");
+        $response = $this->json('DELETE', "/api/v1/incidents/{$incident->id}/updates/{$update->id}");
 
-        $this->assertResponseStatus(204);
+        $response->assertStatus(204);
     }
 }

--- a/tests/Api/MetricTest.php
+++ b/tests/Api/MetricTest.php
@@ -11,6 +11,8 @@
 
 namespace CachetHQ\Tests\Cachet\Api;
 
+use CachetHQ\Cachet\Models\Metric;
+
 /**
  * This is the metric test class.
  *
@@ -19,42 +21,43 @@ namespace CachetHQ\Tests\Cachet\Api;
  */
 class MetricTest extends AbstractApiTestCase
 {
-    public function testGetMetrics()
+    public function test_can_get_all_metrics()
     {
-        $metrics = factory('CachetHQ\Cachet\Models\Metric', 3)->create();
+        $metrics = factory(Metric::class, 3)->create();
 
-        $this->get('/api/v1/metrics');
-        $this->seeJsonContains(['id' => $metrics[0]->id]);
-        $this->seeJsonContains(['id' => $metrics[1]->id]);
-        $this->seeJsonContains(['id' => $metrics[2]->id]);
-        $this->assertResponseOk();
+        $response = $this->json('GET', '/api/v1/metrics');
+
+        $response->assertJsonFragment(['id' => $metrics[0]->id]);
+        $response->assertJsonFragment(['id' => $metrics[1]->id]);
+        $response->assertJsonFragment(['id' => $metrics[2]->id]);
+        $response->assertStatus(200);
     }
 
-    public function testGetInvalidMetric()
+    public function test_cannot_get_invalid_metric()
     {
-        $this->get('/api/v1/metrics/0');
-        $this->assertResponseStatus(404);
+        $response = $this->json('GET', '/api/v1/metrics/0');
+        $response->assertStatus(404);
     }
 
-    public function testPostMetricUnauthorized()
+    public function test_cannot_create_metric_without_authorization()
     {
-        $this->post('/api/v1/metrics');
-        $this->assertResponseStatus(401);
+        $response = $this->json('POST', '/api/v1/metrics');
+        $response->assertStatus(401);
     }
 
-    public function testPostMetricNoData()
+    public function test_cannot_create_metric_without_data()
     {
         $this->beUser();
 
-        $this->post('/api/v1/metrics');
-        $this->assertResponseStatus(400);
+        $response = $this->json('POST', '/api/v1/metrics');
+        $response->assertStatus(400);
     }
 
-    public function testPostMetric()
+    public function test_can_create_metric()
     {
         $this->beUser();
 
-        $this->post('/api/v1/metrics', [
+        $response = $this->json('POST', '/api/v1/metrics', [
             'name'          => 'Foo',
             'suffix'        => 'foo\'s per second',
             'description'   => 'Lorem ipsum dolor',
@@ -65,38 +68,42 @@ class MetricTest extends AbstractApiTestCase
             'threshold'     => 5,
             'order'         => 1,
         ]);
-        $this->seeJsonContains(['name' => 'Foo']);
-        $this->assertResponseOk();
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => 'Foo']);
     }
 
-    public function testGetNewMetric()
+    public function test_can_get_newly_created_metric()
     {
-        $incident = factory('CachetHQ\Cachet\Models\Metric')->create();
+        $incident = factory(Metric::class)->create();
 
-        $this->get('/api/v1/metrics/1');
-        $this->seeJsonContains(['name' => $incident->name]);
-        $this->assertResponseOk();
+        $response = $this->json('GET', '/api/v1/metrics/1');
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => $incident->name]);
     }
 
-    public function testPutMetric()
+    public function test_can_update_metric()
     {
         $this->beUser();
-        $metric = factory('CachetHQ\Cachet\Models\Metric')->create();
+        $metric = factory(Metric::class)->create();
 
-        $this->put('/api/v1/metrics/1', [
+        $response = $this->json('PUT', '/api/v1/metrics/1', [
             'name' => 'Foo',
             'view' => 2,
         ]);
-        $this->seeJsonContains(['name' => 'Foo', 'default_view' => 2]);
-        $this->assertResponseOk();
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => 'Foo', 'default_view' => 2]);
     }
 
-    public function testDeleteMetric()
+    public function test_can_delete_metric()
     {
         $this->beUser();
-        $metric = factory('CachetHQ\Cachet\Models\Metric')->create();
+        $metric = factory(Metric::class)->create();
 
-        $this->delete('/api/v1/metrics/1');
-        $this->assertResponseStatus(204);
+        $response = $this->json('DELETE', '/api/v1/metrics/1');
+
+        $response->assertStatus(204);
     }
 }

--- a/tests/Api/ScheduleTest.php
+++ b/tests/Api/ScheduleTest.php
@@ -11,6 +11,8 @@
 
 namespace CachetHQ\Tests\Cachet\Api;
 
+use CachetHQ\Cachet\Models\Schedule;
+
 /**
  * This is the schedule test class.
  *
@@ -18,31 +20,29 @@ namespace CachetHQ\Tests\Cachet\Api;
  */
 class ScheduleTest extends AbstractApiTestCase
 {
-    public function testGetSchedules()
+    public function test_can_get_all_schedules()
     {
-        $schedules = factory('CachetHQ\Cachet\Models\Schedule', 3)->create();
+        $schedules = factory(Schedule::class, 3)->create();
 
-        $this->get('/api/v1/schedules');
+        $response = $this->json('GET', '/api/v1/schedules');
 
-        $this->assertResponseOk();
-
-        $this->seeJsonContains(['id' => $schedules[0]->id]);
-        $this->seeJsonContains(['id' => $schedules[1]->id]);
-        $this->seeJsonContains(['id' => $schedules[2]->id]);
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['id' => $schedules[0]->id]);
+        $response->assertJsonFragment(['id' => $schedules[1]->id]);
+        $response->assertJsonFragment(['id' => $schedules[2]->id]);
     }
 
-    public function testGetSchedule()
+    public function test_can_get_single_schedule()
     {
-        $schedule = factory('CachetHQ\Cachet\Models\Schedule')->create();
+        $schedule = factory(Schedule::class)->create();
 
-        $this->get('/api/v1/schedules/'.$schedule->id);
+        $response = $this->json('GET', '/api/v1/schedules/'.$schedule->id);
 
-        $this->assertResponseOk();
-
-        $this->seeJsonContains(['name' => $schedule->name]);
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => $schedule->name]);
     }
 
-    public function testCreateSchedule()
+    public function test_can_create_schedule()
     {
         $this->beUser();
 
@@ -53,36 +53,35 @@ class ScheduleTest extends AbstractApiTestCase
             'scheduled_at' => date('Y-m-d H:i'),
         ];
 
-        $this->post('/api/v1/schedules/', $schedule);
+        $response = $this->json('POST', '/api/v1/schedules/', $schedule);
 
         array_forget($schedule, 'scheduled_at');
 
-        $this->assertResponseOk();
-        $this->seeJsonContains($schedule);
+        $response->assertStatus(200);
+        $response->assertJsonFragment($schedule);
     }
 
-    public function testUpdateSchedule()
+    public function test_can_update_schedule()
     {
         $this->beUser();
 
-        $schedule = factory('CachetHQ\Cachet\Models\Schedule')->create();
+        $schedule = factory(Schedule::class)->create();
 
-        $this->put('/api/v1/schedules/'.$schedule->id, [
+        $response = $this->json('PUT', '/api/v1/schedules/'.$schedule->id, [
             'name' => 'Updated schedule',
         ]);
 
-        $this->assertResponseOk();
-
-        $this->seeJsonContains(['name' => 'Updated schedule']);
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => 'Updated schedule']);
     }
 
-    public function testDeleteSchedule()
+    public function test_can_delete_schedule()
     {
         $this->beUser();
-        factory('CachetHQ\Cachet\Models\Schedule')->create();
+        factory(Schedule::class)->create();
 
-        $this->delete('/api/v1/schedules/1');
+        $response = $this->json('DELETE', '/api/v1/schedules/1');
 
-        $this->assertResponseStatus(204);
+        $response->assertStatus(204);
     }
 }


### PR DESCRIPTION
- Test names are now switched to underscore case for easier naming patterns.
- I've removed `laravel/browser-kit-testing` as it's a requirement we didn't need.
- Model factories now use the `::class` notation.

Next part of this is to go through each test case and ensure we're testing for everything (#3083)