### PR TITLE
Include the partial "about-app" in index

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -3,6 +3,7 @@
 @section('content')
 @include('partials.modules.messages')
 @include('partials.modules.status')
+@include('partials.about-app')
 @include('partials.modules.components')
 @include('partials.modules.metrics')
 @include('partials.modules.stickied')


### PR DESCRIPTION
In the settings it's possible to fill a field "About this page". If we
refer to the demo the content of this field is supposed to be shown
under the status on the status page.

The problem was the information was not shown even if it was not empty.
So if we typed "We are a company ...", this was not shown, nowhere.
Technically the problem was because the partial "about-app" was not
included so the information was never shown.

To fix that I have included the partial "about-app" in the index.
Now if the field empty nothing is shown (the same as before) but if the
field is not empty so the information is shown under the status bar.

See: #3249