### PR TITLE
Add maintenance description in schedule email

### DIFF
--- a/app/Notifications/Schedule/NewScheduleNotification.php
+++ b/app/Notifications/Schedule/NewScheduleNotification.php
@@ -74,10 +74,15 @@ class NewScheduleNotification extends Notification implements ShouldQueue
             'date' => $this->schedule->scheduled_at_formatted,
         ]);
 
+        $body = trans('notifications.schedule.new.mail.body', [
+            'message' => $this->schedule->message,
+        ]);
+
         return (new MailMessage())
             ->subject(trans('notifications.schedule.new.mail.subject'))
             ->markdown('notifications.schedule.new', [
                 'content'                => $content,
+                'body'                   => $body,
                 'unsubscribeText'        => trans('cachet.subscriber.unsubscribe'),
                 'unsubscribeUrl'         => cachet_route('subscribe.unsubscribe', $notifiable->verify_code),
                 'manageSubscriptionText' => trans('cachet.subscriber.manage_subscription'),

--- a/resources/lang/af-ZA/notifications.php
+++ b/resources/lang/af-ZA/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/ar-SA/notifications.php
+++ b/resources/lang/ar-SA/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/ca-ES/notifications.php
+++ b/resources/lang/ca-ES/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/cs-CZ/notifications.php
+++ b/resources/lang/cs-CZ/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'Nový plán vytvořen',
                 'content' => ':name bylo naplánováno na :date',
                 'title'   => 'Nová plánovaná údržba byla vytvořena.',
+                'body'    => ':message',
                 'action'  => 'Zobrazit',
             ],
             'slack' => [

--- a/resources/lang/da-DK/notifications.php
+++ b/resources/lang/da-DK/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/de-DE/notifications.php
+++ b/resources/lang/de-DE/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'Neuer Zeitplan erstellt',
                 'content' => ':name wurde für :date geplant',
                 'title'   => 'Eine neue geplante Wartung wurde erstellt.',
+                'body'    => ':message',
                 'action'  => 'Anzeigen',
             ],
             'slack' => [

--- a/resources/lang/el-GR/notifications.php
+++ b/resources/lang/el-GR/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/en-US/notifications.php
+++ b/resources/lang/en-US/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/es-ES/notifications.php
+++ b/resources/lang/es-ES/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/et-EE/notifications.php
+++ b/resources/lang/et-EE/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/fa-IR/notifications.php
+++ b/resources/lang/fa-IR/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/fi-FI/notifications.php
+++ b/resources/lang/fi-FI/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/fr-FR/notifications.php
+++ b/resources/lang/fr-FR/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/he-IL/notifications.php
+++ b/resources/lang/he-IL/notifications.php
@@ -66,6 +66,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/he-IL/notifications.php
+++ b/resources/lang/he-IL/notifications.php
@@ -16,6 +16,7 @@ return [
                 'subject'  => 'Component Status Updated',
                 'greeting' => 'A component\'s status was updated!',
                 'content'  => ':name status changed from :old_status to :new_status.',
+                'body'    => ':message',
                 'action'   => 'View',
             ],
             'slack' => [

--- a/resources/lang/hu-HU/notifications.php
+++ b/resources/lang/hu-HU/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/id-ID/notifications.php
+++ b/resources/lang/id-ID/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'Jadwal Baru Sudah Dibuat',
                 'content' => ':name dijadwalkan pada :date',
                 'title'   => 'Pemeliharaan terjadwal baru telah dibuat.',
+                'body'    => ':message',
                 'action'  => 'Lihat',
             ],
             'slack' => [

--- a/resources/lang/it-IT/notifications.php
+++ b/resources/lang/it-IT/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/ja-JP/notifications.php
+++ b/resources/lang/ja-JP/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/ko-KR/notifications.php
+++ b/resources/lang/ko-KR/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/mn-MN/notifications.php
+++ b/resources/lang/mn-MN/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/nl-NL/notifications.php
+++ b/resources/lang/nl-NL/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'Nieuw tijdschema aangemaakt',
                 'content' => ':name is ingepland voor :date',
                 'title'   => 'Nieuw gepland onderhoud aangemaakt.',
+                'body'    => ':message',
                 'action'  => 'Tonen',
             ],
             'slack' => [

--- a/resources/lang/no-NO/notifications.php
+++ b/resources/lang/no-NO/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'Ny tidsplan opprettet',
                 'content' => ':name ble planlagt for :dato',
                 'title'   => 'En ny planlagt vedlikehold ble opprettet.',
+                'body'    => ':message',
                 'action'  => 'Vis',
             ],
             'slack' => [

--- a/resources/lang/pl-PL/notifications.php
+++ b/resources/lang/pl-PL/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/pt-BR/notifications.php
+++ b/resources/lang/pt-BR/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'Novo Agendamento Criado',
                 'content' => ':name foi agendado para :date',
                 'title'   => 'Uma nova manutenção agendada foi criada.',
+                'body'    => ':message',
                 'action'  => 'Visualizar',
             ],
             'slack' => [

--- a/resources/lang/pt-PT/notifications.php
+++ b/resources/lang/pt-PT/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/ro-RO/notifications.php
+++ b/resources/lang/ro-RO/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/ru-RU/notifications.php
+++ b/resources/lang/ru-RU/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/sl-SI/notifications.php
+++ b/resources/lang/sl-SI/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/sq-AL/notifications.php
+++ b/resources/lang/sq-AL/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/sv-SE/notifications.php
+++ b/resources/lang/sv-SE/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/th-TH/notifications.php
+++ b/resources/lang/th-TH/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/tr-TR/notifications.php
+++ b/resources/lang/tr-TR/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/uk-UA/notifications.php
+++ b/resources/lang/uk-UA/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/vi-VN/notifications.php
+++ b/resources/lang/vi-VN/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/lang/zh-CN/notifications.php
+++ b/resources/lang/zh-CN/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => '新的维护计划已创建',
                 'content' => ':name 已计划于 :date 进行',
                 'title'   => '新的计划维护已创建。',
+                'body'    => ':message',
                 'action'  => '查看',
             ],
             'slack' => [

--- a/resources/lang/zh-TW/notifications.php
+++ b/resources/lang/zh-TW/notifications.php
@@ -65,6 +65,7 @@ return [
                 'subject' => 'New Schedule Created',
                 'content' => ':name was scheduled for :date',
                 'title'   => 'A new scheduled maintenance was created.',
+                'body'    => ':message',
                 'action'  => 'View',
             ],
             'slack' => [

--- a/resources/views/notifications/schedule/new.blade.php
+++ b/resources/views/notifications/schedule/new.blade.php
@@ -3,6 +3,8 @@
 
 {{ $content }}
 
+{{ $body }}
+
 @lang('Thanks,')<br>
 {{ Config::get('setting.app_name') }}
 


### PR DESCRIPTION
Add a **message of maintenance** in email as mentioned at [this issue ](https://github.com/CachetHQ/Cachet/issues/4120) and [here at first point](https://github.com/CachetHQ/Cachet/issues/3665#issue-460617982).