### PR TITLE
Bump sweetalert2 to ^8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "moment": "^2.24.0",
     "promise": "^7.3.1",
     "sortablejs": "^1.8.4",
-    "sweetalert2": "^6.8.0",
+    "sweetalert2": "^8.0.0",
     "vue": "^2.6.10",
     "vue-template-compiler": "^2.6.10"
   },

--- a/resources/assets/js/cachet.js
+++ b/resources/assets/js/cachet.js
@@ -340,21 +340,25 @@ $(function () {
     }
 
     function askConfirmation(callback, cancelCallback) {
-        swal({
+        Swal.fire({
             type: "warning",
             title: "Confirm your action",
             text: "Are you sure you want to do this?",
             buttonsStyling: false,
             reverseButtons: true,
             confirmButtonText: "Yes",
-            confirmButtonClass: "btn btn-lg btn-danger",
-            cancelButtonClass: "btn btn-lg btn-default",
+            customClass: {
+                confirmButton: "btn btn-lg btn-danger",
+                cancelButton: "btn btn-lg btn-default"
+            },
             showCancelButton: true,
             focusCancel: true
-        }).then(function () {
-            if (_.isFunction(callback)) callback();
-        }, function () {
-            if (_.isFunction(cancelCallback)) cancelCallback();
+        }).then(function (result) {
+            if (result.value) {
+                if (_.isFunction(callback)) callback();
+            } else {
+                if (_.isFunction(cancelCallback)) cancelCallback();
+            }
         });
     }
 });

--- a/resources/assets/sass/plugins/_sweetalert.scss
+++ b/resources/assets/sass/plugins/_sweetalert.scss
@@ -1,5 +1,9 @@
 @import "./node_modules/sweetalert2/src/sweetalert2";
 
-.swal2-modal button {
-    margin-right: 8px;
+.swal2-modal {
+    font-size: 1.1rem;
+
+    button {
+        margin-right: 8px;
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6314,10 +6314,10 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-sweetalert2@^6.8.0:
-  version "6.11.5"
-  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-6.11.5.tgz#a1ede34089225eb864898f4b613db4fec5dbe334"
-  integrity sha512-8Otu1SlWGS/u3e31cOg+uqrwyoQbByEScKp7UupmCfwEZE9St3coO1e6CXv83YzZtzdDgowdK1hBPKPW7SRp4Q==
+sweetalert2@^8.0.0:
+  version "8.13.4"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-8.13.4.tgz#66a07848b9ddc344cce3a078bf950b0d1bc8d0b4"
+  integrity sha512-9hW4GGj08D60bqDPF0paN/NJvsPIDrWSY2fPVmqS4M/XaEsZiNF7HNaObdnQJ0FeD8Q9gJgkkFgvyDdXednT3Q==
 
 tapable@^0.2.7:
   version "0.2.9"


### PR DESCRIPTION
`sweetalert2` has advanced a lot since v6, there are a couple of breaking changes which I took into account in `js/cachet.js`.