### PR TITLE
Updated link to PHP manual for date formats

### DIFF
--- a/resources/views/dashboard/settings/localization.blade.php
+++ b/resources/views/dashboard/settings/localization.blade.php
@@ -41,7 +41,7 @@
                                     <div class="form-group">
                                         <label>
                                             {{ trans('forms.settings.localization.date-format') }}
-                                            <a href="http://php.net/manual/en/function.date.php" target="_blank"><i class="ion ion-help-circled"></i></a>
+                                            <a href="http://php.net/manual/en/datetime.format.php" target="_blank"><i class="ion ion-help-circled"></i></a>
                                         </label>
                                         <input type="text" class="form-control" name="date_format" value="{{ Config::get('setting.date_format') ?: 'l jS F Y' }}">
                                     </div>
@@ -52,7 +52,7 @@
                                     <div class="form-group">
                                         <label>
                                             {{ trans('forms.settings.localization.incident-date-format') }}
-                                            <a href="http://php.net/manual/en/function.date.php" target="_blank"><i class="ion ion-help-circled"></i></a>
+                                            <a href="http://php.net/manual/en/datetime.format.php" target="_blank"><i class="ion ion-help-circled"></i></a>
                                         </label>
                                         <input type="text" class="form-control" name="incident_date_format" value="{{ Config::get('setting.incident_date_format') ?: 'l jS F Y H:i:s' }}">
                                     </div>


### PR DESCRIPTION
The replaced links are being used in the settings section of the dashboard.

![image](https://user-images.githubusercontent.com/5056880/100610687-775cdd00-3310-11eb-9277-d6f266b0f28a.png)


The [`datetime.format`](https://www.php.net/manual/datetime.format.php) page actually lists the formatting characters, whereas the previously linked page does not.

![image](https://user-images.githubusercontent.com/5056880/100610541-3795f580-3310-11eb-90e0-430a75918556.png)
