### PR TITLE
Fixed timezone of creation datetime for metric points

### DIFF
--- a/app/Models/MetricPoint.php
+++ b/app/Models/MetricPoint.php
@@ -120,7 +120,7 @@ class MetricPoint extends Model implements HasPresenter
         $timestamp = $createdAt->format('U');
         $timestamp = 30 * round($timestamp / 30);
 
-        $date = Carbon::createFromFormat('U', $timestamp)->toDateTimeString();
+        $date = Carbon::createFromFormat('U', $timestamp)->setTimezone(config('cachet.timezone'))->toDateTimeString();
 
         $this->attributes['created_at'] = $date;
 


### PR DESCRIPTION
I think this fixes a timezone issue that exists since commit 55002bb, which did not include the timezone for the creation date.