### PR TITLE
Fix error Undefined variable: config when running cachet:install

### DIFF
--- a/app/Console/Commands/InstallCommand.php
+++ b/app/Console/Commands/InstallCommand.php
@@ -283,6 +283,7 @@ class InstallCommand extends Command
      */
     protected function configureCachet()
     {
+        $config = [];
         if ($this->confirm('Do you wish to use Cachet Beacon?')) {
             $config['CACHET_BEACON'] = 'true';
         }


### PR DESCRIPTION
Hello There, 

This PR should prevent an error when installing cachet and answering "no" to the following questions:
```
 Do you wish to use Cachet Beacon? (yes/no) [no]:
 > no

 Do you wish to use Emoji? This requires a GitHub oAuth Token! (yes/no) [no]:
 > no

```
