### PR TITLE
Fix PHP 8.5 PDO::MYSQL_ATTR_SSL_CA deprecation warnings

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -33,4 +33,5 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //
-    })->create();
+    })->create()
+    ->dontMergeFrameworkConfiguration();

--- a/config/app.php
+++ b/config/app.php
@@ -9,6 +9,9 @@
  * file that was distributed with this source code.
  */
 
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\ServiceProvider;
+
 return [
 
     /*
@@ -131,5 +134,9 @@ return [
         'driver' => env('APP_MAINTENANCE_DRIVER', 'file'),
         'store'  => env('APP_MAINTENANCE_STORE', 'database'),
     ],
+
+    'providers' => ServiceProvider::defaultProviders()->toArray(),
+
+    'aliases' => Facade::defaultAliases()->toArray(),
 
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -67,7 +67,7 @@ return [
             'strict'         => true,
             'engine'         => null,
             'options'        => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (defined('Pdo\Mysql::ATTR_SSL_CA') ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -87,7 +87,7 @@ return [
             'strict'         => true,
             'engine'         => null,
             'options'        => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (defined('Pdo\Mysql::ATTR_SSL_CA') ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 


### PR DESCRIPTION
## Summary

- Replace deprecated `PDO::MYSQL_ATTR_SSL_CA` with `Pdo\Mysql::ATTR_SSL_CA` in `config/database.php` for both mysql and mariadb connections, with a fallback for PHP 8.2–8.4 compatibility.
- Add `providers` and `aliases` keys to `config/app.php` and call `dontMergeFrameworkConfiguration()` in `bootstrap/app.php` to prevent Laravel's vendor config (which also uses the deprecated constant) from being loaded.

## Test plan

- [ ] Verify the status page loads without deprecation warnings on PHP 8.5
- [ ] Verify the app still works correctly on PHP 8.2–8.4
- [ ] Verify the dashboard/login page loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)