### PR TITLE
Set the default value for the "reserved" column to 0 (instead of null)

### DIFF
--- a/database/migrations/2019_12_12_131400_AlterJobsDropReserved.php
+++ b/database/migrations/2019_12_12_131400_AlterJobsDropReserved.php
@@ -35,7 +35,7 @@ class AlterJobsDropReserved extends Migration
     public function down()
     {
         Schema::table('jobs', function (Blueprint $table) {
-            $table->tinyInteger('reserved')->unsigned()->after('attempts');
+            $table->tinyInteger('reserved')->unsigned()->default(0)->after('attempts');
         });
     }
 }


### PR DESCRIPTION
This pr sets the default value for the column "reserved" to 0 (instead of null, the default) in the migration "2019_12_12_131400_AlterJobsDropReserved".
This fixes the error "Cannot add a NOT NULL column with default value NULL".

Steps to reproduce: 
 * Clone the repo
 * Run phpunit

