### PR TITLE
Update manageSubscriptionUrl to a signed route

### DIFF
--- a/app/Notifications/Component/ComponentStatusChangedNotification.php
+++ b/app/Notifications/Component/ComponentStatusChangedNotification.php
@@ -17,6 +17,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\URL;
 use McCool\LaravelAutoPresenter\Facades\AutoPresenter;
 
 /**
@@ -83,6 +84,8 @@ class ComponentStatusChangedNotification extends Notification
             'new_status' => trans("cachet.components.status.{$this->status}"),
         ]);
 
+        $manage_route = URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $notifiable->verify_code]);
+
         return (new MailMessage())
             ->subject(trans('notifications.component.status_update.mail.subject'))
             ->markdown('notifications.component.update', [
@@ -91,7 +94,7 @@ class ComponentStatusChangedNotification extends Notification
                 'unsubscribeText'        => trans('cachet.subscriber.unsubscribe'),
                 'unsubscribeUrl'         => cachet_route('subscribe.unsubscribe', $notifiable->verify_code),
                 'manageSubscriptionText' => trans('cachet.subscriber.manage_subscription'),
-                'manageSubscriptionUrl'  => cachet_route('subscribe.manage', $notifiable->verify_code),
+                'manageSubscriptionUrl'  => $manage_route,
         ]);
     }
 

--- a/app/Notifications/Incident/NewIncidentNotification.php
+++ b/app/Notifications/Incident/NewIncidentNotification.php
@@ -18,6 +18,7 @@ use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\URL;
 use McCool\LaravelAutoPresenter\Facades\AutoPresenter;
 
 /**
@@ -73,6 +74,8 @@ class NewIncidentNotification extends Notification
             'name' => $this->incident->name,
         ]);
 
+        $manage_route = URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $notifiable->verify_code]);
+
         return (new MailMessage())
                     ->subject(trans('notifications.incident.new.mail.subject'))
                     ->markdown('notifications.incident.new', [
@@ -83,7 +86,7 @@ class NewIncidentNotification extends Notification
                         'unsubscribeText'        => trans('cachet.subscriber.unsubscribe'),
                         'unsubscribeUrl'         => cachet_route('subscribe.unsubscribe', $notifiable->verify_code),
                         'manageSubscriptionText' => trans('cachet.subscriber.manage_subscription'),
-                        'manageSubscriptionUrl'  => cachet_route('subscribe.manage', $notifiable->verify_code),
+                        'manageSubscriptionUrl'  => $manage_route,
                     ]);
     }
 

--- a/app/Notifications/IncidentUpdate/IncidentUpdatedNotification.php
+++ b/app/Notifications/IncidentUpdate/IncidentUpdatedNotification.php
@@ -18,6 +18,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\URL;
 use McCool\LaravelAutoPresenter\Facades\AutoPresenter;
 
 /**
@@ -74,6 +75,8 @@ class IncidentUpdatedNotification extends Notification
             'time'    => $this->update->created_at_diff,
         ]);
 
+        $manage_route = URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $notifiable->verify_code]);
+
         return (new MailMessage())
             ->subject(trans('notifications.incident.update.mail.subject'))
             ->markdown('notifications.incident.update', [
@@ -87,7 +90,7 @@ class IncidentUpdatedNotification extends Notification
                 'unsubscribeText'        => trans('cachet.subscriber.unsubscribe'),
                 'unsubscribeUrl'         => cachet_route('subscribe.unsubscribe', $notifiable->verify_code),
                 'manageSubscriptionText' => trans('cachet.subscriber.manage_subscription'),
-                'manageSubscriptionUrl'  => cachet_route('subscribe.manage', $notifiable->verify_code),
+                'manageSubscriptionUrl'  => $manage_route,
         ]);
     }
 

--- a/app/Notifications/Schedule/NewScheduleNotification.php
+++ b/app/Notifications/Schedule/NewScheduleNotification.php
@@ -18,6 +18,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\URL;
 use McCool\LaravelAutoPresenter\Facades\AutoPresenter;
 
 /**
@@ -74,6 +75,8 @@ class NewScheduleNotification extends Notification implements ShouldQueue
             'date' => $this->schedule->scheduled_at_formatted,
         ]);
 
+        $manage_route = URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $notifiable->verify_code]);
+
         return (new MailMessage())
             ->subject(trans('notifications.schedule.new.mail.subject'))
             ->markdown('notifications.schedule.new', [
@@ -81,7 +84,7 @@ class NewScheduleNotification extends Notification implements ShouldQueue
                 'unsubscribeText'        => trans('cachet.subscriber.unsubscribe'),
                 'unsubscribeUrl'         => cachet_route('subscribe.unsubscribe', $notifiable->verify_code),
                 'manageSubscriptionText' => trans('cachet.subscriber.manage_subscription'),
-                'manageSubscriptionUrl'  => cachet_route('subscribe.manage', $notifiable->verify_code),
+                'manageSubscriptionUrl'  => $manage_route,
         ]);
     }
 


### PR DESCRIPTION
More manage routes in Notification emails. Would it be preferable to create signed versions of cachet_redirect() and cache_route() in helpers? It would essentially be a copy and paste of those methods to cachet_signed_redirect() and cachet_signed_route(), but it seems like they may be sufficiently required to make that a reasonable path.