### PR TITLE
Test for status changes before firing event

### DIFF
--- a/app/Bus/Commands/Component/UpdateComponentCommand.php
+++ b/app/Bus/Commands/Component/UpdateComponentCommand.php
@@ -25,49 +25,49 @@ final class UpdateComponentCommand
     /**
      * The component name.
      *
-     * @var string
+     * @var string|null
      */
     public $name;
 
     /**
      * The component description.
      *
-     * @var string
+     * @var string|null
      */
     public $description;
 
     /**
      * The component status.
      *
-     * @var int
+     * @var int|null
      */
     public $status;
 
     /**
      * The component link.
      *
-     * @var string
+     * @var string|null
      */
     public $link;
 
     /**
      * The component order.
      *
-     * @var int
+     * @var int|null
      */
     public $order;
 
     /**
      * The component group.
      *
-     * @var int
+     * @var int|null
      */
     public $group_id;
 
     /**
      * Is the component enabled?
      *
-     * @var bool
+     * @var bool|null
      */
     public $enabled;
 
@@ -106,24 +106,24 @@ final class UpdateComponentCommand
      * Create a new update component command instance.
      *
      * @param \CachetHQ\Cachet\Models\Component $component
-     * @param string                            $name
-     * @param string                            $description
-     * @param int                               $status
-     * @param string                            $link
-     * @param int                               $order
-     * @param int                               $group_id
-     * @param bool                              $enabled
+     * @param string|null                       $name
+     * @param string|null                       $description
+     * @param int|null                          $status
+     * @param string|null                       $link
+     * @param int|null                          $order
+     * @param int|null                          $group_id
+     * @param bool|null                         $enabled
      * @param array|null                        $meta
      * @param bool                              $silent
      *
      * @return void
      */
-    public function __construct(Component $component, $name, $description, $status, $link, $order, $group_id, $enabled, $meta, $silent)
+    public function __construct(Component $component, $name = null, $description = null, $status = null, $link = null, $order = null, $group_id = null, $enabled = null, $meta = null, $silent = null)
     {
         $this->component = $component;
         $this->name = $name;
         $this->description = $description;
-        $this->status = (int) $status;
+        $this->status = $status;
         $this->link = $link;
         $this->order = $order;
         $this->group_id = $group_id;

--- a/app/Bus/Handlers/Commands/Component/UpdateComponentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Component/UpdateComponentCommandHandler.php
@@ -50,7 +50,9 @@ class UpdateComponentCommandHandler
         $component = $command->component;
         $originalStatus = $component->status;
 
-        event(new ComponentStatusWasChangedEvent($this->auth->user(), $component, $originalStatus, $command->status, $command->silent));
+        if ($command->status && (int) $originalStatus !== (int) $command->status) {
+            event(new ComponentStatusWasChangedEvent($this->auth->user(), $component, $originalStatus, $command->status, $command->silent));
+        }
 
         $component->update($this->filter($command));
 

--- a/app/Http/Controllers/Api/ComponentController.php
+++ b/app/Http/Controllers/Api/ComponentController.php
@@ -119,7 +119,7 @@ class ComponentController extends AbstractApiController
                 Binput::get('link'),
                 Binput::get('order'),
                 Binput::get('group_id'),
-                (bool) Binput::get('enabled', true),
+                (bool) Binput::get('enabled'),
                 Binput::get('meta', null),
                 (bool) Binput::get('silent', false)
             ));


### PR DESCRIPTION
Fixes #3082

---

We now compare the original component status and the new status before we fire the `ComponentStatusWasChangedEvent` event.