### PR TITLE
API endpoint for receiving incidents via the prometheus alertmanager

### DIFF
--- a/app/Bus/Handlers/Commands/IncidentUpdate/CreateIncidentUpdateCommandHandler.php
+++ b/app/Bus/Handlers/Commands/IncidentUpdate/CreateIncidentUpdateCommandHandler.php
@@ -11,9 +11,11 @@
 
 namespace CachetHQ\Cachet\Bus\Handlers\Commands\IncidentUpdate;
 
+use CachetHQ\Cachet\Bus\Commands\Component\UpdateComponentCommand;
 use CachetHQ\Cachet\Bus\Commands\Incident\UpdateIncidentCommand;
 use CachetHQ\Cachet\Bus\Commands\IncidentUpdate\CreateIncidentUpdateCommand;
 use CachetHQ\Cachet\Bus\Events\IncidentUpdate\IncidentUpdateWasReportedEvent;
+use CachetHQ\Cachet\Models\Component;
 use CachetHQ\Cachet\Models\IncidentUpdate;
 use Illuminate\Contracts\Auth\Guard;
 
@@ -77,6 +79,17 @@ class CreateIncidentUpdateCommandHandler
             null,
             []
         ));
+
+        if ($command->component_id) {
+            $component = Component::findOrFail($command->component_id);
+
+            execute(new UpdateComponentCommand(
+                $component,
+                null,
+                null,
+                $command->component_status
+            ));
+        }
 
         event(new IncidentUpdateWasReportedEvent($this->auth->user(), $update));
 

--- a/app/Http/Controllers/Api/Prometheus/IncidentController.php
+++ b/app/Http/Controllers/Api/Prometheus/IncidentController.php
@@ -116,14 +116,15 @@ class IncidentController extends AbstractApiController
 
         $incident = $component->incidents()
             ->where("status", config("prometheus.new_incident_status", 1))
