### PR TITLE
Change app:install reference to cachet:install

### DIFF
--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -71,7 +71,7 @@ Cachet comes with an installation command that will:
 - Run seeders (of which there are none)
 
 ```bash
-php artisan app:install
+php artisan cachet:install
 ```
 
 > Never change the `APP_KEY` after installation on production environment.


### PR DESCRIPTION
It looked like there were a few issues about app:install not working; this MR updates the documentation to refer to the correct command.