### PR TITLE
Refactoring notifications

### DIFF
--- a/app/Notifications/AbstractSubscriberNotification.php
+++ b/app/Notifications/AbstractSubscriberNotification.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CachetHQ\Cachet\Notifications;
+
+use Illuminate\Notifications\Notification;
+
+abstract class AbstractSubscriberNotification extends Notification
+{
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param mixed $notifiable
+     *
+     * @return string[]
+     */
+    public function via($notifiable)
+    {
+        return array_filter([
+            $notifiable->email ? 'mail' : null,
+            $notifiable->phone_number ? 'nexmo' : null,
+            $notifiable->slack_webhook_url ? 'slack' : null,
+        ]);
+    }
+}

--- a/app/Notifications/Component/ComponentStatusChangedNotification.php
+++ b/app/Notifications/Component/ComponentStatusChangedNotification.php
@@ -12,19 +12,14 @@
 namespace CachetHQ\Cachet\Notifications\Component;
 
 use CachetHQ\Cachet\Models\Component;
+use CachetHQ\Cachet\Notifications\AbstractSubscriberNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
-use Illuminate\Notifications\Notification;
 use McCool\LaravelAutoPresenter\Facades\AutoPresenter;
 
-/**
- * This is the component status changed notification class.
- *
- * @author James Brooks <james@alt-three.com>
- */
-class ComponentStatusChangedNotification extends Notification
+class ComponentStatusChangedNotification extends AbstractSubscriberNotification
 {
     use Queueable;
 
@@ -54,18 +49,6 @@ class ComponentStatusChangedNotification extends Notification
     {
         $this->component = AutoPresenter::decorate($component);
         $this->status = $status;
-    }
-
-    /**
-     * Get the notification's delivery channels.
-     *
-     * @param mixed $notifiable
-     *
-     * @return string[]
-     */
-    public function via($notifiable)
-    {
-        return ['mail', 'nexmo', 'slack'];
     }
 
     /**

--- a/app/Notifications/Incident/NewIncidentNotification.php
+++ b/app/Notifications/Incident/NewIncidentNotification.php
@@ -16,16 +16,9 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
-use Illuminate\Notifications\Notification;
-use Illuminate\Support\Facades\Config;
 use McCool\LaravelAutoPresenter\Facades\AutoPresenter;
 
-/**
- * This is the new incident notification class.
- *
- * @author James Brooks <james@alt-three.com>
- */
-class NewIncidentNotification extends Notification
+class NewIncidentNotification extends AbstractSubscriberNotification
 {
     use Queueable;
 
@@ -46,18 +39,6 @@ class NewIncidentNotification extends Notification
     public function __construct(Incident $incident)
     {
         $this->incident = AutoPresenter::decorate($incident);
-    }
-
-    /**
-     * Get the notification's delivery channels.
-     *
-     * @param mixed $notifiable
-     *
-     * @return string[]
-     */
-    public function via($notifiable)
-    {
-        return ['mail', 'nexmo', 'slack'];
     }
 
     /**
@@ -111,7 +92,7 @@ class NewIncidentNotification extends Notification
     public function toSlack($notifiable)
     {
         $content = trans('notifications.incident.new.slack.content', [
-            'app_name' => Config::get('setting.app_name'),
+            'app_name' => setting('app_name'),
         ]);
 
         $status = 'info';

--- a/app/Notifications/IncidentUpdate/IncidentUpdatedNotification.php
+++ b/app/Notifications/IncidentUpdate/IncidentUpdatedNotification.php
@@ -13,19 +13,14 @@ namespace CachetHQ\Cachet\Notifications\IncidentUpdate;
 
 use CachetHQ\Cachet\Models\Incident;
 use CachetHQ\Cachet\Models\IncidentUpdate;
+use CachetHQ\Cachet\Notifications\AbstractSubscriberNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
-use Illuminate\Notifications\Notification;
 use McCool\LaravelAutoPresenter\Facades\AutoPresenter;
 
-/**
- * This is the incident updated notification class.
- *
- * @author James Brooks <james@alt-three.com>
- */
-class IncidentUpdatedNotification extends Notification
+class IncidentUpdatedNotification extends AbstractSubscriberNotification
 {
     use Queueable;
 

--- a/app/Notifications/Schedule/NewScheduleNotification.php
+++ b/app/Notifications/Schedule/NewScheduleNotification.php
@@ -12,20 +12,14 @@
 namespace CachetHQ\Cachet\Notifications\Schedule;
 
 use CachetHQ\Cachet\Models\Schedule;
+use CachetHQ\Cachet\Notifications\AbstractSubscriberNotification;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
-use Illuminate\Notifications\Notification;
 use McCool\LaravelAutoPresenter\Facades\AutoPresenter;
 
-/**
- * This is the new schedule notification class.
- *
- * @author James Brooks <james@alt-three.com>
- */
-class NewScheduleNotification extends Notification implements ShouldQueue
+class NewScheduleNotification extends AbstractSubscriberNotification
 {
     use Queueable;
 

--- a/app/Notifications/Subscriber/VerifySubscriptionNotification.php
+++ b/app/Notifications/Subscriber/VerifySubscriptionNotification.php
@@ -11,17 +11,11 @@
 
 namespace CachetHQ\Cachet\Notifications\Subscriber;
 
+use CachetHQ\Cachet\Notifications\AbstractSubscriberNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Notification;
-use Illuminate\Support\Facades\Config;
 
-/**
- * This is the verify subscription notification class.
- *
- * @author James Brooks <james@alt-three.com>
- */
-class VerifySubscriptionNotification extends Notification
+class VerifySubscriptionNotification extends AbstractSubscriberNotification
 {
     use Queueable;
 
@@ -48,8 +42,8 @@ class VerifySubscriptionNotification extends Notification
     {
         return (new MailMessage())
                     ->subject(trans('notifications.subscriber.verify.mail.subject'))
-                    ->greeting(trans('notifications.subscriber.verify.mail.title', ['app_name' => Config::get('setting.app_name')]))
+                    ->greeting(trans('notifications.subscriber.verify.mail.title', ['app_name' => setting('app_name')]))
                     ->action(trans('notifications.subscriber.verify.mail.action'), cachet_route('subscribe.verify', ['code' => $notifiable->verify_code]))
-                    ->line(trans('notifications.subscriber.verify.mail.content', ['app_name' => Config::get('setting.app_name')]));
+                    ->line(trans('notifications.subscriber.verify.mail.content', ['app_name' => setting('app_name')]));
     }
 }

--- a/app/Notifications/User/InviteUserNotification.php
+++ b/app/Notifications/User/InviteUserNotification.php
@@ -14,13 +14,7 @@ namespace CachetHQ\Cachet\Notifications\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
-use Illuminate\Support\Facades\Config;
 
-/**
- * This is the invite user notification class.
- *
- * @author James Brooks <james@alt-three.com>
- */
 class InviteUserNotification extends Notification
 {
     use Queueable;
@@ -48,8 +42,8 @@ class InviteUserNotification extends Notification
     {
         return (new MailMessage())
                     ->subject(trans('notifications.user.invite.mail.subject'))
-                    ->greeting(trans('notifications.user.invite.mail.title', ['app_name' => Config::get('setting.app_name')]))
+                    ->greeting(trans('notifications.user.invite.mail.title', ['app_name' => setting('app_name')]))
                     ->action(trans('notifications.user.invite.mail.action'), cachet_route('signup.invite', [$notifiable->code]))
-                    ->line(trans('notifications.user.invite.mail.content', ['app_name' => Config::get('setting.app_name')]));
+                    ->line(trans('notifications.user.invite.mail.content', ['app_name' => setting('app_name')]));
     }
 }


### PR DESCRIPTION
- [x] Subscriber notifications shouldn't attempt to send notifications to channels which aren't configured.
- [x] Don't use the `Config` facade for Cachet settings.
- [ ] Check over notification queuing configuration.
- [ ] Check all content of notifications.
- [ ] Tests!