### PR TITLE
Issue #4400 - No component email on incident creation/update

### DIFF
--- a/app/Bus/Handlers/Commands/Incident/CreateIncidentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Incident/CreateIncidentCommandHandler.php
@@ -126,7 +126,8 @@ class CreateIncidentCommandHandler
                 null,
                 null,
                 null,
-                false
+                null,
+                true  // Silent mode
             ));
         }
 

--- a/app/Bus/Handlers/Commands/Incident/UpdateIncidentCommandHandler.php
+++ b/app/Bus/Handlers/Commands/Incident/UpdateIncidentCommandHandler.php
@@ -111,7 +111,8 @@ class UpdateIncidentCommandHandler
                 null,
                 null,
                 null,
-                false
+                null,
+                true // Silent mode
             ));
         }
 


### PR DESCRIPTION
Complete work of previous issue #4395  regarding this issue: do not send components emails with incidents are created/updated.