### PR TITLE
add a CSS class for status to each component element

### DIFF
--- a/resources/views/partials/component.blade.php
+++ b/resources/views/partials/component.blade.php
@@ -1,4 +1,4 @@
-<li class="list-group-item {{ $component->group_id ? "sub-component" : "component" }}">
+<li class="list-group-item {{ $component->group_id ? "sub-component" : "component" }} status-{{ $component->status }}">
     @if($component->link)
     <a href="{{ $component->link }}" target="_blank" class="links">{!! $component->name !!}</a>
     @else


### PR DESCRIPTION
Cachet offers a feature to add additional CSS. This PR builds upon that functionality by enabling users to style components on the main page based on their status. Each component's `<li>` now gets a `status-0` (... `status-4`) class based on their status.

This can be matched against in CSS using `.component.status-1` to target all operational components or `.component.status-4` to match ones that are experiencing a major outage.