### PR TITLE
Fix for Error 500 when opening Component groups

### DIFF
--- a/app/Http/Controllers/Dashboard/ComponentGroupController.php
+++ b/app/Http/Controllers/Dashboard/ComponentGroupController.php
@@ -59,7 +59,7 @@ class ComponentGroupController extends Controller
 
         View::share([
             'sub_menu'  => $this->subMenu,
-            'sub_title' => trans_choice('dashboard.components.components', 2),
+            'subTitle' => trans_choice('dashboard.components.components', 2),
         ]);
     }
 


### PR DESCRIPTION
When you open Component groups (/dashboard/components/groups), you get an error 500.
From the laravel.log:
Next ErrorException: Undefined variable: subTitle (View: /var/www/Cachet-dev/resources/views/dashboard/partials/sub-sidebar.blade.php) 

I fixed the variable name.