### PR TITLE
No components -> no manage subscription

### DIFF
--- a/app/Http/Controllers/SubscribeController.php
+++ b/app/Http/Controllers/SubscribeController.php
@@ -125,7 +125,13 @@ class SubscribeController extends Controller
             execute(new VerifySubscriberCommand($subscriber));
         }
 
-        return redirect()->to(URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $code]))
+        if (Component::enabled()->count() > 1) {
+            $redirect = redirect()->to(URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $code]));
+        } else {
+            $redirect = cachet_redirect('status-page');
+        }
+
+        return $redirect
             ->withSuccess(sprintf('%s %s', trans('dashboard.notifications.awesome'), trans('cachet.subscriber.email.subscribed')));
     }
 

--- a/app/Notifications/Component/ComponentStatusChangedNotification.php
+++ b/app/Notifications/Component/ComponentStatusChangedNotification.php
@@ -17,6 +17,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\URL;
 use McCool\LaravelAutoPresenter\Facades\AutoPresenter;
 
 /**
@@ -83,6 +84,8 @@ class ComponentStatusChangedNotification extends Notification
             'new_status' => trans("cachet.components.status.{$this->status}"),
         ]);
 
+        $manageUrl = URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $notifiable->verify_code]);
+
         return (new MailMessage())
             ->subject(trans('notifications.component.status_update.mail.subject'))
             ->markdown('notifications.component.update', [
@@ -91,7 +94,7 @@ class ComponentStatusChangedNotification extends Notification
                 'unsubscribeText'        => trans('cachet.subscriber.unsubscribe'),
                 'unsubscribeUrl'         => cachet_route('subscribe.unsubscribe', $notifiable->verify_code),
                 'manageSubscriptionText' => trans('cachet.subscriber.manage_subscription'),
-                'manageSubscriptionUrl'  => cachet_route('subscribe.manage', $notifiable->verify_code),
+                'manageSubscriptionUrl'  => $manageUrl,
             ]);
     }
 

--- a/app/Notifications/Component/ComponentStatusChangedNotification.php
+++ b/app/Notifications/Component/ComponentStatusChangedNotification.php
@@ -84,7 +84,14 @@ class ComponentStatusChangedNotification extends Notification
             'new_status' => trans("cachet.components.status.{$this->status}"),
         ]);
 
-        $manageUrl = URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $notifiable->verify_code]);
+        if (Component::enabled()->count() > 1) {
+            $manageUrl = URL::signedRoute(
+                cachet_route_generator('subscribe.manage'),
+                ['code' => $notifiable->verify_code]
+            );
+        } else {
+            $manageUrl = null;
+        }
 
         return (new MailMessage())
             ->subject(trans('notifications.component.status_update.mail.subject'))

--- a/app/Notifications/Incident/NewIncidentNotification.php
+++ b/app/Notifications/Incident/NewIncidentNotification.php
@@ -18,6 +18,7 @@ use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\URL;
 use McCool\LaravelAutoPresenter\Facades\AutoPresenter;
 
 /**
@@ -73,6 +74,8 @@ class NewIncidentNotification extends Notification
             'name' => $this->incident->name,
         ]);
 
+        $manageUrl = URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $notifiable->verify_code]);
+
         return (new MailMessage())
                     ->subject(trans('notifications.incident.new.mail.subject'))
                     ->markdown('notifications.incident.new', [
@@ -83,7 +86,7 @@ class NewIncidentNotification extends Notification
                         'unsubscribeText'        => trans('cachet.subscriber.unsubscribe'),
                         'unsubscribeUrl'         => cachet_route('subscribe.unsubscribe', $notifiable->verify_code),
                         'manageSubscriptionText' => trans('cachet.subscriber.manage_subscription'),
-                        'manageSubscriptionUrl'  => cachet_route('subscribe.manage', $notifiable->verify_code),
+                        'manageSubscriptionUrl'  => $manageUrl,
                     ]);
     }
 

--- a/app/Notifications/Incident/NewIncidentNotification.php
+++ b/app/Notifications/Incident/NewIncidentNotification.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Cachet\Notifications\Incident;
 
+use CachetHQ\Cachet\Models\Component;
 use CachetHQ\Cachet\Models\Incident;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -74,7 +75,14 @@ class NewIncidentNotification extends Notification
             'name' => $this->incident->name,
         ]);
 
-        $manageUrl = URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $notifiable->verify_code]);
+        if (Component::enabled()->count() > 1) {
+            $manageUrl = URL::signedRoute(
+                cachet_route_generator('subscribe.manage'),
+                ['code' => $notifiable->verify_code]
+            );
+        } else {
+            $manageUrl = null;
+        }
 
         return (new MailMessage())
                     ->subject(trans('notifications.incident.new.mail.subject'))

--- a/app/Notifications/IncidentUpdate/IncidentUpdatedNotification.php
+++ b/app/Notifications/IncidentUpdate/IncidentUpdatedNotification.php
@@ -18,6 +18,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\URL;
 use McCool\LaravelAutoPresenter\Facades\AutoPresenter;
 
 /**
@@ -74,6 +75,8 @@ class IncidentUpdatedNotification extends Notification
             'time'    => $this->update->created_at_diff,
         ]);
 
+        $manageUrl = URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $notifiable->verify_code]);
+
         return (new MailMessage())
             ->subject(trans('notifications.incident.update.mail.subject'))
             ->markdown('notifications.incident.update', [
@@ -87,7 +90,7 @@ class IncidentUpdatedNotification extends Notification
                 'unsubscribeText'        => trans('cachet.subscriber.unsubscribe'),
                 'unsubscribeUrl'         => cachet_route('subscribe.unsubscribe', $notifiable->verify_code),
                 'manageSubscriptionText' => trans('cachet.subscriber.manage_subscription'),
-                'manageSubscriptionUrl'  => cachet_route('subscribe.manage', $notifiable->verify_code),
+                'manageSubscriptionUrl'  => $manageUrl,
             ]);
     }
 

--- a/app/Notifications/IncidentUpdate/IncidentUpdatedNotification.php
+++ b/app/Notifications/IncidentUpdate/IncidentUpdatedNotification.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Cachet\Notifications\IncidentUpdate;
 
+use CachetHQ\Cachet\Models\Component;
 use CachetHQ\Cachet\Models\Incident;
 use CachetHQ\Cachet\Models\IncidentUpdate;
 use Illuminate\Bus\Queueable;
@@ -75,7 +76,14 @@ class IncidentUpdatedNotification extends Notification
             'time'    => $this->update->created_at_diff,
         ]);
 
-        $manageUrl = URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $notifiable->verify_code]);
+        if (Component::enabled()->count() > 1) {
+            $manageUrl = URL::signedRoute(
+                cachet_route_generator('subscribe.manage'),
+                ['code' => $notifiable->verify_code]
+            );
+        } else {
+            $manageUrl = null;
+        }
 
         return (new MailMessage())
             ->subject(trans('notifications.incident.update.mail.subject'))

--- a/app/Notifications/Schedule/NewScheduleNotification.php
+++ b/app/Notifications/Schedule/NewScheduleNotification.php
@@ -18,6 +18,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\URL;
 use McCool\LaravelAutoPresenter\Facades\AutoPresenter;
 
 /**
@@ -74,6 +75,8 @@ class NewScheduleNotification extends Notification implements ShouldQueue
             'date' => $this->schedule->scheduled_at_formatted,
         ]);
 
+        $manageUrl = URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $notifiable->verify_code]);
+
         return (new MailMessage())
             ->subject(trans('notifications.schedule.new.mail.subject'))
             ->markdown('notifications.schedule.new', [
@@ -81,7 +84,7 @@ class NewScheduleNotification extends Notification implements ShouldQueue
                 'unsubscribeText'        => trans('cachet.subscriber.unsubscribe'),
                 'unsubscribeUrl'         => cachet_route('subscribe.unsubscribe', $notifiable->verify_code),
                 'manageSubscriptionText' => trans('cachet.subscriber.manage_subscription'),
-                'manageSubscriptionUrl'  => cachet_route('subscribe.manage', $notifiable->verify_code),
+                'manageSubscriptionUrl'  => $manageUrl,
             ]);
     }
 

--- a/app/Notifications/Schedule/NewScheduleNotification.php
+++ b/app/Notifications/Schedule/NewScheduleNotification.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Cachet\Notifications\Schedule;
 
+use CachetHQ\Cachet\Models\Component;
 use CachetHQ\Cachet\Models\Schedule;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -75,7 +76,14 @@ class NewScheduleNotification extends Notification implements ShouldQueue
             'date' => $this->schedule->scheduled_at_formatted,
         ]);
 
-        $manageUrl = URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $notifiable->verify_code]);
+        if (Component::enabled()->count() > 1) {
+            $manageUrl = URL::signedRoute(
+                cachet_route_generator('subscribe.manage'),
+                ['code' => $notifiable->verify_code]
+            );
+        } else {
+            $manageUrl = null;
+        }
 
         return (new MailMessage())
             ->subject(trans('notifications.schedule.new.mail.subject'))

--- a/app/Notifications/Subscriber/ManageSubscriptionNotification.php
+++ b/app/Notifications/Subscriber/ManageSubscriptionNotification.php
@@ -11,6 +11,7 @@
 
 namespace CachetHQ\Cachet\Notifications\Subscriber;
 
+use CachetHQ\Cachet\Models\Component;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -41,12 +42,22 @@ class ManageSubscriptionNotification extends Notification
      */
     public function toMail($notifiable)
     {
-        $route = URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $notifiable->verify_code]);
+        if (Component::enabled()->count() > 1) {
+            $route = URL::signedRoute(cachet_route_generator('subscribe.manage'), ['code' => $notifiable->verify_code]);
 
-        return (new MailMessage())
+            return (new MailMessage())
                     ->subject(trans('notifications.subscriber.manage.mail.subject'))
                     ->greeting(trans('notifications.subscriber.manage.mail.title', ['app_name' => setting('app_name')]))
                     ->action(trans('notifications.subscriber.manage.mail.action'), $route)
                     ->line(trans('notifications.subscriber.manage.mail.content', ['app_name' => setting('app_name')]));
+        }
+
+        $route = cachet_route('subscribe.unsubscribe', $notifiable->verify_code);
+
+        return (new MailMessage())
+            ->subject(trans('notifications.subscriber.already-subscribed.mail.subject'))
+            ->greeting(trans('notifications.subscriber.already-subscribed.mail.title', ['app_name' => setting('app_name')]))
+            ->action(trans('notifications.subscriber.already-subscribed.mail.action'), $route)
+            ->line(trans('notifications.subscriber.already-subscribed.mail.content', ['app_name' => setting('app_name')]));
     }
 }

