### PR TITLE
Add username to the dashboard of who logged an incident or any incident updates.

### DIFF
--- a/resources/lang/en/cachet.php
+++ b/resources/lang/en/cachet.php
@@ -34,7 +34,7 @@ return [
         'stickied'     => 'Stickied Incidents',
         'scheduled'    => 'Maintenance',
         'scheduled_at' => ', scheduled :timestamp',
-        'posted'       => 'Posted :timestamp',
+        'posted'       => 'Posted :timestamp by :username',
         'posted_at'    => 'Posted at :timestamp',
         'status'       => [
             1 => 'Investigating',

--- a/resources/lang/en/dashboard.php
+++ b/resources/lang/en/dashboard.php
@@ -35,7 +35,7 @@ return [
                 'failure' => 'Something went wrong updating the incident update',
             ],
         ],
-        'reported_by'              => 'Reported by :user',
+        'reported_by'              => 'Reported :timestamp by :user',
         'add'                      => [
             'title'   => 'Report an incident',
             'success' => 'Incident added.',

--- a/resources/views/dashboard/incidents/index.blade.php
+++ b/resources/views/dashboard/incidents/index.blade.php
@@ -27,7 +27,7 @@
                             <p>{{ Str::words($incident->message, 5) }}</p>
                             @endif
                             @if ($incident->user)
-                            <p><small>&mdash; {{ trans('dashboard.incidents.reported_by', ['user' => $incident->user->username]) }}</small></p>
+                            <p><small>&mdash; {{ trans('dashboard.incidents.reported_by', ['timestamp' => $incident->created_at_diff, 'user' => $incident->user->username]) }}</small></p>
                             @endif
                         </div>
                         <div class="col-xs-6 text-right">

--- a/resources/views/dashboard/incidents/updates/index.blade.php
+++ b/resources/views/dashboard/incidents/updates/index.blade.php
@@ -26,7 +26,7 @@
                 <div class="row striped-list-item">
                     <div class="col-xs-6">
                         <strong>{{ Str::words($update->message, 8) }}</strong>
-                        <p><small>{{ trans('cachet.incidents.posted', ['timestamp' => $update->created_at_diff]) }}</small></p>
+                        <p><small>{{ trans('cachet.incidents.posted', ['timestamp' => $update->created_at_diff, 'username' => $update->user->username]) }}</small></p>
                     </div>
                     <div class="col-xs-6 text-right">
                         <a href="{{ cachet_route('dashboard.incidents.updates.edit', ['incident' => $incident->id, 'incident_update' => $update]) }}" class="btn btn-default">


### PR DESCRIPTION
In relation to #3046 I've added the username of the person who logged an incident or an incident update on the dashboard.

I've only made the change in the English translation. I've noticed that viewing in other languages it still says "**by** {username}" - hopefully this is okay as I see some other languages aren't fully translated anyway.

I haven't added the name of the person to the notifications that go out as originally specified. I was wondering if that needed more thought? My only thinking is you may not want end users to know who posted it so they don't badger individuals in a company about an outage. I think it's good internally (on the dashboard) for accountability, but think end users perhaps may not need to know who. It may be better to make an option somewhere "Include username in notification emails" so the owner can decide.

Let me know if anything I've said doesn't make sense, or requires amending.