### PR TITLE
Add notifications column to incidents

### DIFF
--- a/app/Models/Incident.php
+++ b/app/Models/Incident.php
@@ -70,18 +70,29 @@ class Incident extends Model implements HasPresenter
     ];
 
     /**
+     * The model's attributes.
+     *
+     * @var string[]
+     */
+    protected $attributes = [
+        'stickied'      => false,
+        'notifications' => false,
+    ];
+
+    /**
      * The attributes that should be casted to native types.
      *
      * @var string[]
      */
     protected $casts = [
-        'component_id'=> 'int',
-        'status'      => 'int',
-        'user_id'     => 'int',
-        'visible'     => 'int',
-        'stickied'    => 'bool',
-        'occurred_at' => 'datetime',
-        'deleted_at'  => 'date',
+        'component_id'  => 'int',
+        'status'        => 'int',
+        'user_id'       => 'int',
+        'visible'       => 'int',
+        'stickied'      => 'bool',
+        'notifications' => 'bool',
+        'occurred_at'   => 'datetime',
+        'deleted_at'    => 'date',
     ];
 
     /**
@@ -96,6 +107,7 @@ class Incident extends Model implements HasPresenter
         'status',
         'visible',
         'stickied',
+        'notifications',
         'message',
         'occurred_at',
         'created_at',
@@ -108,13 +120,14 @@ class Incident extends Model implements HasPresenter
      * @var string[]
      */
     public $rules = [
-        'user_id'      => 'required|int',
-        'component_id' => 'nullable|int',
-        'name'         => 'required|string',
-        'status'       => 'required|int',
-        'visible'      => 'required|bool',
-        'stickied'     => 'required|bool',
-        'message'      => 'required|string',
+        'user_id'       => 'required|int',
+        'component_id'  => 'nullable|int',
+        'name'          => 'required|string',
+        'status'        => 'required|int',
+        'visible'       => 'required|bool',
+        'stickied'      => 'required|bool',
+        'notifications' => 'nullable|bool',
+        'message'       => 'required|string',
     ];
 
     /**

--- a/database/migrations/2018_06_17_182507_AlterIncidentsAddNotifications.php
+++ b/database/migrations/2018_06_17_182507_AlterIncidentsAddNotifications.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterIncidentsAddNotifications extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('incidents', function (Blueprint $table) {
+            $table->boolean('notifications')->default(false)->after('stickied');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('incidents', function (Blueprint $table) {
+            $table->dropColumn('notifications');
+        });
+    }
+}


### PR DESCRIPTION
Part of https://github.com/CachetHQ/Cachet/issues/2508

With this change, Incident Updates will default to inherit the Incidents notification setting i.e. if you create an incident and opt not to notify people, then the Incident Update notifications will be silence by default (you'll be able to select to notify though).