### PR TITLE
API cache control

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -15,6 +15,7 @@ use Barryvdh\Cors\HandleCors;
 use CachetHQ\Cachet\Http\Middleware\Admin;
 use CachetHQ\Cachet\Http\Middleware\ApiAuthentication;
 use CachetHQ\Cachet\Http\Middleware\Authenticate;
+use CachetHQ\Cachet\Http\Middleware\CacheControl;
 use CachetHQ\Cachet\Http\Middleware\Localize;
 use CachetHQ\Cachet\Http\Middleware\ReadyForUse;
 use CachetHQ\Cachet\Http\Middleware\RedirectIfAuthenticated;
@@ -47,6 +48,7 @@ class Kernel extends HttpKernel
         'admin'       => Admin::class,
         'can'         => Authorize::class,
         'cors'        => HandleCors::class,
+        'cache'       => CacheControl::class,
         'auth'        => Authenticate::class,
         'auth.api'    => ApiAuthentication::class,
         'guest'       => RedirectIfAuthenticated::class,

--- a/app/Http/Middleware/CacheControl.php
+++ b/app/Http/Middleware/CacheControl.php
@@ -19,8 +19,9 @@ class CacheControl
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
+     *
      * @return mixed
      */
     public function handle(Request $request, Closure $next)

--- a/app/Http/Middleware/CacheControl.php
+++ b/app/Http/Middleware/CacheControl.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class CacheControl
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $response = $next($request);
+
+        $maxAge = time() + 30;
+
+        $response->header('Cache-Control', 'public,max-age='.$maxAge);
+
+        return $response;
+    }
+}

--- a/app/Http/Routes/ApiSystemRoutes.php
+++ b/app/Http/Routes/ApiSystemRoutes.php
@@ -43,7 +43,7 @@ class ApiSystemRoutes
             $router->group(['middleware' => ['auth.api']], function (Registrar $router) {
                 $router->get('ping', 'GeneralController@ping');
                 $router->get('version', 'GeneralController@version');
-                $router->get('status', 'GeneralController@status');
+                $router->get('status', ['uses' => 'GeneralController@status', 'middleware' => ['cache']]);
             });
         });
     }

--- a/tests/Api/GeneralTest.php
+++ b/tests/Api/GeneralTest.php
@@ -54,8 +54,8 @@ class GeneralTest extends AbstractApiTestCase
                  ->assertJsonFragment([
                      'data' => [
                          'status'  => 'success',
-                         'message' => 'System operational'
-                     ]
+                         'message' => 'System operational',
+                     ],
                  ]);
     }
 
@@ -72,8 +72,8 @@ class GeneralTest extends AbstractApiTestCase
                  ->assertJsonFragment([
                      'data' => [
                          'status'  => 'info',
-                         'message' => 'The system is experiencing issues'
-                     ]
+                         'message' => 'The system is experiencing issues',
+                     ],
                  ]);
     }
 }

--- a/tests/Api/GeneralTest.php
+++ b/tests/Api/GeneralTest.php
@@ -11,6 +11,8 @@
 
 namespace CachetHQ\Tests\Cachet\Api;
 
+use CachetHQ\Cachet\Models\Component;
+
 /**
  * This is the general test class.
  *
@@ -41,5 +43,37 @@ class GeneralTest extends AbstractApiTestCase
         $response = $this->json('GET', '/api/v1/ping', [], ['HTTP_Accept' => 'text/html']);
 
         $response->assertStatus(406);
+    }
+
+    public function test_can_get_system_status()
+    {
+        $response = $this->json('GET', '/api/v1/status');
+
+        $response->assertStatus(200)
+                 ->assertHeader('Cache-Control')
+                 ->assertJsonFragment([
+                     'data' => [
+                         'status'  => 'success',
+                         'message' => 'System operational'
+                     ]
+                 ]);
+    }
+
+    public function test_can_get_system_status_not_success()
+    {
+        factory(Component::class)->create([
+            'status' => 3,
+        ]);
+
+        $response = $this->json('GET', '/api/v1/status');
+
+        $response->assertStatus(200)
+                 ->assertHeader('Cache-Control')
+                 ->assertJsonFragment([
+                     'data' => [
+                         'status'  => 'info',
+                         'message' => 'The system is experiencing issues'
+                     ]
+                 ]);
     }
 }


### PR DESCRIPTION
Closes #3479 

---

This adds the `Cache-Control` middleware to the status endpoint of a max-age of now + 30 seconds. Before this gets merged, the added time needs to be variable (with a default of 30?) so that other endpoints can use it as needed.

Ping @Daniel15 on this one.