### PR TITLE
Fix "failed: ERR invalid DB index"

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -80,6 +80,9 @@ return [
         'redis' => [
             'driver'     => 'redis',
             'connection' => 'default',
+            'password' => env('REDIS_PASSWORD', null),
+            'port' => env('REDIS_PORT', 6379),
+            'database' => env('REDIS_DB', 0),
         ],
 
     ],


### PR DESCRIPTION
When I try to use Redis for the cache database, Cachet said: 
![image](https://user-images.githubusercontent.com/39913604/79684512-a5e7e500-8264-11ea-8ab8-864726176964.png)