### PR TITLE
Increase in the maximum number for the Piwik's site ID

### DIFF
--- a/resources/views/dashboard/settings/analytics.blade.php
+++ b/resources/views/dashboard/settings/analytics.blade.php
@@ -45,7 +45,7 @@
                                 <div class="col-xs-12">
                                     <div class="form-group">
                                         <label>{{ trans('forms.settings.analytics.analytics_piwik_siteid') }}</label>
-                                        <input type="number" min="1" max="100" name="app_analytics_piwik_site_id" class="form-control" value="{{ $app_analytics_piwik_site_id }}" placeholder="1">
+                                        <input type="number" min="1" max="1000" name="app_analytics_piwik_site_id" class="form-control" value="{{ $app_analytics_piwik_site_id }}" placeholder="1">
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Hello,

The maximum number for a Piwik's site ID is 100, but you can sometimes have an ID with a higher number. This pull request sets it to 1000.

Thanks!