### PR TITLE
Allow updating incidents when the incident has no associated user

### DIFF
--- a/app/Models/Incident.php
+++ b/app/Models/Incident.php
@@ -120,7 +120,7 @@ class Incident extends Model implements HasPresenter
      * @var string[]
      */
     public $rules = [
-        'user_id'       => 'required|int',
+        'user_id'       => 'nullable|int',
         'component_id'  => 'nullable|int',
         'name'          => 'required|string',
         'status'        => 'required|int',

--- a/tests/Api/IncidentTest.php
+++ b/tests/Api/IncidentTest.php
@@ -179,6 +179,23 @@ class IncidentTest extends AbstractApiTestCase
         ]);
     }
 
+    public function test_can_update_incident_when_no_user_is_associated()
+    {
+        $incident = factory(Incident::class)->create(['user_id' => null]);
+        $this->beUser();
+        $this->expectsEvents(IncidentWasUpdatedEvent::class);
+
+        $response = $this->json('PUT', '/api/v1/incidents/1', [
+            'name'     => 'Updated incident name',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'name'    => 'Updated incident name',
+            'user_id' => null,
+        ]);
+    }
+
     public function test_can_delete_incident()
     {
         $this->beUser();


### PR DESCRIPTION
Heya,

After reviewing some PR's I noticed that I'm unable to edit incidents created before #2725 was implemented. This PR is a quickfix for this.

### What has been done
- made the `user_id` field optional so it passes model validation whenever we try to update an existing incident

### How to test
- Create incident
- Remove user_id from database
- Update incident
- Acknowledge that it does not pass validation, as a user_id is required
- Checkout PR
- Retry updating the incident
- Acknowledge that it now works

### Todo's
- [] Needs a test

### Notes
- I've considered creating a migration that assigns a user to all incidents present in the DB. But then I saw the `Past incidents will be left as null.` line in the original PR. 