--- a/resources/lang/af-ZA/dashboard.php
+++ b/resources/lang/af-ZA/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/af/dashboard.php
+++ b/resources/lang/af/dashboard.php
@@ -84,7 +84,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component, please try again.',
         ],

--- a/resources/lang/ar-SA/dashboard.php
+++ b/resources/lang/ar-SA/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/ar/dashboard.php
+++ b/resources/lang/ar/dashboard.php
@@ -84,7 +84,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component, please try again.',
         ],

--- a/resources/lang/ca-ES/dashboard.php
+++ b/resources/lang/ca-ES/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/ca/dashboard.php
+++ b/resources/lang/ca/dashboard.php
@@ -84,7 +84,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component, please try again.',
         ],

--- a/resources/lang/cs-CZ/dashboard.php
+++ b/resources/lang/cs-CZ/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/el-GR/dashboard.php
+++ b/resources/lang/el-GR/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/el/dashboard.php
+++ b/resources/lang/el/dashboard.php
@@ -84,7 +84,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component, please try again.',
         ],

--- a/resources/lang/en-US/dashboard.php
+++ b/resources/lang/en-US/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/en/dashboard.php
+++ b/resources/lang/en/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -93,6 +93,14 @@ return [
                 'action'  => 'Manage subscription',
             ],
         ],
