### PR TITLE
Ignore disabled components when determining if a subscription is 'global'

### DIFF
--- a/app/Bus/Handlers/Commands/Subscriber/UpdateSubscriberSubscriptionCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Subscriber/UpdateSubscriberSubscriptionCommandHandler.php
@@ -36,7 +36,7 @@ class UpdateSubscriberSubscriptionCommandHandler
         $subscriber = $command->subscriber;
         $subscriptions = $command->subscriptions ?: [];
 
-        $components = Component::all();
+        $components = Component::enabled()->get();
 
         $updateSubscriptions = $components->filter(function ($item) use ($subscriptions) {
             return in_array($item->id, $subscriptions);


### PR DESCRIPTION
When a user updates the components he wishes to get notifications for, the 'Globally subscribed' status is set when all components are checked. When disabled components exist, Globally subscribed' is never set because the checked components are compared to the result of `Component::all()` which includes disabled components.

Instead we need to compare to `Component::enabled()->get()` which will contain only the active components.