### PR TITLE
Fix API search with pagination when specifying page

### DIFF
--- a/app/Models/Traits/SearchableTrait.php
+++ b/app/Models/Traits/SearchableTrait.php
@@ -34,10 +34,11 @@ trait SearchableTrait
             return $query;
         }
 
-        if (!array_intersect(array_keys($search), $this->searchable)) {
+        $allowed_search = array_intersect_key($search, array_flip($this->searchable));
+        if (!$allowed_search) {
             return $query;
         }
 
-        return $query->where($search);
+        return $query->where($allowed_search);
     }
 }

--- a/tests/Api/IncidentTest.php
+++ b/tests/Api/IncidentTest.php
@@ -30,6 +30,51 @@ class IncidentTest extends AbstractApiTestCase
         $this->assertResponseOk();
     }
 
+    public function testGetIncidentsPaginated()
+    {
+        $incidents = factory('CachetHQ\Cachet\Models\Incident', 3)->create();
+
+        $this->get('/api/v1/incidents?per_page=1&page=1');
+        $this->seeJson(['id' => $incidents[0]->id]);
+        $this->assertResponseOk();
+
+        $this->get('/api/v1/incidents?per_page=1&page=2');
+        $this->seeJson(['id' => $incidents[1]->id]);
+        $this->assertResponseOk();
+    }
+
+    public function testGetIncidentsBySearch()
+    {
+        factory('CachetHQ\Cachet\Models\Incident', 3)->create([
+          'status' => 0
+        ]);
+
+        $incidents = factory('CachetHQ\Cachet\Models\Incident', 2)->create([
+          'status' => 1
+        ]);
+
+
+        $this->get('/api/v1/incidents?status=1');
+        $this->seeJson(['id' => $incidents[0]->id]);
+        $this->assertResponseOk();
+    }
+
+    public function testGetIncidentsPaginatedBySearch()
+    {
+        factory('CachetHQ\Cachet\Models\Incident', 3)->create([
+          'status' => 0
+        ]);
+
+        $incidents = factory('CachetHQ\Cachet\Models\Incident', 2)->create([
+          'status' => 1
+        ]);
+
+
+        $this->get('/api/v1/incidents?status=1&per_page=1&page=1');
+        $this->seeJson(['id' => $incidents[0]->id]);
+        $this->assertResponseOk();
+    }
+
     public function testGetInvalidIncident()
     {
         $this->get('/api/v1/incidents/0');

--- a/tests/Api/IncidentTest.php
+++ b/tests/Api/IncidentTest.php
@@ -46,13 +46,12 @@ class IncidentTest extends AbstractApiTestCase
     public function testGetIncidentsBySearch()
     {
         factory('CachetHQ\Cachet\Models\Incident', 3)->create([
-          'status' => 0
+            'status' => 0,
         ]);
 
         $incidents = factory('CachetHQ\Cachet\Models\Incident', 2)->create([
-          'status' => 1
+            'status' => 1,
         ]);
-
 
         $this->get('/api/v1/incidents?status=1');
         $this->seeJson(['id' => $incidents[0]->id]);
@@ -62,13 +61,12 @@ class IncidentTest extends AbstractApiTestCase
     public function testGetIncidentsPaginatedBySearch()
     {
         factory('CachetHQ\Cachet\Models\Incident', 3)->create([
-          'status' => 0
+            'status' => 0,
         ]);
 
         $incidents = factory('CachetHQ\Cachet\Models\Incident', 2)->create([
-          'status' => 1
+            'status' => 1,
         ]);
-
 
         $this->get('/api/v1/incidents?status=1&per_page=1&page=1');
         $this->seeJson(['id' => $incidents[0]->id]);


### PR DESCRIPTION
Currently if you use the search feature of the API along with pagination, specifying the page you want (`page` param) Cachet throws a 500 error as it adds `page` and value you gave the param as a WHERE clause, even though the table in question doesn't have a `page` column.

**Broken:** `/api/v1/incidents?per_page=6&page=1&status=3`
**Works:** `/api/v1/incidents?per_page=6&page=1`
**Works:** `/api/v1/incidents?per_page=6&status=1`
**Works:** `/api/v1/incidents?status=1`