+        'already-subscribed' => [
+            'mail' => [
+                'subject' => 'Your Subscription',
+                'content' => 'You have subscribed before. Do you want us to stop sending status updates? Click the button above to unsubscribe from the :app_name status page.',
+                'title'   => 'You are subscribed to :app_name status page.',
+                'action'  => 'Unsubscribe',
+            ],
+        ],
     ],
     'system' => [
         'test' => [

--- a/resources/lang/et-EE/dashboard.php
+++ b/resources/lang/et-EE/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/fa-IR/dashboard.php
+++ b/resources/lang/fa-IR/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/fa/dashboard.php
+++ b/resources/lang/fa/dashboard.php
@@ -84,7 +84,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component, please try again.',
         ],

--- a/resources/lang/fi-FI/dashboard.php
+++ b/resources/lang/fi-FI/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/fi/dashboard.php
+++ b/resources/lang/fi/dashboard.php
@@ -84,7 +84,7 @@ return [
         'listed_group'       => 'Ryhmitetään :name alle',
         'add'                => [
             'title'   => 'Lisää komponentti',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Komponentti on luotu.',
             'failure' => 'Jokin meni vikaa luodessa komponenttia, ole hyvä ja yritä uudelleen.',
         ],

--- a/resources/lang/he-IL/dashboard.php
+++ b/resources/lang/he-IL/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/he/dashboard.php
+++ b/resources/lang/he/dashboard.php
@@ -84,7 +84,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component, please try again.',
         ],

--- a/resources/lang/hu-HU/dashboard.php
+++ b/resources/lang/hu-HU/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/hu/dashboard.php
+++ b/resources/lang/hu/dashboard.php
@@ -84,7 +84,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component, please try again.',
         ],

