### PR TITLE
Fix how tags are created

### DIFF
--- a/app/Bus/Commands/Tag/ApplyTagCommand.php
+++ b/app/Bus/Commands/Tag/ApplyTagCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Commands\Tag;
+
+use CachetHQ\Cachet\Models\Tag;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * This is the apply tag coommand class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+final class ApplyTagCommand
+{
+    /**
+     * The model to apply the tag to.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    public $model;
+
+    /**
+     * The tag to apply.
+     *
+     * @var \CachetHQ\Cachet\Models\Tag
+     */
+    public $tag;
+
+    /**
+     * Create a new apply tag command instance.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param \CachetHQ\Cachet\Models\Tag         $tag
+     *
+     * @return void
+     */
+    public function __construct(Model $model, Tag $tag)
+    {
+        $this->model = $model;
+        $this->tag = $tag;
+    }
+}

--- a/app/Bus/Commands/Tag/CreateTagCommand.php
+++ b/app/Bus/Commands/Tag/CreateTagCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Commands\Tag;
+
+/**
+ * This is the create tag coommand class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+final class CreateTagCommand
+{
+    /**
+     * The tag name.
+     *
+     * @var string
+     */
+    public $name;
+
+    /**
+     * The tag slug.
+     *
+     * @var string|null
+     */
+    public $slug;
+
+    /**
+     * Create a new create tag command instance.
+     *
+     * @param string      $name
+     * @param string|null $slug
+     *
+     * @return void
+     */
+    public function __construct($name, $slug = null)
+    {
+        $this->name = $name;
+        $this->slug = $slug;
+    }
+}

--- a/app/Bus/Commands/Tag/DeleteTagCommand.php
+++ b/app/Bus/Commands/Tag/DeleteTagCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Commands\Tag;
+
+use CachetHQ\Cachet\Models\Tag;
+
+/**
+ * This is the delete tag coommand class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+final class DeleteTagCommand
+{
+    /**
+     * The tag.
+     *
+     * @var \CachetHQ\Cachet\Models\Tag
+     */
+    public $tag;
+
+    /**
+     * Create a new delete tag command instance.
+     *
+     * @param \CachetHQ\Cachet\Models\Tag $tag
+     *
+     * @return void
+     */
+    public function __construct(Tag $tag)
+    {
+        $this->tag = $tag;
+    }
+}

--- a/app/Bus/Commands/Tag/UpdateTagCommand.php
+++ b/app/Bus/Commands/Tag/UpdateTagCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Commands\Tag;
+
+use CachetHQ\Cachet\Models\Tag;
+
+/**
+ * This is the update tag coommand class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+final class UpdateTagCommand
+{
+    /**
+     * The tag.
+     *
+     * @var \CachetHQ\Cachet\Models\Tag
+     */
+    public $tag;
+
+    /**
+     * The new tag name.
+     *
+     * @var string|null
+     */
+    public $name;
+
+    /**
+     * The new tag slug.
+     *
+     * @var string|null
+     */
+    public $slug;
+
+    /**
+     * Create a new update tag command instance.
+     *
+     * @param \CachetHQ\Cachet\Models\Tag $tag
+     * @param string|null                 $name
+     * @param string|null                 $slug
+     *
+     * @return void
+     */
+    public function __construct(Tag $tag, $name, $slug)
+    {
+        $this->tag = $tag;
+        $this->name = $name;
+        $this->slug = $slug;
+    }
+}

--- a/app/Bus/Handlers/Commands/Tag/ApplyTagCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Tag/ApplyTagCommandHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Commands\Tag;
+
+use CachetHQ\Cachet\Bus\Commands\Tag\ApplyTagCommand;
+use CachetHQ\Cachet\Models\Taggable;
+
+/**
+ * This is the apply tag command handler class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class ApplyTagCommandHandler
+{
+    /**
+     * Handle the command.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\Tag\ApplyTagCommand $command
+     *
+     * @return void
+     */
+    public function handle(ApplyTagCommand $command)
+    {
+        Taggable::firstOrCreate([
+            'tag_id'        => $command->tag->id,
+            'taggable_id'   => $command->model->id,
+            'taggable_type' => $command->model->getTable(),
+        ]);
+    }
+}

--- a/app/Bus/Handlers/Commands/Tag/CreateTagCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Tag/CreateTagCommandHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Commands\Tag;
+
+use CachetHQ\Cachet\Bus\Commands\Tag\CreateTagCommand;
+use CachetHQ\Cachet\Models\Tag;
+use Illuminate\Support\Str;
+
+/**
+ * This is the create tag command handler class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class CreateTagCommandHandler
+{
+    /**
+     * Handle the command.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\Tag\CreateTagCommand $command
+     *
+     * @return \CachetHQ\Cachet\Models\Tag
+     */
+    public function handle(CreateTagCommand $command)
+    {
+        return Tag::firstOrCreate([
+            'name' => $command->name,
+            'slug' => $command->slug ? $command->slug : Str::slug($command->name),
+        ]);
+    }
+}