-            ->where("occurred_at", $startsAt)->first();
+            ->where("occurred_at", $startsAt.":00")->first();
+
         if (!$incident) {
             return;
         }
 
         execute(new CreateIncidentUpdateCommand(
             $incident,
-            config("prometheus.resolved_incident_status", 1) /* status */,
+            config("prometheus.resolved_incident_status", 4) /* status */,
             trans("prometheus.default-resolved-alert-message"),
             $componentId,
             config("prometheus.resolved_incident_component_status", 1) /* component status */,

--- a/app/Http/Controllers/Api/Prometheus/IncidentController.php
+++ b/app/Http/Controllers/Api/Prometheus/IncidentController.php
@@ -36,6 +36,9 @@ class IncidentController extends AbstractApiController
         Log::debug(__METHOD__." called ", Binput::all());
 
         $alerts = collect(Binput::get("alerts"));
+        if (!$alerts->count()) {
+            throw new BadRequestHttpException();
+        }
         $alerts->each(function ($alert) {
             switch ($alert["status"]) {
                 case "firing":

--- a/app/Http/Controllers/Api/Prometheus/IncidentController.php
+++ b/app/Http/Controllers/Api/Prometheus/IncidentController.php
@@ -80,18 +80,18 @@ class IncidentController extends AbstractApiController
         }
 
         execute(new CreateIncidentCommand(
-            data_get($alert, "annotations.summary", "Störung"),
-            1 /*incident status */,
-            data_get($alert, "annotations.description", "Unsere Technik wurde informiert und untersucht das Problem bereits.") /* message */,
-            true /*visible*/,
+            data_get($alert, "annotations.summary", trans("prometheus.default-alert-name")),
+            config("prometheus.new_incident_status", 1) /*incident status */,
+            data_get($alert, "annotations.description", trans("prometheus.default-alert-message")) /* message */,
+            config("prometheus.new_incident_visible", true) /*visible*/,
             $componentId,
-            2 /* component status */,
-            true /* notify */,
-            false /*stickied*/,
+            config("prometheus.new_incident_component_status", 2) /* component status */,
+            config("prometheus.new_incident_notify", true) /* notify */,
+            config("prometheus.new_incident_stickied", false) /*stickied*/,
             $this->formatPrometheusDate(data_get($alert, "startsAt")) /* occurred_at */,
-            null /*template slug*/,
+            config("prometheus.new_incident_template", null) /*template slug*/,
             [] /*template vars */,
-            data_get($alert, "labels") /*meta*/
+            data_get($alert, config("prometheus.meta_key", "labels")) /*meta*/
         ));
     }
 
@@ -115,7 +115,7 @@ class IncidentController extends AbstractApiController
         $startsAt = $this->formatPrometheusDate(data_get($alert, "startsAt"));
 
         $incident = $component->incidents()
-            ->where("status", 1)
+            ->where("status", config("prometheus.new_incident_status", 1))
             ->where("occurred_at", $startsAt)->first();
         if (!$incident) {
             return;
@@ -123,10 +123,10 @@ class IncidentController extends AbstractApiController
 
         execute(new CreateIncidentUpdateCommand(
             $incident,
-            4 /* status */,
-            "Die Störung wurde behoben.",
+            config("prometheus.resolved_incident_status", 1) /* status */,
+            trans("prometheus.default-resolved-alert-message"),
             $componentId,
-            1 /* component status */,
+            config("prometheus.resolved_incident_component_status", 1) /* component status */,
             request()->user()
         ));
 

--- a/app/Http/Controllers/Api/Prometheus/IncidentController.php
+++ b/app/Http/Controllers/Api/Prometheus/IncidentController.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Http\Controllers\Api\Prometheus;
+
+use CachetHQ\Cachet\Bus\Commands\Incident\CreateIncidentCommand;
+use CachetHQ\Cachet\Bus\Commands\Incident\UpdateIncidentCommand;
+use CachetHQ\Cachet\Bus\Commands\IncidentUpdate\CreateIncidentUpdateCommand;
+use CachetHQ\Cachet\Http\Controllers\Api\AbstractApiController;
+use CachetHQ\Cachet\Models\Incident;
+use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\Schedule;
+use GrahamCampbell\Binput\Facades\Binput;
+use Illuminate\Database\QueryException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Carbon;
+
+class IncidentController extends AbstractApiController
+{
+    /**
+     * Create a new incident.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store()
+    {
+        Log::debug(__METHOD__." called ", Binput::all());
+
+        $alerts = collect(Binput::get("alerts"));
+        $alerts->each(function ($alert) {
+            switch ($alert["status"]) {
+                case "firing":
+                    $this->handleFiringAlert($alert);
+                    break;
+                case "resolved":
+                    $this->handleResolvedAlert($alert);
+                    break;
+                default:
+                    throw new BadRequestHttpException("Unsupported alert status.");
+            }
+        });
+
+        return response(200);
+    }
+
+    /**
+     * creates an incident for the given component and sets
+     * the component's status to "performance problems"
+     *
+     * @param     array    $alert    the prometheus alert to handle
+     * @return    void
+     */
+    protected function handleFiringAlert(array $alert)
+    {
+        $componentId = $this->getComponentId($alert);
+
+        $component = Component::findOrFail($componentId);
+        if ($component->status != 1) {
+            // the component is not in the status "operational"
+            // do not create an incident
+            return;
+        }
+
+        if (Schedule::inProgress()->count()) {
+            // a scheduled maintenance is currently in progress
+            // do not create an incident
+            return;
+        }
+
+        execute(new CreateIncidentCommand(
+            data_get($alert, "annotations.summary", "Störung"),
+            1 /*incident status */,
+            data_get($alert, "annotations.description", "Unsere Technik wurde informiert und untersucht das Problem bereits.") /* message */,
+            true /*visible*/,
+            $componentId,
+            2 /* component status */,
+            true /* notify */,
+            false /*stickied*/,
+            $this->formatPrometheusDate(data_get($alert, "startsAt")) /* occurred_at */,
+            null /*template slug*/,
+            [] /*template vars */,
+            data_get($alert, "labels") /*meta*/
+        ));
+    }
+
+    /**
+     * clears a given incident for the given component
+     * the incident is matched by comparing the "startsAt" field
+     * in the prometheus alert with the "occurred_at" timestamp
+     *
+     * @param     array     $alert    the prometheus alert to handle
+     * @return    void
+     */
+    protected function handleResolvedAlert(array $alert)
+    {
+        $componentId = $this->getComponentId($alert);
+
+        $component = Component::findOrFail($componentId);
+        if ($component->status == 1) {
+            return;
+        }
+
+        $startsAt = $this->formatPrometheusDate(data_get($alert, "startsAt"));
+
+        $incident = $component->incidents()
+            ->where("status", 1)
+            ->where("occurred_at", $startsAt)->first();
+        if (!$incident) {
+            return;
+        }
+
+        execute(new CreateIncidentUpdateCommand(
+            $incident,
+            4 /* status */,
+            "Die Störung wurde behoben.",
+            $componentId,
+            1 /* component status */,
+            request()->user()
+        ));
+
+        return;
+    }
+
+    /**
+     * takes a date coming from prometheus and prepares it for
+     * use in Cachet's commands
+     *
+     * @param     string    $date         the date coming from prometheus
+     * @param     string    $newFormat    the new format of the date
+     * @return    string                  the date suitable for use in the *Command-classes
+     */
+    protected function formatPrometheusDate(string $date, string $newFormat = "Y-m-d H:i")
+    {
+        //remove nanoseconds
+        $date = preg_replace("/\.([\d]{6})([\d]+)/", ".\\1", $date);
+        return Carbon::createFromFormat("Y-m-d\TH:i:s.uP", $date)->format($newFormat);
+    }
+
+    /**
+     * extracts the component_id from prometheus' labels
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\BadRequestHttpException when the component id cannot be found
+     *
+     * @param     array    $alert    the alert that contains the component_id
+     * @return    int                the component id
+     */
+    protected function getComponentId($alert)
+    {
+        if (!$componentId = (int) data_get($alert, "labels.status_page_component_id")) {
+            throw new BadRequestHttpException("No status_page_component_id given.");
+        }
+        return $componentId;
+    }
+}

--- a/app/Http/Middleware/ApiAuthentication.php
+++ b/app/Http/Middleware/ApiAuthentication.php
@@ -80,10 +80,8 @@ class ApiAuthentication
             return $apiToken;
         }
 
-        if (($apiToken = $request->header('Authorization')) && starts_with($apiToken, "Bearer ")) {
+        if (($apiToken = $request->header('Authorization')) && starts_with($apiToken, 'Bearer ')) {
             return mb_substr($apiToken, 7);
         }
-
-        return null;
     }
 }

--- a/app/Http/Middleware/ApiAuthentication.php
+++ b/app/Http/Middleware/ApiAuthentication.php
@@ -58,7 +58,7 @@ class ApiAuthentication
     public function handle(Request $request, Closure $next, $required = false)
     {
         if ($this->auth->guest()) {
-            if ($apiToken = $request->header('X-Cachet-Token')) {
+            if ($apiToken = $this->getApiToken($request)) {
                 try {
                     $this->auth->onceUsingId(User::findByApiToken($apiToken)->id);
                 } catch (ModelNotFoundException $e) {
@@ -72,5 +72,20 @@ class ApiAuthentication
         }
 
         return $next($request);
+    }
+
+    protected function getApiToken(Request $request)
+    {
+        if ($apiToken = $request->header('X-Cachet-Token')) {
+            return $apiToken;
+        }
+
+        $apiToken = $request->header('Authorization');
+
+        if (($apiToken = $request->header('Authorization')) && starts_with($apiToken, "Bearer ")) {
+            return mb_substr($apiToken, 7);
+        }
+
+        return null;
     }
 }

--- a/app/Http/Middleware/ApiAuthentication.php
+++ b/app/Http/Middleware/ApiAuthentication.php
@@ -80,8 +80,6 @@ class ApiAuthentication
             return $apiToken;
         }
 
-        $apiToken = $request->header('Authorization');
-
         if (($apiToken = $request->header('Authorization')) && starts_with($apiToken, "Bearer ")) {
             return mb_substr($apiToken, 7);
         }

--- a/app/Http/Routes/PrometheusRoutes.php
+++ b/app/Http/Routes/PrometheusRoutes.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Http\Routes;
+
+use Illuminate\Contracts\Routing\Registrar;
+
+/**
+ * This is the api routes class.
+ *
+ * @author James Brooks <james@alt-three.com>
+ */
+class PrometheusRoutes
+{
+    /**
+     * Defines if these routes are for the browser.
+     *
+     * @var bool
+     */
+    public static $browser = false;
+
+    /**
+     * Define the api routes.
+     *
+     * @param \Illuminate\Contracts\Routing\Registrar $router
+     *
+     * @return void
+     */
+    public function map(Registrar $router)
+    {
+        $router->group([
+            'namespace' => 'Api',
+            'prefix'    => 'api/v1',
+        ], function (Registrar $router) {
+            $router->group(['middleware' => ['auth.api:true']], function (Registrar $router) {
+                $router->post('incidents/alertmanager', 'Prometheus\IncidentController@store');
+            });
+        });
+    }
+}

--- a/resources/lang/de/prometheus.php
+++ b/resources/lang/de/prometheus.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    "default-alert-name" => "Störung",
-    "default-alert-message" => "Unsere Technik wurde informiert und untersucht das Problem bereits.",
-    "default-resolved-alert-message" => "Die Störung wurde behoben.",
+    'default-alert-name'             => 'Störung',
+    'default-alert-message'          => 'Unsere Technik wurde informiert und untersucht das Problem bereits.',
+    'default-resolved-alert-message' => 'Die Störung wurde behoben.',
 ];

--- a/resources/lang/de/prometheus.php
+++ b/resources/lang/de/prometheus.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    "default-alert-name" => "Störung",
+    "default-alert-message" => "Unsere Technik wurde informiert und untersucht das Problem bereits.",
+    "default-resolved-alert-message" => "Die Störung wurde behoben.",
+];

--- a/resources/lang/en/prometheus.php
+++ b/resources/lang/en/prometheus.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    "default-alert-name" => "New Incident",
-    "default-alert-message" => "A new incident occurred.",
-    "default-resolved-alert-message" => "The incident has been resolved.",
+    'default-alert-name'             => 'New Incident',
+    'default-alert-message'          => 'A new incident occurred.',
+    'default-resolved-alert-message' => 'The incident has been resolved.',
 ];

