### PR TITLE
Fix subscribe endpoint when subscribers are disabled

### DIFF
--- a/app/Http/Controllers/SubscribeController.php
+++ b/app/Http/Controllers/SubscribeController.php
@@ -45,6 +45,10 @@ class SubscribeController extends Controller
      */
     public function showSubscribe()
     {
+        if (!subscribers_enabled()) {
+            return Redirect::route('status-page');
+        }
+
         return View::make('subscribe.subscribe')
             ->withAboutApp(Markdown::convertToHtml(Config::get('setting.app_about')));
     }
@@ -56,8 +60,11 @@ class SubscribeController extends Controller
      */
     public function postSubscribe()
     {
+        if (!subscribers_enabled()) {
+            return Redirect::route('status-page');
+        }
+
         $email = Binput::get('email');
-        $subscriptions = Binput::get('subscriptions');
         $verified = app(Repository::class)->get('setting.skip_subscriber_verification');
 
         try {


### PR DESCRIPTION
Issue link id: #4515
Description:
This change prevents direct access to subscription creation when email notifications are disabled in settings.
Previously, the subscribe page button was hidden but posting directly to the subscribe endpoint could still create subscriptions.
The fix adds a defensive check in SubscribeController for both subscribe page rendering and subscribe submission, redirecting to the status page when subscribers are disabled.