### PR TITLE
Fix configuring Postgres leads to wrong database driver key

### DIFF
--- a/app/Console/Commands/InstallCommand.php
+++ b/app/Console/Commands/InstallCommand.php
@@ -140,7 +140,7 @@ class InstallCommand extends Command
 
         $config['DB_DRIVER'] = $this->choice('Which database driver do you want to use?', [
             'mysql'      => 'MySQL',
-            'postgresql' => 'PostgreSQL',
+            'pgsql'      => 'PostgreSQL',
             'sqlite'     => 'SQLite',
         ], $config['DB_DRIVER']);
 


### PR DESCRIPTION
Heya,

When configuring a postgres connection in the `cachet:install` command. It will result in a `Database [postgres] not configured.` Turns out that the database driver key for postgres is pgsql. :)