--- a/resources/lang/en/prometheus.php
+++ b/resources/lang/en/prometheus.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    "default-alert-name" => "New Incident",
+    "default-alert-message" => "A new incident occurred.",
+    "default-resolved-alert-message" => "The incident has been resolved.",
+];

--- a/tests/Api/AuthenticationTest.php
+++ b/tests/Api/AuthenticationTest.php
@@ -15,50 +15,50 @@ use CachetHQ\Cachet\Models\Subscriber;
 use CachetHQ\Cachet\Models\User;
 
 /**
- * This is the API authentication test class
+ * This is the API authentication test class.
  *
  * @author Erik Anders <github@naugrim.org>
  */
 class AuthenticationTest extends AbstractApiTestCase
 {
-    const API_KEY = "123456789abcdefg";
-    const SUBSCRIBER_EMAIL = "test.subscriber@example.com";
+    const API_KEY = '123456789abcdefg';
+    const SUBSCRIBER_EMAIL = 'test.subscriber@example.com';
 
     public function test_can_authenticate_using_x_cachet_token_header()
     {
         factory(User::class)
-            ->create(["api_key" => self::API_KEY]);
+            ->create(['api_key' => self::API_KEY]);
 
         factory(Subscriber::class)->create([
-            "email" => self::SUBSCRIBER_EMAIL
+            'email' => self::SUBSCRIBER_EMAIL,
         ]);
 
         $response = $this->withHeaders([
-                "X-Cachet-Token" => self::API_KEY
+                'X-Cachet-Token' => self::API_KEY,
             ])
             ->json('GET', '/api/v1/subscribers');
         $response->assertStatus(200);
         $response->assertJsonFragment([
-            "email" => self::SUBSCRIBER_EMAIL
+            'email' => self::SUBSCRIBER_EMAIL,
         ]);
     }
 
     public function test_can_authenticate_using_authorization_header()
     {
         factory(User::class)
-            ->create(["api_key" => self::API_KEY]);
+            ->create(['api_key' => self::API_KEY]);
 
         factory(Subscriber::class)->create([
-            "email" => self::SUBSCRIBER_EMAIL
+            'email' => self::SUBSCRIBER_EMAIL,
         ]);
 
         $response = $this->withHeaders([
-                "Authorization" => "Bearer ".self::API_KEY
+                'Authorization' => 'Bearer '.self::API_KEY,
             ])
             ->json('GET', '/api/v1/subscribers');
         $response->assertStatus(200);
         $response->assertJsonFragment([
-            "email" => self::SUBSCRIBER_EMAIL
+            'email' => self::SUBSCRIBER_EMAIL,
         ]);
     }
 }

