### PR TITLE
fix for undefined property in SetupController [fixes #3774]

### DIFF
--- a/app/Http/Controllers/SetupController.php
+++ b/app/Http/Controllers/SetupController.php
@@ -134,17 +134,20 @@ class SetupController extends Controller
      */
     public function getIndex()
     {
-        $supportedLanguages = Request::getLanguages();
+        $requestedLanguages = Request::getLanguages();
         $userLanguage = Config::get('app.locale');
+        $langs = Config::get('langs');
 
-        foreach ($supportedLanguages as $language) {
+        foreach ($requestedLanguages as $language) {
             $language = str_replace('_', '-', $language);
 
-            if (isset($this->langs[$language])) {
+            if (isset($langs[$language])) {
                 $userLanguage = $language;
                 break;
             }
         }
+
+        app('translator')->setLocale($userLanguage);
 
         // Since .env may already be configured, we should show that data!
         $cacheConfig = [


### PR DESCRIPTION
There is no array property named `langs` in `SetupController`. It has been broken for some time.

I've provided a fix, considering the `Accept-Language` request header. If it matches a locale with translations, the setup happens using them.
