### PR TITLE
Resolve styling error on signup view

### DIFF
--- a/resources/views/signup.blade.php
+++ b/resources/views/signup.blade.php
@@ -23,7 +23,7 @@
 
 @include('partials.errors')
 
-<div class="panel panel-meassage">
+<div class="panel panel-message">
     <div class="panel-heading">
         <strong>{{ trans('cachet.signup.title') }}</strong>
     </div>


### PR DESCRIPTION
In the signup view, the panel has a class (`panel-meassage`)
`panel-meassage` is not referenced anywhere other than this view.
This is probably a typo (for `panel-message`)

This PR will change `panel-meassage` to `panel-message`.