### PR TITLE
Fix timeout with large number of subscribers

### DIFF
--- a/app/Http/Controllers/Dashboard/SubscriberController.php
+++ b/app/Http/Controllers/Dashboard/SubscriberController.php
@@ -31,7 +31,7 @@ class SubscriberController extends Controller
     {
         return View::make('dashboard.subscribers.index')
             ->withPageTitle(trans('dashboard.subscribers.subscribers').' - '.trans('dashboard.dashboard'))
-            ->withSubscribers(Subscriber::all());
+            ->withSubscribers(Subscriber::with('subscriptions.component')->get());
     }
 
     /**


### PR DESCRIPTION
We have Cachet with 1499 subscribers, and this page was timing out.  We troubleshot the issue and found this code running thousands of mysql queries and hitting the 60 second nginx timeout.

Where the template hits this inside a loop, triggering many queries:
https://github.com/CachetHQ/Cachet/blob/2.4/resources/views/dashboard/subscribers/index.blade.php#L43

Helpful page on optimizing code for ORM utilization:
https://laravel-news.com/eloquent-eager-loading

