### PR TITLE
Change text when updating the subscriptions

### DIFF
--- a/app/Http/Controllers/SubscribeController.php
+++ b/app/Http/Controllers/SubscribeController.php
@@ -213,6 +213,6 @@ class SubscribeController extends Controller
         }
 
         return cachet_redirect('subscribe.manage', $subscriber->verify_code)
-            ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('cachet.subscriber.email.subscribed')));
+            ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('cachet.subscriber.email.updated-subscribe')));
     }
 }

--- a/resources/lang/en/cachet.php
+++ b/resources/lang/en/cachet.php
@@ -92,6 +92,7 @@ return [
         'email' => [
             'subscribe'          => 'Subscribe to email updates.',
             'subscribed'         => 'You\'ve been subscribed to email notifications, please check your email to confirm your subscription.',
+            'updated-subscribe'  => 'You\'ve succesfully updated your subscriptions.',
             'verified'           => 'Your email subscription has been confirmed. Thank you!',
             'manage'             => 'Manage your subscription',
             'unsubscribe'        => 'Unsubscribe from email updates.',


### PR DESCRIPTION
Fixes #3561 

The text when updating a subscription was the same as when creating a subscription and this was confusing because this is not the same action.