### PR TITLE
Fixed: when use proxy server use https, the cachat still use http

### DIFF
--- a/resources/views/layout/clean.blade.php
+++ b/resources/views/layout/clean.blade.php
@@ -5,6 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
 
     <meta name="env" content="{{ app('env') }}">
     <meta name="token" content="{{ csrf_token() }}">

--- a/resources/views/layout/dashboard.blade.php
+++ b/resources/views/layout/dashboard.blade.php
@@ -5,6 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
 
     <meta name="env" content="{{ app('env') }}">
     <meta name="token" content="{{ csrf_token() }}">

--- a/resources/views/layout/master.blade.php
+++ b/resources/views/layout/master.blade.php
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
 
     <meta name="env" content="{{ app('env') }}">
     <meta name="token" content="{{ csrf_token() }}">


### PR DESCRIPTION
When I use Nginx to proxy the cachet in Docker, it display like this 
![image](https://user-images.githubusercontent.com/39913604/64852930-efc47900-d64c-11e9-8b3b-8f03572fc4ce.png)

Then I try to add `<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">` to let it use HTTPS if HTTPS is Available. Finally, it works!
