### PR TITLE
[3.x] Implement the filament user contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Here are some useful quick links:
 
 To test out the v3 demo, you can log in to the [Cachet dashboard](https://v3.cachethq.io/dashboard) with the following credentials:
 
-- **Email:** `test@example.com`
+- **Email:** `test@test.com`
 - **Password:** `test123`
 
 > **Note**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,12 +12,14 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
-class User extends Authenticatable
+class User extends Authenticatable implements FilamentUser
 {
     use HasApiTokens;
     use HasFactory;
@@ -53,4 +55,9 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password'          => 'hashed',
     ];
+
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
This PR adds the FilamentUser interface to the user model to prevent a 403 when logging in on a non-local environment. I've set it to just return true to allow all users access to the cachet dashboard as I believe this is the desired functionality. I can amend this if needed.

I've updated the test account email in the README to reflect the user that is seeded and mentioned in the recent blog post.