### PR TITLE
fix(dashboard): RSS feed is no more avariable

### DIFF
--- a/app/Http/Controllers/Dashboard/DashboardController.php
+++ b/app/Http/Controllers/Dashboard/DashboardController.php
@@ -84,7 +84,7 @@ class DashboardController extends Controller
         $ungroupedComponents = Component::enabled()->where('group_id', 0)->orderBy('order')->orderBy('created_at')->get();
 
         $entries = null;
-        if ($feed = $this->feed->latest()) {
+        if ($feed = $this->feed->latest() != Feel::FAILED) {
             $entries = array_slice($feed->channel->item, 0, 5);
         }
 


### PR DESCRIPTION
Hi

As the RSS feed referenced here https://github.com/CachetHQ/Cachet/blob/2.4/app/Integrations/Core/Feed.php#L31 is no more avariable the retreiving of last feed failed.

This PR handle this by disabling the feed if not avariable.

Regards  