### PR TITLE
Translate missing words in e-mail notifications

### DIFF
--- a/resources/views/notifications/component/update.blade.php
+++ b/resources/views/notifications/component/update.blade.php
@@ -3,7 +3,7 @@
 
 {{ $content }}
 
-Thanks,<br>
+@lang('Thanks,')<br>
 {{ Config::get('setting.app_name') }}
 
 @include('notifications.partials.subscription')

--- a/resources/views/notifications/incident/new.blade.php
+++ b/resources/views/notifications/incident/new.blade.php
@@ -7,7 +7,7 @@
 {{ $actionText }}
 @endcomponent
 
-Thanks,<br>
+@lang('Thanks,')<br>
 {{ Config::get('setting.app_name') }}
 
 @include('notifications.partials.subscription')

--- a/resources/views/notifications/incident/update.blade.php
+++ b/resources/views/notifications/incident/update.blade.php
@@ -7,7 +7,7 @@
 {{ $actionText }}
 @endcomponent
 
-Thanks,<br>
+@lang('Thanks,')<br>
 {{ Config::get('setting.app_name') }}
 
 @include('notifications.partials.subscription')

--- a/resources/views/notifications/schedule/new.blade.php
+++ b/resources/views/notifications/schedule/new.blade.php
@@ -3,7 +3,7 @@
 
 {{ $content }}
 
-Thanks,<br>
+@lang('Thanks,')<br>
 {{ Config::get('setting.app_name') }}
 
 @include('notifications.partials.subscription')


### PR DESCRIPTION
Some "Thanks" were written in e-mail notifications but was not
translated. The "@lang" directive was added around.

See #3690