### PR TITLE
Added ID to metric list

### DIFF
--- a/resources/views/partials/metrics.blade.php
+++ b/resources/views/partials/metrics.blade.php
@@ -1,7 +1,7 @@
 @if($metrics->count() > 0)
 <ul class="list-group">
     @foreach($metrics as $metric)
-    <li class="list-group-item metric" data-metric-id="{{ $metric->id }}">
+    <li class="list-group-item metric" data-metric-id="{{ $metric->id }}" id="data-metric-{{ $metric->id }}">
         <div class="row">
             <div class="col-xs-10">
                 <strong>


### PR DESCRIPTION
This change will allow us to scroll to the metric by its ID. Check the following screenshot:-
![screen shot 2018-07-12 at 4 54 54 pm](https://user-images.githubusercontent.com/6787093/42658814-75f9e01e-85f4-11e8-9bdb-7cef4fcd8767.png)

**Note:** This change should apply to the current version (2.4) too.