### PR TITLE
Make maintenance also optional to notify subscribers

### DIFF
--- a/app/Bus/Commands/Schedule/CreateScheduleCommand.php
+++ b/app/Bus/Commands/Schedule/CreateScheduleCommand.php
@@ -91,7 +91,7 @@ final class CreateScheduleCommand
      * @param string $scheduled_at
      * @param string $completed_at
      * @param array  $components
-     * @param notify $notify
+     * @param bool $notify
      *
      * @return void
      */

--- a/app/Bus/Commands/Schedule/CreateScheduleCommand.php
+++ b/app/Bus/Commands/Schedule/CreateScheduleCommand.php
@@ -79,7 +79,7 @@ final class CreateScheduleCommand
         'scheduled_at' => 'required|string',
         'completed_at' => 'nullable|string',
         'components'   => 'nullable|array',
-        'notify'       => 'nullable|bool'
+        'notify'       => 'nullable|bool',
     ];
 
     /**
@@ -95,7 +95,7 @@ final class CreateScheduleCommand
      *
      * @return void
      */
-    public function __construct($name, $message, $status, $scheduled_at, $completed_at, array $components = [], $notify)
+    public function __construct($name, $message, $status, $scheduled_at, $completed_at, $components, $notify)
     {
         $this->name = $name;
         $this->message = $message;

--- a/app/Bus/Commands/Schedule/CreateScheduleCommand.php
+++ b/app/Bus/Commands/Schedule/CreateScheduleCommand.php
@@ -61,6 +61,13 @@ final class CreateScheduleCommand
     public $components;
 
     /**
+     * Whether to notify that the incident was reported.
+     *
+     * @var bool
+     */
+    public $notify;
+
+    /**
      * The validation rules.
      *
      * @var string[]
@@ -72,6 +79,7 @@ final class CreateScheduleCommand
         'scheduled_at' => 'required|string',
         'completed_at' => 'nullable|string',
         'components'   => 'nullable|array',
+        'notify'       => 'nullable|bool'
     ];
 
     /**
@@ -83,10 +91,11 @@ final class CreateScheduleCommand
      * @param string $scheduled_at
      * @param string $completed_at
      * @param array  $components
+     * @param notify $notify
      *
      * @return void
      */
-    public function __construct($name, $message, $status, $scheduled_at, $completed_at, array $components = [])
+    public function __construct($name, $message, $status, $scheduled_at, $completed_at, array $components = [], $notify)
     {
         $this->name = $name;
         $this->message = $message;
@@ -94,5 +103,6 @@ final class CreateScheduleCommand
         $this->scheduled_at = $scheduled_at;
         $this->completed_at = $completed_at;
         $this->components = $components;
+        $this->notify = $notify;
     }
 }

--- a/app/Bus/Commands/Schedule/CreateScheduleCommand.php
+++ b/app/Bus/Commands/Schedule/CreateScheduleCommand.php
@@ -91,7 +91,7 @@ final class CreateScheduleCommand
      * @param string $scheduled_at
      * @param string $completed_at
      * @param array  $components
-     * @param bool $notify
+     * @param bool   $notify
      *
      * @return void
      */

--- a/app/Bus/Events/Schedule/ScheduleWasCreatedEvent.php
+++ b/app/Bus/Events/Schedule/ScheduleWasCreatedEvent.php
@@ -36,7 +36,7 @@ final class ScheduleWasCreatedEvent implements ActionInterface, ScheduleEventInt
      */
     public $schedule;
 
-     /**
+    /**
      * Whether to notify that the incident was reported.
      *
      * @var bool
@@ -52,7 +52,7 @@ final class ScheduleWasCreatedEvent implements ActionInterface, ScheduleEventInt
      *
      * @return void
      */
