### PR TITLE
Add newline before timezone line

### DIFF
--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -9,7 +9,7 @@
                 <p>
                     {!! trans('cachet.powered_by') !!}
                     @if($showTimezone)
-                    {{ trans('cachet.timezone', ['timezone' => $timezone]) }}
+                    <br/>{{ trans('cachet.timezone', ['timezone' => $timezone]) }}
                     @endif
                 </p>
                 @endif


### PR DESCRIPTION
Add newline before timezone line on index page in the footer.
It just looks a bit nicer because the div is only max pixels wide.