--- a/app/Bus/Handlers/Commands/Tag/DeleteTagCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Tag/DeleteTagCommandHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Commands\Tag;
+
+use CachetHQ\Cachet\Bus\Commands\Tag\DeleteTagCommand;
+
+/**
+ * This is the delete tag command handler class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class DeleteTagCommandHandler
+{
+    /**
+     * Handle the command.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\Tag\DeleteTagCommand $command
+     *
+     * @return \CachetHQ\Cachet\Models\Tag
+     */
+    public function handle(DeleteTagCommand $command)
+    {
+        $command->tag->delete();
+    }
+}

--- a/app/Bus/Handlers/Commands/Tag/UpdateTagCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Tag/UpdateTagCommandHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Bus\Handlers\Commands\Tag;
+
+use CachetHQ\Cachet\Bus\Commands\Tag\UpdateTagCommand;
+use Illuminate\Support\Str;
+
+/**
+ * This is the create tag command handler class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class UpdateTagCommandHandler
+{
+    /**
+     * Handle the command.
+     *
+     * @param \CachetHQ\Cachet\Bus\Commands\Tag\UpdateTagCommand $command
+     *
+     * @return void
+     */
+    public function handle(UpdateTagCommand $command)
+    {
+        return $command->tag->update([
+            'name' => $command->name,
+            'slug' => $command->slug ? $command->slug : Str::slug($command->name),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/ComponentController.php
+++ b/app/Http/Controllers/Api/ComponentController.php
@@ -20,6 +20,7 @@ use CachetHQ\Cachet\Models\Component;
 use GrahamCampbell\Binput\Facades\Binput;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Database\QueryException;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 

--- a/app/Http/Controllers/Api/ComponentController.php
+++ b/app/Http/Controllers/Api/ComponentController.php
@@ -14,8 +14,9 @@ namespace CachetHQ\Cachet\Http\Controllers\Api;
 use CachetHQ\Cachet\Bus\Commands\Component\CreateComponentCommand;
 use CachetHQ\Cachet\Bus\Commands\Component\RemoveComponentCommand;
 use CachetHQ\Cachet\Bus\Commands\Component\UpdateComponentCommand;
+use CachetHQ\Cachet\Bus\Commands\Tag\ApplyTagCommand;
+use CachetHQ\Cachet\Bus\Commands\Tag\CreateTagCommand;
 use CachetHQ\Cachet\Models\Component;
-use CachetHQ\Cachet\Models\Tag;
 use GrahamCampbell\Binput\Facades\Binput;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Database\QueryException;
@@ -85,17 +86,16 @@ class ComponentController extends AbstractApiController
         }
 
         if (Binput::has('tags')) {
+            $component->tags()->delete();
+
             // The component was added successfully, so now let's deal with the tags.
-            $tags = preg_split('/ ?, ?/', Binput::get('tags'));
-
-            // For every tag, do we need to create it?
-            $componentTags = array_map(function ($taggable) use ($component) {
-                return Tag::firstOrCreate([
-                    'name' => $taggable,
-                ])->id;
-            }, $tags);
-
-            $component->tags()->sync($componentTags);
+            Collection::make(preg_split('/ ?, ?/', $tags))->map(function ($tag) {
+                return trim($tag);
+            })->map(function ($tag) {
+                return dispatch(new CreateTagCommand($tag));
+            })->each(function ($tag) use ($component) {
+                dispatch(new ApplyTagCommand($component, $tag));
+            });
         }
 
         return $this->item($component);
@@ -128,14 +128,16 @@ class ComponentController extends AbstractApiController
         }
 
         if (Binput::has('tags')) {
-            $tags = preg_split('/ ?, ?/', Binput::get('tags'));
+            $component->tags()->delete();
 
-            // For every tag, do we need to create it?
-            $componentTags = array_map(function ($taggable) use ($component) {
-                return Tag::firstOrCreate(['name' => $taggable])->id;
-            }, $tags);
-
-            $component->tags()->sync($componentTags);
+            // The component was added successfully, so now let's deal with the tags.
+            Collection::make(preg_split('/ ?, ?/', $tags))->map(function ($tag) {
+                return trim($tag);
+            })->map(function ($tag) {
+                return dispatch(new CreateTagCommand($tag));
+            })->each(function ($tag) use ($component) {
+                dispatch(new ApplyTagCommand($component, $tag));
+            });
         }
 
         return $this->item($component);

--- a/resources/views/dashboard/components/edit.blade.php
+++ b/resources/views/dashboard/components/edit.blade.php
@@ -53,7 +53,7 @@
                     </div>
                     <div class="form-group">
                         <label>{{ trans('forms.components.tags') }}</label>
-                        <input name="component[tags]" class="form-control" value="{{ $component->tagsList }}" placeholder="{{ trans('forms.components.tags') }}">
+                        <input name="component[tags]" class="form-control" value="{{ $component->tags->implode(', ') }}" placeholder="{{ trans('forms.components.tags') }}">
                         <span class="help-block">{{ trans('forms.components.tags-help') }}</span>
                     </div>
                     <div class="checkbox">

--- a/tests/Bus/Commands/Tag/ApplyTagCommandTest.php
+++ b/tests/Bus/Commands/Tag/ApplyTagCommandTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Bus\Commands\Tag;
+
+use AltThree\TestBench\CommandTrait;
+use CachetHQ\Cachet\Bus\Commands\Tag\ApplyTagCommand;
+use CachetHQ\Cachet\Bus\Handlers\Commands\Tag\ApplyTagCommandHandler;
+use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\Tag;
+use CachetHQ\Tests\Cachet\AbstractTestCase;
+
+/**
+ * This is the apply tag command test class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class ApplyTagCommandTest extends AbstractTestCase
+{
+    use CommandTrait;
+
+    protected function getObjectAndParams()
+    {
+        $params = [
+            'model' => new Component(),
+            'tag'   => new Tag(),
+        ];
+
+        $object = new ApplyTagCommand(
+            $params['model'],
+            $params['tag']
+        );
+
+        return compact('params', 'object');
+    }
+
+    protected function objectHasRules()
+    {
+        return false;
+    }
+
+    protected function getHandlerClass()
+    {
+        return ApplyTagCommandHandler::class;
+    }
+}

--- a/tests/Bus/Commands/Tag/CreateTagCommandTest.php
+++ b/tests/Bus/Commands/Tag/CreateTagCommandTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Bus\Commands\Tag;
+
+use AltThree\TestBench\CommandTrait;
+use CachetHQ\Cachet\Bus\Commands\Tag\CreateTagCommand;
+use CachetHQ\Cachet\Bus\Handlers\Commands\Tag\CreateTagCommandHandler;
+use CachetHQ\Tests\Cachet\AbstractTestCase;
+
+/**
+ * This is the create tag command test class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class CreateTagCommandTest extends AbstractTestCase
+{
+    use CommandTrait;
+
+    protected function getObjectAndParams()
+    {
+        $params = [
+            'name' => 'Test',
+            'slug' => 'test',
+        ];
+
+        $object = new CreateTagCommand(
+            $params['name'],
+            $params['slug']
+        );
+
+        return compact('params', 'object');
+    }
+
+    protected function objectHasRules()
+    {
+        return false;
+    }
+
+    protected function getHandlerClass()
+    {
+        return CreateTagCommandHandler::class;
+    }
+}

--- a/tests/Bus/Commands/Tag/DeleteTagCommandTest.php
+++ b/tests/Bus/Commands/Tag/DeleteTagCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Bus\Commands\Tag;
+
+use AltThree\TestBench\CommandTrait;
+use CachetHQ\Cachet\Bus\Commands\Tag\DeleteTagCommand;
+use CachetHQ\Cachet\Bus\Handlers\Commands\Tag\DeleteTagCommandHandler;
+use CachetHQ\Cachet\Models\Tag;
+use CachetHQ\Tests\Cachet\AbstractTestCase;
+
+/**
+ * This is the delete tag command test class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class DeleteTagCommandTest extends AbstractTestCase
+{
+    use CommandTrait;
+
+    protected function getObjectAndParams()
+    {
+        $params = [
+            'tag' => new Tag(),
+        ];
+
+        $object = new DeleteTagCommand(
+            $params['tag']
+        );
+
+        return compact('params', 'object');
+    }
+
+    protected function objectHasRules()
+    {
+        return false;
+    }
+
+    protected function getHandlerClass()
+    {
+        return DeleteTagCommandHandler::class;
+    }
+}

--- a/tests/Bus/Commands/Tag/UpdateTagCommandTest.php
+++ b/tests/Bus/Commands/Tag/UpdateTagCommandTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Bus\Commands\Tag;
+
+use AltThree\TestBench\CommandTrait;
+use CachetHQ\Cachet\Bus\Commands\Tag\UpdateTagCommand;
+use CachetHQ\Cachet\Bus\Handlers\Commands\Tag\UpdateTagCommandHandler;
+use CachetHQ\Cachet\Models\Tag;
+use CachetHQ\Tests\Cachet\AbstractTestCase;
+
+/**
+ * This is the update tag command test class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class UpdateTagCommandTest extends AbstractTestCase
+{
+    use CommandTrait;
+
+    protected function getObjectAndParams()
+    {
+        $params = [
+            'tag'  => new Tag(),
+            'name' => 'Test',
+            'slug' => 'test',
+        ];
+
+        $object = new UpdateTagCommand(
+            $params['tag'],
+            $params['name'],
+            $params['slug']
+        );
+
+        return compact('params', 'object');
+    }
+
+    protected function objectHasRules()
+    {
+        return false;
+    }
+
+    protected function getHandlerClass()
+    {
+        return UpdateTagCommandHandler::class;
+    }
+}


### PR DESCRIPTION
Fixes #3004

---

We now have commands that create, delete, update and apply tags. This fixes the issue where `sync` is not available on a `ManyToMany` relation.