### PR TITLE
adding asset() helper to dist folder to respect APP_URL

### DIFF
--- a/resources/views/layout/clean.blade.php
+++ b/resources/views/layout/clean.blade.php
@@ -25,7 +25,7 @@
     @if($enableExternalDependencies)
     {{-- <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700&subset={{ $fontSubset }}" rel="stylesheet" type="text/css"> --}}
     @endif
-    <link rel="stylesheet" href="{{ mix('dist/css/dashboard/dashboard.css') }}">
+    <link rel="stylesheet" href="{{ asset(mix('dist/css/dashboard/dashboard.css')) }}">
     @yield('css')
 
     @include('partials.crowdin')
@@ -35,8 +35,8 @@
         Global.locale = '{{ $appLocale }}';
     </script>
 
-    <script src="{{ mix('dist/js/manifest.js') }}"></script>
-    <script src="{{ mix('dist/js/vendor.js') }}"></script>
+    <script src="{{ asset(mix('dist/js/manifest.js')) }}"></script>
+    <script src="{{ asset(mix('dist/js/vendor.js')) }}"></script>
 </head>
 
 <body class="@yield('bodyClass')">
@@ -45,5 +45,5 @@
     </div>
 </body>
 @yield('js')
-<script src="{{ mix('dist/js/all.js') }}"></script>
+<script src="{{ asset(mix('dist/js/all.js')) }}"></script>
 </html>

--- a/resources/views/layout/dashboard.blade.php
+++ b/resources/views/layout/dashboard.blade.php
@@ -31,13 +31,13 @@
     @if($enableExternalDependencies)
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700&subset={{ $fontSubset }}" rel="stylesheet" type="text/css">
     @endif
-    <link rel="stylesheet" href="{{ mix('dist/css/dashboard/dashboard.css') }}">
+    <link rel="stylesheet" href="{{ asset(mix('dist/css/dashboard/dashboard.css')) }}">
     @yield('css')
 
     @include('partials.crowdin')
 
-    <script src="{{ mix('dist/js/manifest.js') }}"></script>
-    <script src="{{ mix('dist/js/vendor.js') }}"></script>
+    <script src="{{ asset(mix('dist/js/manifest.js')) }}"></script>
+    <script src="{{ asset(mix('dist/js/vendor.js')) }}"></script>
 </head>
 
 <body class="dashboard">
@@ -61,5 +61,5 @@
     </div>
 </body>
 @yield('js')
-<script src="{{ mix('dist/js/all.js') }}"></script>
+<script src="{{ asset(mix('dist/js/all.js')) }}"></script>
 </html>

--- a/resources/views/layout/master.blade.php
+++ b/resources/views/layout/master.blade.php
@@ -49,7 +49,7 @@
     @if($enableExternalDependencies)
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700&subset={{ $fontSubset }}" rel="stylesheet" type="text/css">
     @endif
-    <link rel="stylesheet" href="{{ mix('dist/css/app.css') }}">
+    <link rel="stylesheet" href="{{ asset(mix('dist/css/app.css')) }}">
 
     @include('partials.stylesheet')
 
@@ -75,8 +75,8 @@
 
         Global.locale = '{{ $appLocale }}';
     </script>
-    <script src="{{ mix('dist/js/manifest.js') }}"></script>
-    <script src="{{ mix('dist/js/vendor.js') }}"></script>
+    <script src="{{ asset(mix('dist/js/manifest.js')) }}"></script>
+    <script src="{{ asset(mix('dist/js/vendor.js')) }}"></script>
 </head>
 <body class="status-page @yield('bodyClass')">
     @yield('outer-content')
@@ -89,5 +89,5 @@
 
     @yield('bottom-content')
 </body>
-<script src="{{ mix('dist/js/all.js') }}"></script>
+<script src="{{ asset(mix('dist/js/all.js')) }}"></script>
 </html>


### PR DESCRIPTION
#1696 

`APP_URL` is used to adjust a root url in order to serve Cachet from a subdirectory (proxied by Nginx or Apache), however static assets `URI`s are not adjusted. This fix modifies these links to respect `APP_URL` by using the `asset()` helper around `mix()`.