### PR TITLE
Fix typos across Cachet repo

### DIFF
--- a/docs/metrics/create-metric.md
+++ b/docs/metrics/create-metric.md
@@ -27,7 +27,7 @@ Let's explain the fields:
   What does it measure? Example: "The average response time of our API".
 - `Calculation of metrics`: What computation should be done on your data before
   displaying them in the metric? It may be either _Sum_ or _Average_. Example:
-  _Average_ to compute the average reponse time for a given time.
+  _Average_ to compute the average response time for a given time.
 - `Default view`: The default view of the metric. Viewing the datas of 1 year
   ago is not useful, but it's about your preference to see datas of the last
   hour, 12 hours, week or month. Example: _Last 12 hours_ because you want to

--- a/resources/lang/en/cachet.php
+++ b/resources/lang/en/cachet.php
@@ -93,7 +93,7 @@ return [
             'manage_subscription' => 'We\'ve sent you an email, please click the link to manage your subscription',
             'subscribe'           => 'Subscribe to email updates.',
             'subscribed'          => 'You\'ve been subscribed to email notifications, please check your email to confirm your subscription.',
-            'updated-subscribe'   => 'You\'ve succesfully updated your subscriptions.',
+            'updated-subscribe'   => 'You\'ve successfully updated your subscriptions.',
             'verified'            => 'Your email subscription has been confirmed. Thank you!',
             'manage'              => 'Manage your subscription',
             'unsubscribe'         => 'Unsubscribe from email updates.',


### PR DESCRIPTION
:writing_hand: **Fix typos across Cachet repo**

**Files that have typos**

```
Cachet/docs/metrics/create-metric.md:30:35: "reponse" is a misspelling of "response"
Cachet/resources/lang/en/cachet.php:96:46: "succesfully" is a misspelling of "successfully"
```

**PS:** I use [**client9/misspell**](https://github.com/client9/misspell) to scan typos :heart: