### PR TITLE
Show current ongoing maintenance, not just future ones.

### DIFF
--- a/app/Models/Schedule.php
+++ b/app/Models/Schedule.php
@@ -171,7 +171,7 @@ class Schedule extends Model implements HasPresenter
      */
     public function scopeFutureSchedules($query)
     {
-        return $query->whereIn('status', [self::UPCOMING, self::IN_PROGRESS])->where('scheduled_at', '>=', Carbon::now());
+        return $query->whereIn('status', [self::UPCOMING, self::IN_PROGRESS])->where('completed_at', '>=', Carbon::now());
     }
 
     /**


### PR DESCRIPTION
Without this, the maintenance on the dashboard disappears once it starts. It should only disappear when the maintenance is completed.