### PR TITLE
Fix mail markdown notifications

### DIFF
--- a/app/Notifications/Incident/NewIncidentNotification.php
+++ b/app/Notifications/Incident/NewIncidentNotification.php
@@ -76,14 +76,14 @@ class NewIncidentNotification extends Notification
         return (new MailMessage())
                     ->subject(trans('notifications.incident.new.mail.subject'))
                     ->markdown('notifications.incident.new', [
-                        'incident'   => $this->incident,
-                        'content'    => $content,
-                        'actionText' => trans('notifications.incident.new.mail.action'),
-                        'actionUrl'  => cachet_route('incident', [$this->incident]),
-                        'unsubscribeText' => trans('cachet.subscriber.unsubscribe'),
-                        'unsubscribeUrl' => cachet_route('subscribe.unsubscribe', $notifiable->verify_code),
+                        'incident'               => $this->incident,
+                        'content'                => $content,
+                        'actionText'             => trans('notifications.incident.new.mail.action'),
+                        'actionUrl'              => cachet_route('incident', [$this->incident]),
+                        'unsubscribeText'        => trans('cachet.subscriber.unsubscribe'),
+                        'unsubscribeUrl'         => cachet_route('subscribe.unsubscribe', $notifiable->verify_code),
                         'manageSubscriptionText' => trans('cachet.subscriber.manage_subscription'),
-                        'manageSubscriptionUrl' => cachet_route('subscribe.manage', $notifiable->verify_code),
+                        'manageSubscriptionUrl'  => cachet_route('subscribe.manage', $notifiable->verify_code),
                     ]);
     }
 

--- a/app/Notifications/Incident/NewIncidentNotification.php
+++ b/app/Notifications/Incident/NewIncidentNotification.php
@@ -75,12 +75,16 @@ class NewIncidentNotification extends Notification
 
         return (new MailMessage())
                     ->subject(trans('notifications.incident.new.mail.subject'))
-                    ->greeting(trans('notifications.incident.new.mail.greeting', ['app_name' => Config::get('setting.app_name')]))
-                    ->line($content)
-                    ->action(trans('notifications.incident.new.mail.action'), cachet_route('incident', [$this->incident]))
-                    ->line($this->incident->raw_message)
-                    ->line(trans('cachet.subscriber.unsubscribe', ['link' => cachet_route('subscribe.unsubscribe', $notifiable->verify_code)]))
-                    ->line(trans('cachet.subscriber.manage.manage_at_link', ['link' => cachet_route('subscribe.manage', $notifiable->verify_code)]));
+                    ->markdown('notifications.incident.new', [
+                        'incident'   => $this->incident,
+                        'content'    => $content,
+                        'actionText' => trans('notifications.incident.new.mail.action'),
+                        'actionUrl'  => cachet_route('incident', [$this->incident]),
+                        'unsubscribeText' => trans('cachet.subscriber.unsubscribe'),
+                        'unsubscribeUrl' => cachet_route('subscribe.unsubscribe', $notifiable->verify_code),
+                        'manageSubscriptionText' => trans('cachet.subscriber.manage_subscription'),
+                        'manageSubscriptionUrl' => cachet_route('subscribe.manage', $notifiable->verify_code),
+                    ]);
     }
 
     /**

--- a/resources/lang/en/cachet.php
+++ b/resources/lang/en/cachet.php
@@ -75,10 +75,11 @@ return [
 
     // Subscriber
     'subscriber' => [
-        'subscribe'   => 'Subscribe to get the updates',
-        'unsubscribe' => 'Unsubscribe at :link',
-        'button'      => 'Subscribe',
-        'manage'      => [
+        'subscribe'           => 'Subscribe to get the updates',
+        'unsubscribe'         => 'Unsubscribe',
+        'button'              => 'Subscribe',
+        'manage_subscription' => 'Manage subscription',
+        'manage'              => [
             'no_subscriptions' => 'You\'re currently subscribed to all updates.',
             'my_subscriptions' => 'You\'re currently subscribed to the following updates.',
             'manage_at_link'   => 'Manage your subscriptions at :link',

--- a/resources/views/notifications/incident/new.blade.php
+++ b/resources/views/notifications/incident/new.blade.php
@@ -8,10 +8,8 @@
 @endcomponent
 
 Thanks,<br>
-{{ config('app.name') }}
+{{ Config::get('setting.app_name') }}
 
-@component('mail::subcopy')
-[{{ $unsubscribeText }}]({{ $unsubscribeUrl }}) &mdash; [{{ $manageSubscriptionText }}]({{ $manageSubscriptionUrl }})
-@endcomponent
+@include('notifications.partials.subscription')
 
 @endcomponent

--- a/resources/views/notifications/incident/new.blade.php
+++ b/resources/views/notifications/incident/new.blade.php
@@ -1,0 +1,17 @@
+@component('mail::message')
+# {{ trans('notifications.incident.new.mail.greeting', ['app_name' => Config::get('setting.app_name')]) }}
+
+{{ $incident->message }}
+
+@component('mail::button', ['url' => $actionUrl])
+{{ $actionText }}
+@endcomponent
+
+Thanks,<br>
+{{ config('app.name') }}
+
+@component('mail::subcopy')
+[{{ $unsubscribeText }}]({{ $unsubscribeUrl }}) &mdash; [{{ $manageSubscriptionText }}]({{ $manageSubscriptionUrl }})
+@endcomponent
+
+@endcomponent

--- a/resources/views/notifications/partials/subscription.blade.php
+++ b/resources/views/notifications/partials/subscription.blade.php
@@ -1,0 +1,3 @@
+@component('mail::subcopy')
+[{{ $unsubscribeText }}]({{ $unsubscribeUrl }}) &mdash; [{{ $manageSubscriptionText }}]({{ $manageSubscriptionUrl }})
+@endcomponent


### PR DESCRIPTION
Closes #2966

---

Mail notifications should use Markdown views, this will need applying to **all** notifications in the near future, but does require slight refactoring.

<img width="541" alt="image" src="https://user-images.githubusercontent.com/246103/41510526-28d1e84e-725e-11e8-9e27-fd8e90e37d6e.png">
