### PR TITLE
Write port numbers explicitly to the .env

### DIFF
--- a/app/Console/Commands/InstallCommand.php
+++ b/app/Console/Commands/InstallCommand.php
@@ -389,11 +389,12 @@ class InstallCommand extends Command
             $envKey = strtoupper($key);
             $envValue = env($envKey) ?: 'null';
 
-            file_put_contents($path, str_replace(
-                "{$envKey}={$envValue}",
-                "{$envKey}={$value}",
-                file_get_contents($path)
-            ));
+            $envFileContents = file_get_contents($path);
+            $envFileContents = str_replace("{$envKey}={$envValue}", "{$envKey}={$value}", $envFileContents, $count);
+            if ($count < 1 && $envValue === 'null') {
+                $envFileContents = str_replace("{$envKey}=", "{$envKey}={$value}", $envFileContents);
+            }
+            file_put_contents($path, $envFileContents);
         } catch (InvalidPathException $e) {
             throw $e;
         }

--- a/app/Console/Commands/InstallCommand.php
+++ b/app/Console/Commands/InstallCommand.php
@@ -155,6 +155,7 @@ class InstallCommand extends Command
 
             $config['DB_PASSWORD'] = $this->secret('What password should we connect with?', $config['DB_PASSWORD']);
 
+            $config['DB_PORT'] = $config['DB_DRIVER'] === 'mysql' ? 3306 : 5432;
             if ($this->confirm('Is your database listening on a non-standard port number?')) {
                 $config['DB_PORT'] = $this->anticipate('What port number is your database using?', [3306, 5432], $config['DB_PORT']);
             }


### PR DESCRIPTION
Hey, 

When installing cachet for postgres and using the default port options it will fail the installation because the null value is not being handled nicely, resulting in a
`SQLSTATE[08006] [7] invalid port number: "sslmode=prefer"`.

This PR will explicitly configure port numbers for the mysql and pgsql drivers when you've selected them during configuration. The PR also adds support for finding & replacing "empty null values?" in the .env file like the following:

```
DB_PORT=
```

I'd love to know your thoughts on this. 
Have a great weekend 🎉 