### PR TITLE
Add a canonical tag with full URL to status page

### DIFF
--- a/resources/views/layout/master.blade.php
+++ b/resources/views/layout/master.blade.php
@@ -25,6 +25,8 @@
     <meta name="msapplication-TileColor" content="{{ $themeGreens }}" />
     <meta name="msapplication-TileImage" content="{{ asset('/img/favicon.png') }}" />
 
+    <link href="{{ Request::fullUrl() }}" rel="canonical">
+
     @if (isset($favicon))
     <link rel="icon" href="{{ asset("/img/{$favicon}.ico") }}" type="image/x-icon">
     <link rel="shortcut icon" href="{{ asset("/img/{$favicon}.png") }}" type="image/png">


### PR DESCRIPTION
I didn't include it in the dashboard layout, because it's hidden from the public and any crawler.

Fixes https://github.com/CachetHQ/Cachet/issues/3513