### PR TITLE
Fix RemoteUserAuthenticate running after Authenticate

### DIFF
--- a/app/Foundation/Providers/RouteServiceProvider.php
+++ b/app/Foundation/Providers/RouteServiceProvider.php
@@ -151,8 +151,8 @@ class RouteServiceProvider extends ServiceProvider
         ];
 
         if ($applyAlwaysAuthenticate && !$this->isWhiteListedAuthRoute($routes)) {
-            $middleware[] = Authenticate::class;
             $middleware[] = RemoteUserAuthenticate::class;
+            $middleware[] = Authenticate::class;
         }
 
         $router->group(['middleware' => $middleware], function (Router $router) use ($routes) {


### PR DESCRIPTION
Having the middleware RemoteUserAuthenticate run after Authenticate does nothing - a request requiring a login was already redirected away before reaching the logic to load the user from the REMOTE_USER server setting.

Moving RemoteUserAuthenticate before Authenticate fixes this.