### PR TITLE
Ignore the package-lock.json because we use Yarn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 .env
+package-lock.json


### PR DESCRIPTION
We are using yarn so the npm files don't need to be followed.