### PR TITLE
Substitute :name by incident name on slack title

### DIFF
--- a/app/Notifications/Incident/NewIncidentNotification.php
+++ b/app/Notifications/Incident/NewIncidentNotification.php
@@ -128,7 +128,7 @@ class NewIncidentNotification extends Notification
                     ->$status()
                     ->content($content)
                     ->attachment(function ($attachment) use ($notifiable) {
-                        $attachment->title(trans('notifications.incident.new.slack.title', [$this->incident->name]))
+                        $attachment->title(trans('notifications.incident.new.slack.title', ['name' => $this->incident->name]))
                                    ->timestamp($this->incident->getWrappedObject()->occurred_at)
                                    ->fields(array_filter([
                                         'ID'   => "#{$this->incident->id}",


### PR DESCRIPTION
Slack title for created incident has ':name', which is being substituted by incident name. With previous  change it was reported as 'Incident :name Reported' in slack title.