### PR TITLE
Creating incidents linked to components don't require a component status

### DIFF
--- a/app/Bus/Commands/Incident/CreateIncidentCommand.php
+++ b/app/Bus/Commands/Incident/CreateIncidentCommand.php
@@ -114,7 +114,7 @@ final class CreateIncidentCommand
         'message'          => 'nullable|string',
         'visible'          => 'nullable|bool',
         'component_id'     => 'nullable|required_with:component_status|int',
-        'component_status' => 'nullable|required_with:component_id|int|min:0|max:4',
+        'component_status' => 'nullable|int|min:0|max:4',
         'notify'           => 'nullable|bool',
         'stickied'         => 'required|bool',
         'occurred_at'      => 'nullable|string',

--- a/app/Bus/Handlers/Commands/Incident/CreateIncidentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Incident/CreateIncidentCommandHandler.php
@@ -114,8 +114,8 @@ class CreateIncidentCommandHandler
             }
         }
 
-        // Update the component.
-        if ($component = Component::find($command->component_id)) {
+        // Update the component if we have a component and the status is set.
+        if ($component = Component::find($command->component_id) && $command->component_status) {
             dispatch(new UpdateComponentCommand(
                 Component::find($command->component_id),
                 null,

--- a/tests/Api/IncidentTest.php
+++ b/tests/Api/IncidentTest.php
@@ -84,7 +84,28 @@ class IncidentTest extends AbstractApiTestCase
         $response->assertJsonFragment(['name' => 'Foo']);
     }
 
-    public function test_can_create_incident_with_component_status()
+    public function test_can_create_incident_with_component_no_status()
+    {
+        $component = factory(Component::class)->create();
+
+        $this->beUser();
+
+        $this->expectsEvents(IncidentWasCreatedEvent::class);
+
+        $response = $this->json('POST', '/api/v1/incidents', [
+            'name'             => 'Foo',
+            'message'          => 'Lorem ipsum dolor sit amet',
+            'status'           => 1,
+            'component_id'     => $component->id,
+            'visible'          => 1,
+            'stickied'         => false,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => 'Foo']);
+    }
+
+    public function test_can_create_incident_with_component_and_status()
     {
         $component = factory(Component::class)->create();
 


### PR DESCRIPTION
Fixes #2809 

---

A component status is no longer required when linking a newly created incident to a component. The component's status will no longer be modified.