### PR TITLE
Replace all URLs from Piwik to Matomo

### DIFF
--- a/resources/views/partials/analytics.blade.php
+++ b/resources/views/partials/analytics.blade.php
@@ -25,12 +25,12 @@
     _paq.push(['enableLinkTracking']);
     (function() {
         var u="{{ $appAnalyticsPiwikUrl }}";
-        _paq.push(['setTrackerUrl', u+'/piwik.php']);
+        _paq.push(['setTrackerUrl', u+'/matomo.php']);
         _paq.push(['setSiteId', {{ $appAnalyticsPiwikSiteId }}]);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'/piwik.js'; s.parentNode.insertBefore(g,s);
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'/matomo.js'; s.parentNode.insertBefore(g,s);
     })();
 </script>
-<noscript><p><img src="{{ $appAnalyticsPiwikUrl }}/piwik.php?idsite={{ $appAnalyticsPiwikSiteId }}" style="border:0;" alt="" /></p></noscript>
+<noscript><p><img src="{{ $appAnalyticsPiwikUrl }}/matomo.php?idsite={{ $appAnalyticsPiwikSiteId }}" style="border:0;" alt="" /></p></noscript>
 @endif
 @endif


### PR DESCRIPTION
Hello,

Piwik is now Matomo. Not all URLs work with Matomo. This pull request makes Cachet compatible with Matomo.

Sincerly,
0pc0deFR