### PR TITLE
Let notification to the users be queue-able

### DIFF
--- a/app/Notifications/Schedule/NewScheduleNotification.php
+++ b/app/Notifications/Schedule/NewScheduleNotification.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Cachet\Notifications\Schedule;
 
 use CachetHQ\Cachet\Models\Schedule;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
@@ -24,7 +25,7 @@ use McCool\LaravelAutoPresenter\Facades\AutoPresenter;
  *
  * @author James Brooks <james@alt-three.com>
  */
-class NewScheduleNotification extends Notification
+class NewScheduleNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 


### PR DESCRIPTION
Currently my instance times out cause we have over 150+ subscribers. 

Adding this actually adds it to the queue. 