### PR TITLE
App banner is now an uploaded file

### DIFF
--- a/app/Composers/AppComposer.php
+++ b/app/Composers/AppComposer.php
@@ -66,6 +66,7 @@ class AppComposer
         $view->withAppAnalyticsGoSquared($this->config->get('setting.app_analytics_gs'));
         $view->withAppAnalyticsPiwikUrl($this->config->get('setting.app_analytics_piwik_url'));
         $view->withAppAnalyticsPiwikSiteId($this->config->get('setting.app_analytics_piwik_site_id'));
+        $view->withAppBannerUrl($this->config->get('setting.app_banner_url'));
         $view->withAppBanner($this->config->get('setting.app_banner'));
         $view->withAppBannerStyleFullWidth($this->config->get('setting.style_fullwidth_header'));
         $view->withAppBannerType($this->config->get('setting.app_banner_type'));

--- a/app/Http/Controllers/Dashboard/SettingsController.php
+++ b/app/Http/Controllers/Dashboard/SettingsController.php
@@ -18,6 +18,7 @@ use CachetHQ\Cachet\Notifications\System\SystemTestNotification;
 use CachetHQ\Cachet\Settings\Repository;
 use Exception;
 use GrahamCampbell\Binput\Facades\Binput;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Auth;
@@ -329,9 +330,11 @@ class SettingsController extends Controller
     /**
      * Updates the status page settings.
      *
+     * @param \Illuminate\Http\Request $request
+     *
      * @return \Illuminate\View\View
      */
-    public function postSettings()
+    public function postSettings(Request $request)
     {
         $setting = app(Repository::class);
 
@@ -366,7 +369,7 @@ class SettingsController extends Controller
         }
 
         if (Binput::hasFile('app_banner')) {
-            $this->handleUpdateBanner($setting);
+            $this->handleUpdateBanner($request, $setting);
         }
 
         $excludedParams = [
@@ -406,9 +409,9 @@ class SettingsController extends Controller
      *
      * @param \CachetHQ\Cachet\Settings\Repository $setting
      *
-     * @return void
+     * @return \Illuminate\Http\RedirectResponse|void
      */
-    protected function handleUpdateBanner(Repository $setting)
+    protected function handleUpdateBanner(Request $request, Repository $setting)
     {
         $file = Binput::file('app_banner');
         $redirectUrl = $this->subMenu['theme']['url'];
@@ -430,9 +433,8 @@ class SettingsController extends Controller
         }
 
         // Store the banner.
-        $setting->set('app_banner', base64_encode(file_get_contents($file->getRealPath())));
-
-        // Store the banner type.
-        $setting->set('app_banner_type', $file->getMimeType());
+        $logoFilename = $request->app_banner->getClientOriginalName();
+        $path = $request->app_banner->storeAs('uploads', $logoFilename, 'public');
+        $setting->set('app_banner_url', "uploads/{$logoFilename}");
     }
 }

--- a/resources/views/partials/banner.blade.php
+++ b/resources/views/partials/banner.blade.php
@@ -1,19 +1,17 @@
 @if($appHeader)
 {!! $appHeader !!}
-@else
-@if($appBanner)
+@elseif($appBannerUrl || $appBanner)
 <div @if($appBannerStyleFullWidth)class="app-banner"@endif>
     <div class="container">
         <div class="row app-banner-padding  @if(!$appBannerStyleFullWidth) app-banner @endif">
             <div class="col-md-12 text-center">
                 @if($appDomain)
-                <a href="{{ $appDomain }}" class="links"><img src="data:{{ $appBannerType }};base64, {{ $appBanner }}" class="banner-image img-responsive"></a>
+                <a href="{{ $appDomain }}" class="links"><img src="{{ asset($appBannerUrl) ?? "data:{$appBannerType};base64, {$appBanner}" }}" class="banner-image img-responsive"></a>
                 @else
-                <img src="data:{{ $appBannerType }};base64, {{ $appBanner }}" class="banner-image img-responsive">
+                <img src="{{ asset($appBannerUrl) ?? "data:{$appBannerType};base64, {$appBanner}" }}" class="banner-image img-responsive">
                 @endif
             </div>
         </div>
     </div>
 </div>
-@endif
 @endif

--- a/resources/views/partials/banner.blade.php
+++ b/resources/views/partials/banner.blade.php
@@ -6,9 +6,9 @@
         <div class="row app-banner-padding  @if(!$appBannerStyleFullWidth) app-banner @endif">
             <div class="col-md-12 text-center">
                 @if($appDomain)
-                <a href="{{ $appDomain }}" class="links"><img src="{{ asset($appBannerUrl) ?? "data:{$appBannerType};base64, {$appBanner}" }}" class="banner-image img-responsive"></a>
+                <a href="{{ $appDomain }}" class="links"><img src="{{ asset($appBannerUrl) ?? "data:{$appBannerType};base64, {$appBanner}" }}" class="banner-image img-responsive" alt="{{ $siteTitle }}"></a>
                 @else
-                <img src="{{ asset($appBannerUrl) ?? "data:{$appBannerType};base64, {$appBanner}" }}" class="banner-image img-responsive">
+                <img src="{{ asset($appBannerUrl) ?? "data:{$appBannerType};base64, {$appBanner}" }}" class="banner-image img-responsive" alt="{{ $siteTitle }}">
                 @endif
             </div>
         </div>

--- a/storage/app/public/.gitignore
+++ b/storage/app/public/.gitignore
@@ -1,3 +1,2 @@
 *
-!public/
 !.gitignore


### PR DESCRIPTION
Fixes #3709

---

This requires the `php artisan storage:link` command to be ran so that a banner image can be uploaded instead of stored in the DB. It also allows us to upload vector images.

Ping @Pimorez.