### PR TITLE
Use safer markdown defaults

### DIFF
--- a/config/markdown.php
+++ b/config/markdown.php
@@ -119,16 +119,41 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Safe Mode
+    | HTML Input
     |--------------------------------------------------------------------------
     |
-    | This option specifies if raw HTML is rendered in the document. Setting
-    | this to true will not render HTML, and false will.
+    | This option specifies how to handle untrusted HTML input.
     |
-    | Default: false
+    | Default: 'strip'
     |
     */
 
-    'safe' => true,
+    'html_input' => 'strip',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Allow Unsafe Links
+    |--------------------------------------------------------------------------
+    |
+    | This option specifies whether to allow risky image URLs and links.
+    |
+    | Default: true
+    |
+    */
+
+    'allow_unsafe_links' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Maximum Nesting Level
+    |--------------------------------------------------------------------------
+    |
+    | This option specifies the maximum permitted block nesting level.
+    |
+    | Default: INF
+    |
+    */
+
+    'max_nesting_level' => INF,
 
 ];


### PR DESCRIPTION
In light of https://github.com/CachetHQ/Cachet/pull/3382 and https://github.com/thephpleague/commonmark/issues/337, we probably want to turn this on by default for Cachet.