-    public function __construct(User $user, Schedule $schedule,  $notify = false)
+    public function __construct(User $user, Schedule $schedule, $notify = false)
     {
         $this->user = $user;
         $this->schedule = $schedule;

--- a/app/Bus/Events/Schedule/ScheduleWasCreatedEvent.php
+++ b/app/Bus/Events/Schedule/ScheduleWasCreatedEvent.php
@@ -36,18 +36,27 @@ final class ScheduleWasCreatedEvent implements ActionInterface, ScheduleEventInt
      */
     public $schedule;
 
+     /**
+     * Whether to notify that the incident was reported.
+     *
+     * @var bool
+     */
+    public $notify;
+
     /**
      * Create a new schedule was created event instance.
      *
      * @param \CachetHQ\Cachet\Models\User     $user
      * @param \CachetHQ\Cachet\Models\Schedule $schedule
+     * @param bool notify
      *
      * @return void
      */
-    public function __construct(User $user, Schedule $schedule)
+    public function __construct(User $user, Schedule $schedule,  $notify = false)
     {
         $this->user = $user;
         $this->schedule = $schedule;
+        $this->notify = $notify;
     }
 
     /**

--- a/app/Bus/Handlers/Commands/Schedule/CreateScheduleCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Schedule/CreateScheduleCommandHandler.php
@@ -66,8 +66,7 @@ class CreateScheduleCommandHandler
     {
         try {
             $schedule = Schedule::create($this->filter($command));
-
-            event(new ScheduleWasCreatedEvent($this->auth->user(), $schedule));
+            event(new ScheduleWasCreatedEvent($this->auth->user(), $schedule, (bool) $command->notify));
         } catch (InvalidArgumentException $e) {
             throw new ValidationException(new MessageBag([$e->getMessage()]));
         }
@@ -96,6 +95,7 @@ class CreateScheduleCommandHandler
             'status'       => $command->status,
             'scheduled_at' => $scheduledAt,
             'completed_at' => $completedAt,
+            'notify'       => $command->notify,
         ];
 
         $availableParams = array_filter($params, function ($val) {

--- a/app/Bus/Handlers/Events/Schedule/SendScheduleEmailNotificationHandler.php
+++ b/app/Bus/Handlers/Events/Schedule/SendScheduleEmailNotificationHandler.php
@@ -51,6 +51,9 @@ class SendScheduleEmailNotificationHandler
     public function handle(ScheduleEventInterface $event)
     {
         $schedule = $event->schedule;
+        if (!$event->notify) {
+            return false;
+        }
 
         // First notify all global subscribers.
         $globalSubscribers = $this->subscriber->isVerified()->isGlobal()->get()->each(function ($subscriber) use ($schedule) {

--- a/app/Http/Controllers/Api/ScheduleController.php
+++ b/app/Http/Controllers/Api/ScheduleController.php
@@ -73,7 +73,8 @@ class ScheduleController extends AbstractApiController
                 Binput::get('status'),
                 Binput::get('scheduled_at'),
                 Binput::get('completed_at'),
-                Binput::get('components', [])
+                Binput::get('components', []),
+                Binput::get('notify', false)
             ));
         } catch (QueryException $e) {
             throw new BadRequestHttpException();

--- a/app/Http/Controllers/Dashboard/ScheduleController.php
+++ b/app/Http/Controllers/Dashboard/ScheduleController.php
@@ -15,6 +15,7 @@ use AltThree\Validator\ValidationException;
 use CachetHQ\Cachet\Bus\Commands\Schedule\CreateScheduleCommand;
 use CachetHQ\Cachet\Bus\Commands\Schedule\DeleteScheduleCommand;
 use CachetHQ\Cachet\Bus\Commands\Schedule\UpdateScheduleCommand;
+use CachetHQ\Cachet\Integrations\Contracts\System;
 use CachetHQ\Cachet\Models\IncidentTemplate;
 use CachetHQ\Cachet\Models\Schedule;
 use GrahamCampbell\Binput\Facades\Binput;
@@ -36,12 +37,21 @@ class ScheduleController extends Controller
     protected $subMenu = [];
 
     /**
+     * The system instance.
+     *
+     * @var \CachetHQ\Cachet\Integrations\Contracts\System
+     */
+    protected $system;
+
+
+    /**
      * Creates a new schedule controller instance.
      *
      * @return void
      */
-    public function __construct()
+    public function __construct(System $system)
     {
+        $this->system = $system;
         View::share('subTitle', trans('dashboard.schedule.title'));
     }
 
@@ -70,7 +80,8 @@ class ScheduleController extends Controller
 
         return View::make('dashboard.maintenance.add')
             ->withPageTitle(trans('dashboard.schedule.add.title').' - '.trans('dashboard.dashboard'))
-            ->withIncidentTemplates($incidentTemplates);
+            ->withIncidentTemplates($incidentTemplates)
+            ->withNotificationsEnabled($this->system->canNotifySubscribers());
     }
 
     /**
@@ -87,7 +98,8 @@ class ScheduleController extends Controller
                 Binput::get('status', Schedule::UPCOMING),
                 Binput::get('scheduled_at'),
                 Binput::get('completed_at'),
-                Binput::get('components', [])
+                Binput::get('components', []),
+                Binput::get('notify', false)
             ));
         } catch (ValidationException $e) {
             return cachet_redirect('dashboard.schedule.create')

--- a/app/Http/Controllers/Dashboard/ScheduleController.php
+++ b/app/Http/Controllers/Dashboard/ScheduleController.php
@@ -43,7 +43,6 @@ class ScheduleController extends Controller
      */
     protected $system;
 
