### PR TITLE
Add warning when setting up localhost with mysql driver

### DIFF
--- a/app/Console/Commands/InstallCommand.php
+++ b/app/Console/Commands/InstallCommand.php
@@ -148,6 +148,9 @@ class InstallCommand extends Command
             $config['DB_DATABASE'] = $this->ask('Please provide the full path to your SQLite file.', $config['DB_DATABASE']);
         } else {
             $config['DB_HOST'] = $this->ask("What is the host of your {$config['DB_DRIVER']} database?", $config['DB_HOST']);
+            if ($config['DB_HOST'] === 'localhost' && $config['DB_DRIVER'] === 'mysql') {
+                $this->warn("Using 'localhost' will result in the usage of a local unix socket. Use 127.0.0.1 if you want to connect over TCP");
+            }
 
             $config['DB_DATABASE'] = $this->ask('What is the name of the database that Cachet should use?', $config['DB_DATABASE']);
 


### PR DESCRIPTION
Heya,

Small quirk everyone experiences when they are setting up any PHP project with PDO drivers: using localhost as a hostname will try to connect over a local unix socket. 

I thought it would be nice to warn about this in case you're configuring your application using `cachet:install`


