### PR TITLE
Do not use arr_* or str_* helpers

### DIFF
--- a/app/Composers/StatusComposer.php
+++ b/app/Composers/StatusComposer.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Cachet\Composers;
 
 use CachetHQ\Cachet\Integrations\Contracts\System;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Arr;
 
 /**
  * This is the status composer.
@@ -52,7 +53,7 @@ class StatusComposer
     {
         $status = $this->system->getStatus();
 
-        $view->withSystemStatus(array_get($status, 'system_status'));
-        $view->withSystemMessage(array_get($status, 'system_message'));
+        $view->withSystemStatus(Arr::get($status, 'system_status'));
+        $view->withSystemMessage(Arr::get($status, 'system_message'));
     }
 }

--- a/app/Composers/TimezoneLocaleComposer.php
+++ b/app/Composers/TimezoneLocaleComposer.php
@@ -15,6 +15,7 @@ use DateTime;
 use DateTimeZone;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Arr;
 
 /**
  * This is the timezone locale composer class.
@@ -58,7 +59,7 @@ class TimezoneLocaleComposer
         $langs = array_map(function ($lang) use ($enabledLangs) {
             $locale = basename($lang);
 
-            return [$locale => array_get($enabledLangs, $locale, [
+            return [$locale => Arr::get($enabledLangs, $locale, [
                 'name'   => $locale,
                 'subset' => null,
             ])];

--- a/app/Foundation/Exceptions/Filters/ApiFilter.php
+++ b/app/Foundation/Exceptions/Filters/ApiFilter.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Cachet\Foundation\Exceptions\Filters;
 
 use Exception;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 class ApiFilter
 {
@@ -31,7 +32,7 @@ class ApiFilter
     {
         if ($request->is('api*')) {
             foreach ($displayers as $index => $displayer) {
-                if (!str_contains($displayer->contentType(), 'application/')) {
+                if (!Str::contains($displayer->contentType(), 'application/')) {
                     unset($displayers[$index]);
                 }
             }

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -17,6 +17,7 @@ use CachetHQ\Cachet\Bus\Events\User\UserLoggedOutEvent;
 use CachetHQ\Cachet\Bus\Events\User\UserPassedTwoAuthEvent;
 use GrahamCampbell\Binput\Facades\Binput;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;
@@ -47,9 +48,9 @@ class AuthController extends Controller
 
         // Login with username or email.
         $loginKey = filter_var($loginData['username'], FILTER_VALIDATE_EMAIL) ? 'email' : 'username';
-        $loginData[$loginKey] = array_pull($loginData, 'username');
+        $loginData[$loginKey] = Arr::pull($loginData, 'username');
 
-        $rememberUser = array_pull($loginData, 'remember_me') === '1';
+        $rememberUser = Arr::pull($loginData, 'remember_me') === '1';
 
         // Validate login credentials.
         if (Auth::validate($loginData)) {

--- a/app/Http/Controllers/Dashboard/ComponentController.php
+++ b/app/Http/Controllers/Dashboard/ComponentController.php
@@ -21,6 +21,7 @@ use CachetHQ\Cachet\Models\Component;
 use CachetHQ\Cachet\Models\ComponentGroup;
 use GrahamCampbell\Binput\Facades\Binput;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\View;
 
@@ -112,7 +113,7 @@ class ComponentController extends Controller
     public function updateComponentAction(Component $component)
     {
         $componentData = Binput::get('component');
-        $tags = array_pull($componentData, 'tags');
+        $tags = Arr::pull($componentData, 'tags');
 
         try {
             $component = execute(new UpdateComponentCommand(
@@ -169,7 +170,7 @@ class ComponentController extends Controller
     public function createComponentAction()
     {
         $componentData = Binput::get('component');
-        $tags = array_pull($componentData, 'tags');
+        $tags = Arr::pull($componentData, 'tags');
 
         try {
             $component = execute(new CreateComponentCommand(

--- a/app/Http/Controllers/Dashboard/UserController.php
+++ b/app/Http/Controllers/Dashboard/UserController.php
@@ -18,6 +18,7 @@ use CachetHQ\Cachet\Bus\Events\User\UserRegeneratedApiTokenEvent;
 use CachetHQ\Cachet\Models\User;
 use GrahamCampbell\Binput\Facades\Binput;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\View;
 use PragmaRX\Google2FA\Vendor\Laravel\Facade as Google2FA;
@@ -44,7 +45,7 @@ class UserController extends Controller
     {
         $userData = array_filter(Binput::only(['username', 'email', 'password', 'google2fa']));
 
-        $enable2FA = (bool) array_pull($userData, 'google2fa');
+        $enable2FA = (bool) Arr::pull($userData, 'google2fa');
 
         // Let's enable/disable auth
         if ($enable2FA && !Auth::user()->hasTwoFactor) {

--- a/app/Http/Controllers/SetupController.php
+++ b/app/Http/Controllers/SetupController.php
@@ -16,6 +16,7 @@ use CachetHQ\Cachet\Models\User;
 use CachetHQ\Cachet\Settings\Repository;
 use GrahamCampbell\Binput\Facades\Binput;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Request;
@@ -240,7 +241,7 @@ class SetupController extends Controller
 
         if ($v->passes()) {
             // Pull the user details out.
-            $userDetails = array_pull($postData, 'user');
+            $userDetails = Arr::pull($postData, 'user');
 
             $user = User::create([
                 'username' => $userDetails['username'],
@@ -253,13 +254,13 @@ class SetupController extends Controller
 
             $setting = app(Repository::class);
 
-            $settings = array_pull($postData, 'settings');
+            $settings = Arr::pull($postData, 'settings');
 
             foreach ($settings as $settingName => $settingValue) {
                 $setting->set($settingName, $settingValue);
             }
 
-            $envData = array_pull($postData, 'env');
+            $envData = Arr::pull($postData, 'env');
 
             // Write the env to the .env file.
             execute(new UpdateConfigCommand($envData));

--- a/app/Integrations/Core/Beacon.php
+++ b/app/Integrations/Core/Beacon.php
@@ -25,6 +25,7 @@ use CachetHQ\Cachet\Settings\Repository as Setting;
 use Exception;
 use GuzzleHttp\Client;
 use Illuminate\Contracts\Config\Repository;
+use Illuminate\Support\Str;
 
 /**
  * This is the beacon class.
@@ -84,7 +85,7 @@ class Beacon implements BeaconContract
         $setting = app(Setting::class);
 
         if (!$installId = $setting->get('install_id', null)) {
-            $installId = sha1(str_random(20));
+            $installId = sha1(Str::random(20));
 
             $setting->set('install_id', $installId);
         }

--- a/app/Models/Invite.php
+++ b/app/Models/Invite.php
@@ -13,6 +13,7 @@ namespace CachetHQ\Cachet\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Str;
 
 /**
  * This is the invite class.
@@ -51,7 +52,7 @@ class Invite extends Model
 
         self::creating(function ($invite) {
             if (!$invite->code) {
-                $invite->code = str_random(20);
+                $invite->code = Str::random(20);
             }
         });
     }

--- a/app/Models/Subscriber.php
+++ b/app/Models/Subscriber.php
@@ -16,6 +16,7 @@ use CachetHQ\Cachet\Presenters\SubscriberPresenter;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Str;
 use McCool\LaravelAutoPresenter\HasPresenter;
 
 /**
@@ -166,7 +167,7 @@ class Subscriber extends Model implements HasPresenter
      */
     public static function generateVerifyCode()
     {
-        return str_random(42);
+        return Str::random(42);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
 use McCool\LaravelAutoPresenter\HasPresenter;
 
 /**
@@ -188,7 +189,7 @@ class User extends Authenticatable implements HasPresenter
      */
     public static function generateApiKey()
     {
-        return str_random(20);
+        return Str::random(20);
     }
 
     /**

--- a/tests/Api/ScheduleTest.php
+++ b/tests/Api/ScheduleTest.php
@@ -55,7 +55,7 @@ class ScheduleTest extends AbstractApiTestCase
 
         $response = $this->json('POST', '/api/v1/schedules/', $schedule);
 
-        array_forget($schedule, 'scheduled_at');
+        Arr::forget($schedule, 'scheduled_at');
 
         $response->assertStatus(200);
         $response->assertJsonFragment($schedule);

--- a/tests/Api/ScheduleTest.php
+++ b/tests/Api/ScheduleTest.php
@@ -12,6 +12,7 @@
 namespace CachetHQ\Tests\Cachet\Api;
 
 use CachetHQ\Cachet\Models\Schedule;
+use Illuminate\Support\Arr;
 
 /**
  * This is the schedule test class.


### PR DESCRIPTION
The upcoming [Laravel 5.8 release](https://laravel-news.com/laravel-5-8-deprecates-string-and-array-helpers) deprecates the use of the `arr_*` and `str_*` helpers. Let's remove them in preparation.