### PR TITLE
Show schedules till they are completed

### DIFF
--- a/app/Models/Schedule.php
+++ b/app/Models/Schedule.php
@@ -176,7 +176,7 @@ class Schedule extends Model implements HasPresenter
      */
     public function scopeFutureSchedules($query)
     {
-        return $query->whereIn('status', [self::UPCOMING, self::IN_PROGRESS])->where('scheduled_at', '>=', Carbon::now());
+        return $query->whereIn('status', [self::UPCOMING, self::IN_PROGRESS])->where('completed_at', '>=', Carbon::now());
     }
 
     /**


### PR DESCRIPTION
Currently schedules are shown on the status page when they are in the status upcoming or in progress. But, when the scheduled time is in the past - it's hidden, even when it's still going on and regardless of the completed time entered.

This PR fixes this issue by hiding the maintenance when it's in the status completed, or the completed time has passed.