### PR TITLE
Make sticked messages work on PHP7.3 - Resolves #3515

### DIFF
--- a/resources/views/partials/modules/stickied.blade.php
+++ b/resources/views/partials/modules/stickied.blade.php
@@ -2,7 +2,7 @@
 <div class="section-stickied">
     <h1>{{ trans('cachet.incidents.stickied') }}</h1>
     @foreach($stickiedIncidents as $date => $incidents)
-    @include('partials.incidents', [compact($date), compact($incidents)])
+    @include('partials.incidents')
     @endforeach
 </div>
 @endif


### PR DESCRIPTION
compact changed behaviour on PHP7.3, and I also can't see the need for it as date and incidents are still passed to the view.

This resolves #3515