### PR TITLE
Checks if start_date has correct format before parsing the input

### DIFF
--- a/app/Http/Controllers/StatusPageController.php
+++ b/app/Http/Controllers/StatusPageController.php
@@ -46,8 +46,9 @@ class StatusPageController extends AbstractApiController
     {
         $onlyDisruptedDays = Config::get('setting.only_disrupted_days');
         $appIncidentDays = (int) Config::get('setting.app_incident_days', 1);
+        $startDateInput = Binput::get('start_date', Date::now()->toDateString());
 
-        $startDate = Date::createFromFormat('Y-m-d', Binput::get('start_date', Date::now()->toDateString()));
+        $startDate = Date::createFromFormat('Y-m-d', Carbon::hasFormat($startDateInput, 'Y-m-d') ? $startDateInput : Date::now()->toDateString());
         $endDate = $startDate->copy()->subDays($appIncidentDays);
 
         $canPageForward = false;


### PR DESCRIPTION
Currently, Cachet crashes if anyone provides a `start_date` that doesn't fully conform to the defined format ('Y-m-d').

This adds a check that the format matches the defined format before attempting parsing.

A future improvement could be to detect the format and use the closest valid value.