### PR TITLE
Added a one-click deploy template

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,7 @@ To test out the demo, you can log in to the [Cachet dashboard](https://demo.cach
 ## Security Vulnerabilities
 
 If you discover a security vulnerability within Cachet, please send an e-mail to [support@cachethq.io](mailto:support@cachethq.io?Cachet%20Security%20Vulnerability). All security vulnerabilities are reviewed on a case-by-case basis.
+
+## Third-Party Hosting
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploy.png)](https://repocloud.io/details/?app_id=96)


### PR DESCRIPTION
Added a third-party hosting section and a link to the 1-click installer template at RepoCloud.io - allowing users access to their affordable cloud hosting.

(This link also qualifies the cachet team to earn 25% recurring lifetime referral commissions)