### PR TITLE
Resolve #3269

### DIFF
--- a/app/Bus/Commands/Component/CreateComponentCommand.php
+++ b/app/Bus/Commands/Component/CreateComponentCommand.php
@@ -81,7 +81,7 @@ final class CreateComponentCommand
      */
     public $rules = [
         'name'        => 'required|string',
-        'description' => 'required|string',
+        'description' => 'nullable|string',
         'status'      => 'required|int|min:0|max:4',
         'link'        => 'nullable|url',
         'order'       => 'nullable|int',

--- a/tests/Api/ComponentTest.php
+++ b/tests/Api/ComponentTest.php
@@ -84,6 +84,21 @@ class ComponentTest extends AbstractApiTestCase
         $response->assertJsonFragment(['name' => 'Foo']);
     }
 
+    public function test_can_create_minimal_component()
+    {
+        $this->beUser();
+
+        $this->expectsEvents(ComponentWasCreatedEvent::class);
+
+        $response = $this->json('POST', '/api/v1/components', [
+            'name'        => 'Foo',
+            'status'      => 1,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => 'Foo']);
+    }
+
     public function test_can_create_component_without_enabled_field()
     {
         $this->beUser();


### PR DESCRIPTION
When creating a new component description is required. But when modifying not?
hope this is a decent fix