### PR TITLE
Clear the cached config file after writing to the .env file

### DIFF
--- a/app/Bus/Handlers/Commands/System/Config/UpdateConfigCommandHandler.php
+++ b/app/Bus/Handlers/Commands/System/Config/UpdateConfigCommandHandler.php
@@ -14,6 +14,7 @@ namespace CachetHQ\Cachet\Bus\Handlers\Commands\System\Config;
 use CachetHQ\Cachet\Bus\Commands\System\Config\UpdateConfigCommand;
 use Dotenv\Dotenv;
 use Dotenv\Exception\InvalidPathException;
+use Illuminate\Filesystem\Filesystem;
 
 /**
  * This is the update config command handler class.

--- a/app/Bus/Handlers/Commands/System/Config/UpdateConfigCommandHandler.php
+++ b/app/Bus/Handlers/Commands/System/Config/UpdateConfigCommandHandler.php
@@ -23,6 +23,25 @@ use Dotenv\Exception\InvalidPathException;
 class UpdateConfigCommandHandler
 {
     /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * Create a new update config command handler instance.
+     *
+     * @param \Illuminate\Filesystem\Filesystem $files
+     *
+     * @return void
+     */
+    public function __construct(Filesystem $files)
+    {
+        $this->files = $files;
+    }
+
+    /**
      * Handle update config command handler instance.
      *
      * @param \CachetHQ\Cachet\Bus\Commands\System\Config\UpdateConfigCommand $command
@@ -33,6 +52,11 @@ class UpdateConfigCommandHandler
     {
         foreach ($command->values as $setting => $value) {
             $this->writeEnv($setting, $value);
+        }
+
+        // Clears the cached config file like artisan config:clear does.
+        if (app()->configurationIsCached()) {
+            $this->files->delete(app()->getCachedConfigPath());
         }
     }
 


### PR DESCRIPTION
This clears the cached config file so that the application loads the new settings from the freshly written .env file.
The command handler writes the new mail settings into the .env file but they are not loaded if the config is cached.

This fixes #4260 