### PR TITLE
Lowercase email for Gravatar avatars

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -116,7 +116,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
      */
     public function getGravatarAttribute($size = 200)
     {
-        return sprintf('https://www.gravatar.com/avatar/%s?size=%d', md5($this->email), $size);
+        return sprintf('https://www.gravatar.com/avatar/%s?size=%d', md5(strtolower($this->email)), $size);
     }
 
     /**


### PR DESCRIPTION
The Gravatar docs [explicitly say that e-mail addresses have to be lowercased](https://en.gravatar.com/site/implement/hash/) before hashing. In the `2.4` branch this was already resolved in 0f4c14ac0820562a3155d6f60ea4a7770d19084b back in 2016 so it is safe to backport that change to the latest stable branch for a maintenance patch release.