### PR TITLE
Updating post-create-project-cmd in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,10 @@
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
         ],
         "post-create-project-cmd": [
-            "@php artisan key:generate --ansi"
+            "@php artisan key:generate --ansi",
+            "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",
+            "@php artisan migrate --graceful --ansi",
+            "@php artisan vendor:publish --tag=cachet"
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",


### PR DESCRIPTION
Hey @jbrooksuk 👋

This PR will add the necessary steps to get Cachet up and running on a local instance using the new Laravel installer `--using` flag.

So, users can type the following:

```
laravel new status-page --using=cachethq/cachet
```

and it will now create the sqlite file, run migrations, and publish the necessary cachet files.

I'll ping you on Slack as well 😉

Thanks! Hope you're having a great day 👏