### PR TITLE
Only use AboutApp when the setting "setting.app_about" is set

### DIFF
--- a/app/Composers/AppComposer.php
+++ b/app/Composers/AppComposer.php
@@ -61,7 +61,13 @@ class AppComposer
      */
     public function compose(View $view)
     {
-        $view->withAboutApp(Markdown::convertToHtml($this->config->get('setting.app_about')));
+        if ($this->config->get('setting.app_about')) {
+            $about = Markdown::convertToHtml($this->config->get('setting.app_about'));
+        } else {
+            $about = '';
+        }
+        
+        $view->withAboutApp($about);
         $view->withAppAnalytics($this->config->get('setting.app_analytics'));
         $view->withAppAnalyticsGoSquared($this->config->get('setting.app_analytics_gs'));
         $view->withAppAnalyticsPiwikUrl($this->config->get('setting.app_analytics_piwik_url'));


### PR DESCRIPTION
This pr sets the AboutApp value only when the setting "setting.app_about" is set. When the setting is not set it uses an empty string instead.
This fixes the error "Argument 1 passed to League\CommonMark\Converter::convertToHtml() must be of the type string, null given".

Steps to reproduce:
 * Clone the repo
 * Run phpunit