### PR TITLE
Added GET incident templates to use in POST incidents template

### DIFF
--- a/app/Http/Controllers/Api/IncidentTemplateController.php
+++ b/app/Http/Controllers/Api/IncidentTemplateController.php
@@ -19,14 +19,14 @@ class IncidentTemplateController extends AbstractApiController
 {
     /**
      * Get all incident templates.
+     *
      * @return \Illuminate\Http\JsonResponse
      */
     public function index()
     {
         $templates = IncidentTemplate::query();
 
-        if ($sortBy = Binput::get('sort'))
-        {
+        if ($sortBy = Binput::get('sort')) {
             $direction = Binput::has('order') && Binput::get('order') == 'desc';
 
             $templates->sort($sortBy, $direction);

--- a/app/Http/Controllers/Api/IncidentTemplateController.php
+++ b/app/Http/Controllers/Api/IncidentTemplateController.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Http\Controllers\Api;
+
+use CachetHQ\Cachet\Models\IncidentTemplate;
+use GrahamCampbell\Binput\Facades\Binput;
+use Illuminate\Support\Facades\Request;
+
+class IncidentTemplateController extends AbstractApiController
+{
+    /**
+     * Get all incident templates.
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function index()
+    {
+        $templates = IncidentTemplate::query();
+
+        if ($sortBy = Binput::get('sort'))
+        {
+            $direction = Binput::has('order') && Binput::get('order') == 'desc';
+
+            $templates->sort($sortBy, $direction);
+        }
+
+        $templates = $templates->paginate(Binput::get('per_page', 20));
+
+        return $this->paginator($templates, Request::instance());
+    }
+
+    /**
+     * Get a single incident templates.
+     *
+     * @param \CachetHQ\Cachet\Models\IncidentTemplate $incidentTemplate
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function show(IncidentTemplate $incidentTemplate)
+    {
+        return $this->item($incidentTemplate);
+    }
+}

--- a/app/Http/Routes/ApiRoutes.php
+++ b/app/Http/Routes/ApiRoutes.php
@@ -47,8 +47,11 @@ class ApiRoutes
                 $router->get('components/{component}', 'ComponentController@show');
 
                 $router->get('incidents', 'IncidentController@index');
-                $router->get('incidents/{incident}', 'IncidentController@show');
 
+                $router->get('incidents/templates', 'IncidentTemplateController@index');
+                $router->get('incidents/templates/{incident_template}', 'IncidentTemplateController@show');
+
+                $router->get('incidents/{incident}', 'IncidentController@show');
                 $router->get('incidents/{incident}/updates', 'IncidentUpdateController@index');
                 $router->get('incidents/{incident}/updates/{update}', 'IncidentUpdateController@show');
 

--- a/tests/Api/IncidentTemplateTest.php
+++ b/tests/Api/IncidentTemplateTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Api;
+
+use CachetHQ\Cachet\Models\IncidentTemplate;
+
+/**
+ * This is the incident template test class.
+ * @author Marc Hagen <hello@marchagen.nl>
+ */
+class IncidentTemplateTest extends AbstractApiTestCase
+{
+    public function test_can_get_all_incident_templates()
+    {
+        $templates = factory(IncidentTemplate::class, 3)->create();
+
+        $response = $this->json('GET', '/api/v1/incidents/templates');
+
+        $response->assertJsonFragment([ 'id' => $templates[0]->id ]);
+        $response->assertJsonFragment([ 'id' => $templates[1]->id ]);
+        $response->assertJsonFragment([ 'id' => $templates[2]->id ]);
+        $response->assertStatus(200);
+    }
+
+    public function test_cannot_get_invalid_incident_template()
+    {
+        $response = $this->json('GET', '/api/v1/incidents/templates/1');
+
+        $response->assertStatus(404);
+    }
+
+}

--- a/tests/Api/IncidentTemplateTest.php
+++ b/tests/Api/IncidentTemplateTest.php
@@ -15,6 +15,7 @@ use CachetHQ\Cachet\Models\IncidentTemplate;
 
 /**
  * This is the incident template test class.
+ *
  * @author Marc Hagen <hello@marchagen.nl>
  */
 class IncidentTemplateTest extends AbstractApiTestCase
@@ -25,9 +26,9 @@ class IncidentTemplateTest extends AbstractApiTestCase
 
         $response = $this->json('GET', '/api/v1/incidents/templates');
 
-        $response->assertJsonFragment([ 'id' => $templates[0]->id ]);
-        $response->assertJsonFragment([ 'id' => $templates[1]->id ]);
-        $response->assertJsonFragment([ 'id' => $templates[2]->id ]);
+        $response->assertJsonFragment(['id' => $templates[0]->id]);
+        $response->assertJsonFragment(['id' => $templates[1]->id]);
+        $response->assertJsonFragment(['id' => $templates[2]->id]);
         $response->assertStatus(200);
     }
 
@@ -37,5 +38,4 @@ class IncidentTemplateTest extends AbstractApiTestCase
 
         $response->assertStatus(404);
     }
-
 }


### PR DESCRIPTION
Atm there was no way to get the incident template slug from the API, while we can use it to create a incident through the api.