### PR TITLE
Make Stylesheet <textarea> vertically resizable

### DIFF
--- a/resources/assets/sass/dashboard/partials/_content.scss
+++ b/resources/assets/sass/dashboard/partials/_content.scss
@@ -8,6 +8,9 @@ body.dashboard {
             &.header-fixed {
                 margin-top: 60px;
             }
+            textarea[name="stylesheet"] {
+                resize: vertical;
+            }       
         }
         .header {
             position: relative;


### PR DESCRIPTION
When you have a decent amount of custom CSS in Dashboard > Settings > Stylesheet, vertical resizing is very helpful