### PR TITLE
Add empty array fallback when contributor fetching fails

### DIFF
--- a/app/Http/Controllers/Dashboard/SettingsController.php
+++ b/app/Http/Controllers/Dashboard/SettingsController.php
@@ -248,8 +248,8 @@ class SettingsController extends Controller
 
         $credits = app(Credits::class)->latest();
 
-        $backers = $credits['backers'];
-        $contributors = $credits['contributors'];
+        $backers = $credits['backers'] ?? [];
+        $contributors = $credits['contributors'] ?? [];
 
         shuffle($backers);
         shuffle($contributors);


### PR DESCRIPTION
Hey,

Just saw a short hiccup in my internet connection and noticed that it crashed my cachet settings page. This PR will add a fallback value to the settings contributor page.