### PR TITLE
SRE-632 Prevent null values appearing in metric point graph

### DIFF
--- a/resources/lang/af-ZA/forms.php
+++ b/resources/lang/af-ZA/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Beskrywing',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/ar-SA/forms.php
+++ b/resources/lang/ar-SA/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/ca-ES/forms.php
+++ b/resources/lang/ca-ES/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/el-GR/forms.php
+++ b/resources/lang/el-GR/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/en-US/forms.php
+++ b/resources/lang/en-US/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/en/forms.php
+++ b/resources/lang/en/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/et-EE/forms.php
+++ b/resources/lang/et-EE/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/fa-IR/forms.php
+++ b/resources/lang/fa-IR/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/fi-FI/forms.php
+++ b/resources/lang/fi-FI/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/he-IL/forms.php
+++ b/resources/lang/he-IL/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/hu-HU/forms.php
+++ b/resources/lang/hu-HU/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/ja-JP/forms.php
+++ b/resources/lang/ja-JP/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/mn-MN/forms.php
+++ b/resources/lang/mn-MN/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/sl-SI/forms.php
+++ b/resources/lang/sl-SI/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/sq-AL/forms.php
+++ b/resources/lang/sq-AL/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/th-TH/forms.php
+++ b/resources/lang/th-TH/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/tr-TR/forms.php
+++ b/resources/lang/tr-TR/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/uk-UA/forms.php
+++ b/resources/lang/uk-UA/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/vi-VN/forms.php
+++ b/resources/lang/vi-VN/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => 'Description',
         'description-help'         => 'You may also use Markdown.',
         'display-chart'            => 'Display chart on status page?',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => 'Sum',
         'type_avg'                 => 'Average',

--- a/resources/lang/zh-TW/forms.php
+++ b/resources/lang/zh-TW/forms.php
@@ -127,7 +127,7 @@ return [
         'description'              => '描述',
         'description-help'         => '你可以使用 Markdown 。',
         'display-chart'            => '在狀態頁上顯示圖表？',
-        'default-value'            => 'Default value',
+        'default-value'            => 'Default value (-1 to hide)',
         'calc_type'                => 'Calculation of metrics',
         'type_sum'                 => '總和',
         'type_avg'                 => '平均',


### PR DESCRIPTION
This allows the option to disable the default_value metric to prevent drops when data is missing.

Before;
![Screenshot 2021-01-12 at 13 53 29](https://user-images.githubusercontent.com/303487/104286938-d734cf00-54dd-11eb-99bf-3d88f8e4dcba.png)


After;

![Screenshot 2021-01-12 at 13 56 04](https://user-images.githubusercontent.com/303487/104287025-f59aca80-54dd-11eb-954f-d264afd76aa8.png)

Any feedback welcome.