--- a/tests/Api/AuthenticationTest.php
+++ b/tests/Api/AuthenticationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Api;
+
+use CachetHQ\Cachet\Models\Subscriber;
+use CachetHQ\Cachet\Models\User;
+
+/**
+ * This is the API authentication test class
+ *
+ * @author Erik Anders <github@naugrim.org>
+ */
+class AuthenticationTest extends AbstractApiTestCase
+{
+    const API_KEY = "123456789abcdefg";
+    const SUBSCRIBER_EMAIL = "test.subscriber@example.com";
+
+    public function test_can_authenticate_using_x_cachet_token_header()
+    {
+        factory(User::class)
+            ->create(["api_key" => self::API_KEY]);
+
+        factory(Subscriber::class)->create([
+            "email" => self::SUBSCRIBER_EMAIL
+        ]);
+
+        $response = $this->withHeaders([
+                "X-Cachet-Token" => self::API_KEY
+            ])
+            ->json('GET', '/api/v1/subscribers');
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            "email" => self::SUBSCRIBER_EMAIL
+        ]);
+    }
+
+    public function test_can_authenticate_using_authorization_header()
+    {
+        factory(User::class)
+            ->create(["api_key" => self::API_KEY]);
+
+        factory(Subscriber::class)->create([
+            "email" => self::SUBSCRIBER_EMAIL
+        ]);
+
+        $response = $this->withHeaders([
+                "Authorization" => "Bearer ".self::API_KEY
+            ])
+            ->json('GET', '/api/v1/subscribers');
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            "email" => self::SUBSCRIBER_EMAIL
+        ]);
+    }
+}

--- a/tests/Api/IncidentUpdateTest.php
+++ b/tests/Api/IncidentUpdateTest.php
@@ -107,18 +107,18 @@ class IncidentUpdateTest extends AbstractApiTestCase
     {
         $this->beUser();
         $incident = factory(Incident::class)->create();
-        $component = factory(Component::class)->create(["status" => 1]);
+        $component = factory(Component::class)->create(['status' => 1]);
 
         $response = $this->json('POST', "/api/v1/incidents/{$incident->id}/updates", [
-            'status'  => 1,
-            'message' => 'New incident!',
-            "component_id" => $component->id,
-            "component_status" => 2,
+            'status'           => 1,
+            'message'          => 'New incident!',
+            'component_id'     => $component->id,
+            'component_status' => 2,
         ]);
 
         $response->assertStatus(200);
 
-        $response = $this->json("GET", "/api/v1/components/{$component->id}");
+        $response = $this->json('GET', "/api/v1/components/{$component->id}");
 
         $response->assertStatus(200);
         $response->assertJsonFragment(['status' => 2]);

--- a/tests/Api/IncidentUpdateTest.php
+++ b/tests/Api/IncidentUpdateTest.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Tests\Cachet\Api;
 
+use CachetHQ\Cachet\Models\Component;
 use CachetHQ\Cachet\Models\Incident;
 use CachetHQ\Cachet\Models\IncidentUpdate;
 
@@ -100,5 +101,26 @@ class IncidentUpdateTest extends AbstractApiTestCase
         $response = $this->json('DELETE', "/api/v1/incidents/{$incident->id}/updates/{$update->id}");
 
         $response->assertStatus(204);
+    }
+
+    public function test_incident_update_with_component_update()
+    {
+        $this->beUser();
+        $incident = factory(Incident::class)->create();
+        $component = factory(Component::class)->create(["status" => 1]);
+
+        $response = $this->json('POST', "/api/v1/incidents/{$incident->id}/updates", [
+            'status'  => 1,
+            'message' => 'New incident!',
+            "component_id" => $component->id,
+            "component_status" => 2,
+        ]);
+
+        $response->assertStatus(200);
+
+        $response = $this->json("GET", "/api/v1/components/{$component->id}");
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['status' => 2]);
     }
 }

--- a/tests/Api/PrometheusIncidentTest.php
+++ b/tests/Api/PrometheusIncidentTest.php
@@ -12,11 +12,9 @@
 namespace CachetHQ\Tests\Cachet\Api;
 
 use CachetHQ\Cachet\Bus\Events\Incident\IncidentWasCreatedEvent;
-use CachetHQ\Cachet\Bus\Events\Incident\IncidentWasRemovedEvent;
 use CachetHQ\Cachet\Bus\Events\Incident\IncidentWasUpdatedEvent;
 use CachetHQ\Cachet\Models\Component;
 use CachetHQ\Cachet\Models\Incident;
