### PR TITLE
Cachet causes a 500 error when clicking 'subscribe' after a clean install.

### DIFF
--- a/app/Http/Controllers/SubscribeController.php
+++ b/app/Http/Controllers/SubscribeController.php
@@ -66,8 +66,13 @@ class SubscribeController extends Controller
      */
     public function showSubscribe()
     {
+        $aboutMarkdown = Config::get('setting.app_about');
+        if (empty($aboutMarkdown)) {
+            $aboutMarkdown = '';
+        }
+
         return View::make('subscribe.subscribe')
-            ->withAboutApp(Markdown::convertToHtml(Config::get('setting.app_about')));
+            ->withAboutApp(Markdown::convertToHtml($aboutMarkdown));
     }
 
     /**


### PR DESCRIPTION
Clicking subscribe causes a 500 error, because Leauge/Markdown expects a string, but the unset value is actually null. This PR fixes this 500 error.