### PR TITLE
Remove extra parenthesis on subscribe page

### DIFF
--- a/resources/views/subscribe/subscribe.blade.php
+++ b/resources/views/subscribe/subscribe.blade.php
@@ -1,6 +1,6 @@
 @extends('layout.master')
 
-@section('title',  trans('cachet.subscriber.subscribe'). " | ". $siteTitle))
+@section('title',  trans('cachet.subscriber.subscribe'). " | ". $siteTitle)
 
 @section('description', trans('cachet.meta.description.subscribe', ['app' => $siteTitle]))
 


### PR DESCRIPTION
There is an extra parenthesis on the subscribe page after the title section.