-use CachetHQ\Cachet\Models\IncidentTemplate;
 
 /**
  * This is the promtheus incident test class.
@@ -53,47 +51,41 @@ class PrometheusIncidentTest extends AbstractApiTestCase
 
         $alertWithoutComponentId = [
             'receiver' => 'statuspage-receiver',
-            'status' => 'firing',
-            'alerts' =>
-                [
+            'status'   => 'firing',
+            'alerts'   => [
                     [
                         'status' => 'firing',
-                        'labels' =>
-                            [
+                        'labels' => [
                                 'alertname' => 'test-rule-metrics',
-                                'code' => '200',
-                                'instance' => 'localhost:9090',
-                                'job' => 'prometheus',
+                                'code'      => '200',
+                                'instance'  => 'localhost:9090',
+                                'job'       => 'prometheus',
                                 //'status_page_component_id' => '1', //commented intentionally
                             ],
-                        'annotations' =>
-                            [
+                        'annotations' => [
                                 'description' => 'A Test-Message.',
-                                'summary' => 'A Test-Summary.',
+                                'summary'     => 'A Test-Summary.',
                             ],
-                        'startsAt' => '2019-01-18T10:02:49.770506166Z',
-                        'endsAt' => '0001-01-01T00:00:00Z',
+                        'startsAt'     => '2019-01-18T10:02:49.770506166Z',
+                        'endsAt'       => '0001-01-01T00:00:00Z',
                         'generatorURL' => 'http://homestead:9090/graph?g0.expr=promhttp_metric_handler_requests_total+>+0&g0.tab=1',
                     ],
                 ],
-            'groupLabels' =>
-                [],
-            'commonLabels' =>
-                [
+            'groupLabels'  => [],
+            'commonLabels' => [
                     'alertname' => 'test-rule-metrics',
-                    'code' => '200',
-                    'instance' => 'localhost:9090',
-                    'job' => 'prometheus',
+                    'code'      => '200',
+                    'instance'  => 'localhost:9090',
+                    'job'       => 'prometheus',
                     //'status_page_component_id' => '1', //commented intentionally
                 ],
-            'commonAnnotations' =>
-                [
+            'commonAnnotations' => [
                     'description' => 'A Test-Message.',
-                    'summary' => 'A Test-Summary.',
+                    'summary'     => 'A Test-Summary.',
                 ],
             'externalURL' => 'http://homestead:9093',
-            'version' => '4',
-            'groupKey' => '{}:{}',
+            'version'     => '4',
+            'groupKey'    => '{}:{}',
         ];
 
         $response = $this->json('POST', '/api/v1/incidents/alertmanager', $alertWithoutComponentId);
@@ -109,67 +101,61 @@ class PrometheusIncidentTest extends AbstractApiTestCase
         $this->expectsEvents(IncidentWasCreatedEvent::class);
 
         $component = factory(Component::class)->create([
-            "status" => 1
+            'status' => 1,
         ]);
 
         $alert = [
             'receiver' => 'statuspage-receiver',
-            'status' => 'firing',
-            'alerts' =>
-                [
+            'status'   => 'firing',
+            'alerts'   => [
                     [
                         'status' => 'firing',
-                        'labels' =>
-                            [
-                                'alertname' => 'test-rule-metrics',
-                                'code' => '200',
-                                'instance' => 'localhost:9090',
-                                'job' => 'prometheus',
+                        'labels' => [
+                                'alertname'                => 'test-rule-metrics',
+                                'code'                     => '200',
+                                'instance'                 => 'localhost:9090',
+                                'job'                      => 'prometheus',
                                 'status_page_component_id' => (string) $component->id, //commented intentionally
                             ],
-                        'annotations' =>
-                            [
+                        'annotations' => [
                                 'description' => 'A Test-Message.',
-                                'summary' => 'A Test-Summary.',
+                                'summary'     => 'A Test-Summary.',
                             ],
-                        'startsAt' => '2019-01-18T10:02:49.770506166Z',
-                        'endsAt' => '0001-01-01T00:00:00Z',
+                        'startsAt'     => '2019-01-18T10:02:49.770506166Z',
+                        'endsAt'       => '0001-01-01T00:00:00Z',
                         'generatorURL' => 'http://homestead:9090/graph?g0.expr=promhttp_metric_handler_requests_total+>+0&g0.tab=1',
                     ],
                 ],
-            'groupLabels' =>
-                [],
-            'commonLabels' =>
-                [
-                    'alertname' => 'test-rule-metrics',
-                    'code' => '200',
-                    'instance' => 'localhost:9090',
-                    'job' => 'prometheus',
+            'groupLabels'  => [],
+            'commonLabels' => [
+                    'alertname'                => 'test-rule-metrics',
+                    'code'                     => '200',
+                    'instance'                 => 'localhost:9090',
+                    'job'                      => 'prometheus',
                     'status_page_component_id' => (string) $component->id, //commented intentionally
                 ],
-            'commonAnnotations' =>
-                [
+            'commonAnnotations' => [
                     'description' => 'A Test-Message.',
-                    'summary' => 'A Test-Summary.',
+                    'summary'     => 'A Test-Summary.',
                 ],
             'externalURL' => 'http://homestead:9093',
-            'version' => '4',
-            'groupKey' => '{}:{}',
+            'version'     => '4',
+            'groupKey'    => '{}:{}',
         ];
 
         $response = $this->json('POST', '/api/v1/incidents/alertmanager', $alert);
         $response->assertStatus(200);
-        $incident = Incident::where("name", "A Test-Summary.")->first();
+        $incident = Incident::where('name', 'A Test-Summary.')->first();
 
         $this->assertEquals($component->id, $incident->component->id);
 
         $this->assertEquals(
-            config("prometheus.new_incident_status", 1),
+            config('prometheus.new_incident_status', 1),
             $incident->status
         );
 
         $this->assertEquals(
-            config("prometheus.new_incident_component_status", 2),
+            config('prometheus.new_incident_component_status', 2),
             $incident->component->status
         );
     }
@@ -181,52 +167,46 @@ class PrometheusIncidentTest extends AbstractApiTestCase
         $this->expectsEvents(IncidentWasUpdatedEvent::class);
 
         $component = factory(Component::class)->create([
-            "status" => 1
+            'status' => 1,
         ]);
 
         $alert = [
             'receiver' => 'statuspage-receiver',
-            'status' => 'firing',
-            'alerts' =>
-                [
+            'status'   => 'firing',
+            'alerts'   => [
                     [
                         'status' => 'firing',
-                        'labels' =>
-                            [
-                                'alertname' => 'test-rule-metrics',
-                                'code' => '200',
-                                'instance' => 'localhost:9090',
-                                'job' => 'prometheus',
+                        'labels' => [
+                                'alertname'                => 'test-rule-metrics',
+                                'code'                     => '200',
+                                'instance'                 => 'localhost:9090',
+                                'job'                      => 'prometheus',
                                 'status_page_component_id' => (string) $component->id, //commented intentionally
                             ],
-                        'annotations' =>
-                            [
+                        'annotations' => [
                                 'description' => 'A Test-Message.',
-                                'summary' => 'A Test-Summary.',
+                                'summary'     => 'A Test-Summary.',
                             ],
-                        'startsAt' => '2019-01-18T10:02:49.770506166Z',
-                        'endsAt' => '0001-01-01T00:00:00Z',
+                        'startsAt'     => '2019-01-18T10:02:49.770506166Z',
+                        'endsAt'       => '0001-01-01T00:00:00Z',
                         'generatorURL' => 'http://homestead:9090/graph?g0.expr=promhttp_metric_handler_requests_total+>+0&g0.tab=1',
                     ],
                 ],
-            'groupLabels' =>
-                [],
-            'commonLabels' =>
-                [
-                    'alertname' => 'test-rule-metrics',
-                    'code' => '200',
-                    'instance' => 'localhost:9090',
-                    'job' => 'prometheus',
+            'groupLabels'  => [],
+            'commonLabels' => [
+                    'alertname'                => 'test-rule-metrics',
+                    'code'                     => '200',
+                    'instance'                 => 'localhost:9090',
+                    'job'                      => 'prometheus',
                     'status_page_component_id' => (string) $component->id, //commented intentionally
                 ],
-            'commonAnnotations' =>
-                [
+            'commonAnnotations' => [
                     'description' => 'A Test-Message.',
-                    'summary' => 'A Test-Summary.',
+                    'summary'     => 'A Test-Summary.',
                 ],
             'externalURL' => 'http://homestead:9093',
-            'version' => '4',
-            'groupKey' => '{}:{}',
+            'version'     => '4',
+            'groupKey'    => '{}:{}',
         ];
 
         $response = $this->json('POST', '/api/v1/incidents/alertmanager', $alert);
@@ -235,63 +215,56 @@ class PrometheusIncidentTest extends AbstractApiTestCase
         //now resolve the incident we just created
         $alert = [
             'receiver' => 'statuspage-receiver',
-            'status' => 'resolved',
-            'alerts' =>
-                [
+            'status'   => 'resolved',
+            'alerts'   => [
                     [
                         'status' => 'resolved',
-                        'labels' =>
-                            [
-                                'alertname' => 'test-rule-metrics',
-                                'code' => '200',
-                                'instance' => 'localhost:9090',
-                                'job' => 'prometheus',
+                        'labels' => [
+                                'alertname'                => 'test-rule-metrics',
+                                'code'                     => '200',
+                                'instance'                 => 'localhost:9090',
+                                'job'                      => 'prometheus',
                                 'status_page_component_id' => (string) $component->id, //commented intentionally
                             ],
-                        'annotations' =>
-                            [
+                        'annotations' => [
                                 'description' => 'A Test-Message.',
-                                'summary' => 'A Test-Summary.',
+                                'summary'     => 'A Test-Summary.',
                             ],
-                        'startsAt' => '2019-01-18T10:02:49.770506166Z',
-                        'endsAt' => '2019-01-18T11:02:49.770506166Z',
+                        'startsAt'     => '2019-01-18T10:02:49.770506166Z',
+                        'endsAt'       => '2019-01-18T11:02:49.770506166Z',
                         'generatorURL' => 'http://homestead:9090/graph?g0.expr=promhttp_metric_handler_requests_total+>+0&g0.tab=1',
                     ],
                 ],
-            'groupLabels' =>
-                [],
-            'commonLabels' =>
-                [
-                    'alertname' => 'test-rule-metrics',
-                    'code' => '200',
-                    'instance' => 'localhost:9090',
-                    'job' => 'prometheus',
+            'groupLabels'  => [],
+            'commonLabels' => [
+                    'alertname'                => 'test-rule-metrics',
+                    'code'                     => '200',
+                    'instance'                 => 'localhost:9090',
+                    'job'                      => 'prometheus',
                     'status_page_component_id' => (string) $component->id, //commented intentionally
                 ],
-            'commonAnnotations' =>
-                [
+            'commonAnnotations' => [
                     'description' => 'A Test-Message.',
-                    'summary' => 'A Test-Summary.',
+                    'summary'     => 'A Test-Summary.',
                 ],
             'externalURL' => 'http://homestead:9093',
-            'version' => '4',
-            'groupKey' => '{}:{}',
+            'version'     => '4',
+            'groupKey'    => '{}:{}',
         ];
 
         $response = $this->json('POST', '/api/v1/incidents/alertmanager', $alert);
         $response->assertStatus(200);
 
-        $incident = Incident::where("name", "A Test-Summary.")->first();
+        $incident = Incident::where('name', 'A Test-Summary.')->first();
 
         $this->assertEquals(
-            config("prometheus.resolved_incident_status", 4),
+            config('prometheus.resolved_incident_status', 4),
             $incident->status
         );
 
         $this->assertEquals(
-            config("prometheus.resolved_incident_component_status", 1),
+            config('prometheus.resolved_incident_component_status', 1),
             $incident->component->status
         );
-
     }
 }

--- a/tests/Api/PrometheusIncidentTest.php
+++ b/tests/Api/PrometheusIncidentTest.php
@@ -1,0 +1,297 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Tests\Cachet\Api;
+
+use CachetHQ\Cachet\Bus\Events\Incident\IncidentWasCreatedEvent;
+use CachetHQ\Cachet\Bus\Events\Incident\IncidentWasRemovedEvent;
+use CachetHQ\Cachet\Bus\Events\Incident\IncidentWasUpdatedEvent;
+use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Models\Incident;
+use CachetHQ\Cachet\Models\IncidentTemplate;
+
+/**
+ * This is the promtheus incident test class.
+ *
+ * @author Erik Anders <github@naugrim.org>
+ */
+class PrometheusIncidentTest extends AbstractApiTestCase
+{
+    public function test_cannot_create_incident_without_authorization()
+    {
+        $this->doesntExpectEvents(IncidentWasCreatedEvent::class);
+
+        $response = $this->json('POST', '/api/v1/incidents/alertmanager');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_cannot_create_incident_with_missing_data()
+    {
+        $this->beUser();
+
+        $this->doesntExpectEvents(IncidentWasCreatedEvent::class);
+
+        $response = $this->json('POST', '/api/v1/incidents/alertmanager');
+
+        $response->assertStatus(400);
+    }
+
+    public function test_cannot_create_incident_without_component_id()
+    {
+        $this->beUser();
+
+        $this->doesntExpectEvents(IncidentWasCreatedEvent::class);
+
+        $alertWithoutComponentId = [
+            'receiver' => 'statuspage-receiver',
+            'status' => 'firing',
+            'alerts' =>
+                [
+                    [
+                        'status' => 'firing',
+                        'labels' =>
+                            [
+                                'alertname' => 'test-rule-metrics',
+                                'code' => '200',
+                                'instance' => 'localhost:9090',
+                                'job' => 'prometheus',
+                                //'status_page_component_id' => '1', //commented intentionally
+                            ],
+                        'annotations' =>
+                            [
+                                'description' => 'A Test-Message.',
+                                'summary' => 'A Test-Summary.',
+                            ],
+                        'startsAt' => '2019-01-18T10:02:49.770506166Z',
+                        'endsAt' => '0001-01-01T00:00:00Z',
+                        'generatorURL' => 'http://homestead:9090/graph?g0.expr=promhttp_metric_handler_requests_total+>+0&g0.tab=1',
+                    ],
+                ],
+            'groupLabels' =>
+                [],
+            'commonLabels' =>
+                [
+                    'alertname' => 'test-rule-metrics',
+                    'code' => '200',
+                    'instance' => 'localhost:9090',
+                    'job' => 'prometheus',
+                    //'status_page_component_id' => '1', //commented intentionally
+                ],
+            'commonAnnotations' =>
+                [
+                    'description' => 'A Test-Message.',
+                    'summary' => 'A Test-Summary.',
+                ],
+            'externalURL' => 'http://homestead:9093',
+            'version' => '4',
+            'groupKey' => '{}:{}',
+        ];
+
+        $response = $this->json('POST', '/api/v1/incidents/alertmanager', $alertWithoutComponentId);
+
+        $response->assertStatus(400);
+        $response->assertJsonFragment(['detail' => 'No status_page_component_id given.']);
+    }
+
+    public function test_can_create_incident()
+    {
+        $this->beUser();
+
+        $this->expectsEvents(IncidentWasCreatedEvent::class);
+
+        $component = factory(Component::class)->create([
+            "status" => 1
+        ]);
+
+        $alert = [
+            'receiver' => 'statuspage-receiver',
+            'status' => 'firing',
+            'alerts' =>
+                [
+                    [
+                        'status' => 'firing',
+                        'labels' =>
+                            [
+                                'alertname' => 'test-rule-metrics',
+                                'code' => '200',
+                                'instance' => 'localhost:9090',
+                                'job' => 'prometheus',
+                                'status_page_component_id' => (string) $component->id, //commented intentionally
+                            ],
+                        'annotations' =>
+                            [
+                                'description' => 'A Test-Message.',
+                                'summary' => 'A Test-Summary.',
+                            ],
+                        'startsAt' => '2019-01-18T10:02:49.770506166Z',
+                        'endsAt' => '0001-01-01T00:00:00Z',
+                        'generatorURL' => 'http://homestead:9090/graph?g0.expr=promhttp_metric_handler_requests_total+>+0&g0.tab=1',
+                    ],
+                ],
+            'groupLabels' =>
+                [],
+            'commonLabels' =>
+                [
+                    'alertname' => 'test-rule-metrics',
+                    'code' => '200',
+                    'instance' => 'localhost:9090',
+                    'job' => 'prometheus',
+                    'status_page_component_id' => (string) $component->id, //commented intentionally
+                ],
+            'commonAnnotations' =>
+                [
+                    'description' => 'A Test-Message.',
+                    'summary' => 'A Test-Summary.',
+                ],
+            'externalURL' => 'http://homestead:9093',
+            'version' => '4',
+            'groupKey' => '{}:{}',
+        ];
+
+        $response = $this->json('POST', '/api/v1/incidents/alertmanager', $alert);
+        $response->assertStatus(200);
+        $incident = Incident::where("name", "A Test-Summary.")->first();
+
+        $this->assertEquals($component->id, $incident->component->id);
+
+        $this->assertEquals(
+            config("prometheus.new_incident_status", 1),
+            $incident->status
+        );
+
+        $this->assertEquals(
+            config("prometheus.new_incident_component_status", 2),
+            $incident->component->status
+        );
+    }
+
+    public function test_can_resolve_incident()
+    {
+        $this->beUser();
+
+        $this->expectsEvents(IncidentWasUpdatedEvent::class);
+
+        $component = factory(Component::class)->create([
+            "status" => 1
+        ]);
+
+        $alert = [
+            'receiver' => 'statuspage-receiver',
+            'status' => 'firing',
+            'alerts' =>
+                [
+                    [
+                        'status' => 'firing',
+                        'labels' =>
+                            [
+                                'alertname' => 'test-rule-metrics',
+                                'code' => '200',
+                                'instance' => 'localhost:9090',
+                                'job' => 'prometheus',
+                                'status_page_component_id' => (string) $component->id, //commented intentionally
+                            ],
+                        'annotations' =>
+                            [
+                                'description' => 'A Test-Message.',
+                                'summary' => 'A Test-Summary.',
+                            ],
+                        'startsAt' => '2019-01-18T10:02:49.770506166Z',
+                        'endsAt' => '0001-01-01T00:00:00Z',
+                        'generatorURL' => 'http://homestead:9090/graph?g0.expr=promhttp_metric_handler_requests_total+>+0&g0.tab=1',
+                    ],
+                ],
+            'groupLabels' =>
+                [],
+            'commonLabels' =>
+                [
+                    'alertname' => 'test-rule-metrics',
+                    'code' => '200',
+                    'instance' => 'localhost:9090',
+                    'job' => 'prometheus',
+                    'status_page_component_id' => (string) $component->id, //commented intentionally
+                ],
+            'commonAnnotations' =>
+                [
+                    'description' => 'A Test-Message.',
+                    'summary' => 'A Test-Summary.',
+                ],
+            'externalURL' => 'http://homestead:9093',
+            'version' => '4',
+            'groupKey' => '{}:{}',
+        ];
+
+        $response = $this->json('POST', '/api/v1/incidents/alertmanager', $alert);
+        $response->assertStatus(200);
+
+        //now resolve the incident we just created
+        $alert = [
+            'receiver' => 'statuspage-receiver',
+            'status' => 'resolved',
+            'alerts' =>
+                [
+                    [
+                        'status' => 'resolved',
+                        'labels' =>
+                            [
+                                'alertname' => 'test-rule-metrics',
+                                'code' => '200',
+                                'instance' => 'localhost:9090',
+                                'job' => 'prometheus',
+                                'status_page_component_id' => (string) $component->id, //commented intentionally
+                            ],
+                        'annotations' =>
+                            [
+                                'description' => 'A Test-Message.',
+                                'summary' => 'A Test-Summary.',
+                            ],
+                        'startsAt' => '2019-01-18T10:02:49.770506166Z',
+                        'endsAt' => '2019-01-18T11:02:49.770506166Z',
+                        'generatorURL' => 'http://homestead:9090/graph?g0.expr=promhttp_metric_handler_requests_total+>+0&g0.tab=1',
+                    ],
+                ],
+            'groupLabels' =>
+                [],
+            'commonLabels' =>
+                [
+                    'alertname' => 'test-rule-metrics',
+                    'code' => '200',
+                    'instance' => 'localhost:9090',
+                    'job' => 'prometheus',
+                    'status_page_component_id' => (string) $component->id, //commented intentionally
+                ],
+            'commonAnnotations' =>
+                [
+                    'description' => 'A Test-Message.',
+                    'summary' => 'A Test-Summary.',
+                ],
+            'externalURL' => 'http://homestead:9093',
+            'version' => '4',
+            'groupKey' => '{}:{}',
+        ];
+
+        $response = $this->json('POST', '/api/v1/incidents/alertmanager', $alert);
+        $response->assertStatus(200);
+
+        $incident = Incident::where("name", "A Test-Summary.")->first();
+
+        $this->assertEquals(
+            config("prometheus.resolved_incident_status", 4),
+            $incident->status
+        );
+
+        $this->assertEquals(
+            config("prometheus.resolved_incident_component_status", 1),
+            $incident->component->status
+        );
+
+    }
+}

--- a/tests/Api/PrometheusIncidentTest.php
+++ b/tests/Api/PrometheusIncidentTest.php
@@ -224,7 +224,7 @@ class PrometheusIncidentTest extends AbstractApiTestCase
                                 'code'                     => '200',
                                 'instance'                 => 'localhost:9090',
                                 'job'                      => 'prometheus',
-                                'status_page_component_id' => (string) $component->id, //commented intentionally
+                                'status_page_component_id' => (string) $component->id,
                             ],
                         'annotations' => [
                                 'description' => 'A Test-Message.',
@@ -241,7 +241,7 @@ class PrometheusIncidentTest extends AbstractApiTestCase
                     'code'                     => '200',
                     'instance'                 => 'localhost:9090',
                     'job'                      => 'prometheus',
-                    'status_page_component_id' => (string) $component->id, //commented intentionally
+                    'status_page_component_id' => (string) $component->id,
                 ],
             'commonAnnotations' => [
                     'description' => 'A Test-Message.',


### PR DESCRIPTION
related to #2521

This pull request adds a new endpoint to the HTTP API that can be used as a webhook URL in the [prometheus alertmanager ](https://prometheus.io/docs/alerting/alertmanager/).

An example rule in prometheus looks like this:

```yml
groups:
  - name: test-rules
    rules:
    - alert: test-rule-metrics
      expr: promhttp_metric_handler_requests_total > 0
      for: 30s
      labels:
        status_page_component_id: 1 # put the ID of the component here under which to file this incident
      annotations:
        summary: "A Test-Incident"
        description: "A Test-Message."
```

The webhook-config in the Alertmanager is as follows:

```yml
# ...
receivers:
- name: statuspage-receiver
  webhook_configs:
  - http_config:
      bearer_token: 123456789abcdef
    send_resolved: true
    url: https://status.localdomain/api/v1/incidents/alertmanager
# ...
```

By default, the component status will be updated to "Performance Issues". The incident will be created with the status "Investigating".

These default-values can be set in `config/prometheus.php`. 

When the alertmanager sends a "resolved" message, the component status will be set to "Operational" and the incident status will be set to "Fixed" **only if** the status of the component/incident was not manually changed.

The ApiAuthentication middleware has been extended to support `Authorization: Bearer <LE-API-KEY>` in addition to the already existing `X-Cachet-Token` header.