### PR TITLE
Add MariaDB to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For more information on the Cachet rebuild and our plans for 3.x, you can read t
 - PHP 7.1.3 – 7.3
 - HTTP server with PHP support (e.g.: Apache, Nginx, Caddy)
 - [Composer](https://getcomposer.org)
-- A supported database: MySQL, PostgreSQL or SQLite
+- A supported database: MariaDB, MySQL, PostgreSQL or SQLite
 
 ## Installation, Upgrades and Documentation
 


### PR DESCRIPTION
Suggesting to add MariaDB as supported database to README.md, as discussed in https://github.com/cachethq/cachet/issues/4419#event-14577435109