### PR TITLE
Remove unused "reserved" column from jobs table

### DIFF
--- a/database/migrations/2019_12_12_131400_AlterJobsDropReserved.php
+++ b/database/migrations/2019_12_12_131400_AlterJobsDropReserved.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Cachet.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterJobsDropReserved extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('jobs', function (Blueprint $table) {
+            $table->dropColumn('reserved');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('jobs', function (Blueprint $table) {
+            $table->tinyInteger('reserved')->unsigned()->after('attempts');
+        });
+    }
+}


### PR DESCRIPTION
Fixes "null value" error as mentioned in #3626:
SQLSTATE[23502]: Not null violation: 7 ERROR:  null value in column "reserved" violates not-null constraint

This mirrors the removal of the column in illuminate/queue:
 illuminate/queue@061851b#diff-fd99f8447bff90123d06344bfe84dd89