--- a/resources/lang/ja-JP/dashboard.php
+++ b/resources/lang/ja-JP/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/mn-MN/dashboard.php
+++ b/resources/lang/mn-MN/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/nl-NL/notifications.php
+++ b/resources/lang/nl-NL/notifications.php
@@ -85,6 +85,22 @@ return [
                 'action'  => 'Verifiëren',
             ],
         ],
+        'manage' => [
+            'mail' => [
+                'subject' => 'Inschrijving aanpassen',
+                'content' => 'Klik om je inschrijving op de :app_name statuspagina aan te passen.',
+                'title'   => 'Inschrijving op de :app_name statuspagina aanpassen.',
+                'action'  => 'Aanpassen',
+            ],
+        ],
+        'already-subscribed' => [
+            'mail' => [
+                'subject' => 'Je inschrijving',
+                'content' => 'Je was eerder al ingeschreven. Wil je toch geen status updates ontvangen? Klik dan op de knop hierboven om je uit te schrijven.',
+                'title'   => 'Je bent ingeschreven op de :app_name status page.',
+                'action'  => 'Abonnement opzeggen',
+            ],
+        ],
     ],
     'system' => [
         'test' => [

--- a/resources/lang/no-NO/dashboard.php
+++ b/resources/lang/no-NO/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/sl-SI/dashboard.php
+++ b/resources/lang/sl-SI/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/sq-AL/dashboard.php
+++ b/resources/lang/sq-AL/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/sq/dashboard.php
+++ b/resources/lang/sq/dashboard.php
@@ -84,7 +84,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component, please try again.',
         ],

--- a/resources/lang/sr/dashboard.php
+++ b/resources/lang/sr/dashboard.php
@@ -84,7 +84,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component, please try again.',
         ],

--- a/resources/lang/th-TH/dashboard.php
+++ b/resources/lang/th-TH/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/tr-TR/dashboard.php
+++ b/resources/lang/tr-TR/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/tr/dashboard.php
+++ b/resources/lang/tr/dashboard.php
@@ -84,7 +84,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component, please try again.',
         ],

--- a/resources/lang/uk-UA/dashboard.php
+++ b/resources/lang/uk-UA/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/uk/dashboard.php
+++ b/resources/lang/uk/dashboard.php
@@ -90,7 +90,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/lang/vi-VN/dashboard.php
+++ b/resources/lang/vi-VN/dashboard.php
@@ -100,7 +100,7 @@ return [
         'listed_group'       => 'Grouped under :name',
         'add'                => [
             'title'   => 'Add a component',
-            'message' => 'You should add a component.',
+            'message' => 'If you have multiple separate infrastructure components you wish to communicate about you can define these components here.',
             'success' => 'Component created.',
             'failure' => 'Something went wrong with the component group, please try again.',
         ],

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -18,21 +18,15 @@
                 </div>
             </div>
 
+            @if(!$componentGroups->isEmpty() || !$ungroupedComponents->isEmpty())
             <div class="row">
-              <div class="col-md-12">
+                <div class="col-md-12">
                   <div class="section-components no-select">
-                      @if(!$componentGroups->isEmpty() || !$ungroupedComponents->isEmpty())
                       @include('dashboard.partials.components')
-                      @else
-                      <ul class="list-group components">
-                          <li class="list-group-item">
-                              <a href="{{ cachet_route('dashboard.components.create') }}">{{ trans('dashboard.components.add.message') }}</a>
-                          </li>
-                      </ul>
-                      @endif
                   </div>
-              </div>
+                </div>
             </div>
+            @endif
 
             <div class="row">
                 <div class="col-sm-12 col-lg-6">

--- a/resources/views/notifications/partials/subscription.blade.php
+++ b/resources/views/notifications/partials/subscription.blade.php
@@ -1,3 +1,6 @@
 @component('mail::subcopy')
-[{{ $unsubscribeText }}]({{ $unsubscribeUrl }}) &mdash; [{{ $manageSubscriptionText }}]({{ $manageSubscriptionUrl }})
+[{{ $unsubscribeText }}]({{ $unsubscribeUrl }})
+@if($manageSubscriptionUrl)
+&mdash; [{{ $manageSubscriptionText }}]({{ $manageSubscriptionUrl }})
+@endif
 @endcomponent


### PR DESCRIPTION
I count the number of components (active ones) to determine if the manage link should be in the notifications. Only if the number of components is higher than 1 it is shown.

Obviously, having a single component is the same as having no components. There is nothing to choose for a subscriber. Either you do or you don't receive notifications.

Note that I build this on my other PR https://github.com/CachetHQ/Cachet/pull/4020