### PR TITLE
Fix missing update author username on single incident view

### DIFF
--- a/resources/views/single-incident.blade.php
+++ b/resources/views/single-incident.blade.php
@@ -46,7 +46,7 @@
                             <small>
                                 <span data-toggle="tooltip" title="
                                     {{ trans('cachet.incidents.posted_at', ['timestamp' => $update->created_at_formatted]) }}">
-                                    {{ trans('cachet.incidents.posted', ['timestamp' => $update->created_at_diff]) }}
+                                    {{ trans('cachet.incidents.posted', ['timestamp' => $update->created_at_diff,'username' => $update->user->username]) }}
                                 </span>
                             </small>
                         </div>


### PR DESCRIPTION
On the current 2.4 branch the update author username is missing on single incident view:

![Screenshot 2020-02-05 13 30 21](https://user-images.githubusercontent.com/104225/73881905-70fbf280-481e-11ea-88a6-3ab3c0be2005.png)

This change adds the missing `username` variable to the translation args.