-
     /**
      * Creates a new schedule controller instance.
      *

--- a/resources/views/dashboard/maintenance/add.blade.php
+++ b/resources/views/dashboard/maintenance/add.blade.php
@@ -57,7 +57,15 @@
                             <input type="text" name="completed_at" class="form-control flatpickr-time" data-date-format="Y-m-d H:i" placeholder="{{ trans('forms.schedules.completed_at') }}">
                         </div>
                     </fieldset>
-
+                    @if($notificationsEnabled)
+                    <input type="hidden" name="notify" value="0">
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" name="notify" value="1" checked="{{ Binput::old('notify', 'checked') }}">
+                            {{ trans('forms.incidents.notify_subscribers') }}
+                        </label>
+                    </div>
+                    @endif
                     <div class="form-group">
                         <div class="btn-group">
                             <button type="submit" class="btn btn-success">{{ trans('forms.add') }}</button>

--- a/tests/Api/ScheduleTest.php
+++ b/tests/Api/ScheduleTest.php
@@ -52,6 +52,7 @@ class ScheduleTest extends AbstractApiTestCase
             'message'      => 'Foo bar, baz.',
             'status'       => 1,
             'scheduled_at' => date('Y-m-d H:i'),
+            'notify'       => 1,
         ];
 
         $response = $this->json('POST', '/api/v1/schedules/', $schedule);

--- a/tests/Api/ScheduleTest.php
+++ b/tests/Api/ScheduleTest.php
@@ -52,7 +52,6 @@ class ScheduleTest extends AbstractApiTestCase
             'message'      => 'Foo bar, baz.',
             'status'       => 1,
             'scheduled_at' => date('Y-m-d H:i'),
-            'notify'       => 1,
         ];
 
         $response = $this->json('POST', '/api/v1/schedules/', $schedule);

--- a/tests/Bus/Commands/Schedule/CreateScheduleCommandTest.php
+++ b/tests/Bus/Commands/Schedule/CreateScheduleCommandTest.php
@@ -34,6 +34,7 @@ class CreateScheduleCommandTest extends AbstractTestCase
             'scheduled_at' => date('Y-m-d H:i'),
             'completed_at' => date('Y-m-d H:i'),
             'components'   => [],
+            'notify'       => 1,
         ];
         $object = new CreateScheduleCommand(
             $params['name'],
@@ -41,7 +42,8 @@ class CreateScheduleCommandTest extends AbstractTestCase
             $params['status'],
             $params['scheduled_at'],
             $params['completed_at'],
-            $params['components']
+            $params['components'],
+            $params['notify']
         );
 
         return compact('params', 'object');


### PR DESCRIPTION
Fixes #3562 

Adds a checkbox to maintenance to make it optional to notify subscribers of this. Default is checked just like with normal incidents.

<img width="1226" alt="Screenshot 2019-04-26 at 11 51 33" src="https://user-images.githubusercontent.com/5811560/56799676-b57f4a00-6819-11e9-8654-cdd95af168d4.png">