### PR TITLE
Make pgsql schema configurable via environment variable

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -72,7 +72,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'charset'  => 'utf8',
             'prefix'   => env('DB_PREFIX', null),
-            'schema'   => 'public',
+            'schema'   => env('DB_SCHEMA', 'public'),
             'sslmode'  => 'prefer',
         ],
 


### PR DESCRIPTION
This change restores the option to set the postgres schema via DB_SCHEMA, as is the case in the 2.3 branch.