### PR TITLE
Increase days of incidents limit from 100 to 10000

### DIFF
--- a/resources/views/dashboard/settings/app-setup.blade.php
+++ b/resources/views/dashboard/settings/app-setup.blade.php
@@ -45,7 +45,7 @@
                             <div class="col-xs-12">
                                 <div class="form-group">
                                     <label>{{ trans('forms.settings.app-setup.days-of-incidents') }}</label>
-                                    <input type="number" max="100" name="app_incident_days" class="form-control" value="{{ Config::get('setting.app_incident_days', 7) }}" placeholder="{{ trans('forms.settings.app-setup.days-of-incidents') }}">
+                                    <input type="number" max="10000" name="app_incident_days" class="form-control" value="{{ Config::get('setting.app_incident_days', 7) }}" placeholder="{{ trans('forms.settings.app-setup.days-of-incidents') }}">
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Currently the number of days is limited to 100, but only in the view it seems.

We would like our status page to be an advertisement on how little incidents we have and how transparent we handle incidents. We therefore like to show more than 100 days of incidents.