### PR TITLE
Change subscribe page description to be more precise

### DIFF
--- a/resources/lang/en/cachet.php
+++ b/resources/lang/en/cachet.php
@@ -77,7 +77,7 @@ return [
 
     // Subscriber
     'subscriber' => [
-        'subscribe'           => 'Subscribe to get the updates',
+        'subscribe'           => 'Subscribe to status changes and incident updates',
         'unsubscribe'         => 'Unsubscribe',
         'button'              => 'Subscribe',
         'manage_subscription' => 'Manage subscription',


### PR DESCRIPTION
"Subscribe to get the updates" can be "Subscribe to status changes and incident updates" to be less vague and more precise.