### PR TITLE
Fix login Method Not Allowed error by registering missing service providers

### DIFF
--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -11,4 +11,6 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    Cachet\CachetCoreServiceProvider::class,
+    Cachet\CachetDashboardServiceProvider::class,
 ];


### PR DESCRIPTION
## Summary
Fixes the dashboard login "Method Not Allowed" error by adding missing service providers to Laravel 11's bootstrap/providers.php file.

## Problem
The dashboard login was failing with "The POST method is not supported for route dashboard/login. Supported methods: GET, HEAD." This occurred because Cachet's service providers were not properly registered, causing Filament authentication routes to not be loaded.

## Solution
Added `CachetCoreServiceProvider` and `CachetDashboardServiceProvider` to the providers array in `bootstrap/providers.php`. This ensures all Filament routes are properly registered and the login functionality works correctly.

## Test Plan
- [x] Fresh installation of Cachet v3
- [x] Verify dashboard login now works with POST method
- [x] Confirm all Filament routes are properly registered

Fixes #4533