### PR TITLE
Ignore `completed_at` time for schedules

### DIFF
--- a/app/Models/Schedule.php
+++ b/app/Models/Schedule.php
@@ -152,9 +152,7 @@ class Schedule extends Model implements HasPresenter
      */
     public function scopeUncompleted(Builder $query)
     {
-        return $query->whereIn('status', [self::UPCOMING, self::IN_PROGRESS])->where(function (Builder $query) {
-            return $query->whereNull('completed_at');
-        });
+        return $query->whereIn('status', [self::UPCOMING, self::IN_PROGRESS]);
     }
 
     /**
@@ -166,9 +164,7 @@ class Schedule extends Model implements HasPresenter
      */
     public function scopeInProgress(Builder $query)
     {
-        return $query->where('scheduled_at', '<=', Carbon::now())->where('status', '<>', self::COMPLETE)->where(function ($query) {
-            $query->whereNull('completed_at');
-        });
+        return $query->where('scheduled_at', '<=', Carbon::now())->where('status', '<>', self::COMPLETE);
     }
 
     /**


### PR DESCRIPTION
We always set a `completed_at` time for schedules, as a maximum time when the schedule should be finished. With these where-statements, schedules with `completed_at` time aren't displayed.