### PR TITLE
Update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2019 Alt Three Services Limited.
+Copyright (c) 2015-2019 apilayer.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
Back in July, Cachet was acquired by @apilayer, see the announcement at http://alt-three.com/apilayer-have-acquired-cachet/ 🎉 