### PR TITLE
Fix removing all component tags

### DIFF
--- a/app/Http/Controllers/Api/ComponentController.php
+++ b/app/Http/Controllers/Api/ComponentController.php
@@ -25,6 +25,20 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 class ComponentController extends AbstractApiController
 {
     /**
+     * Parse a comma-separated tags payload into a clean tag list.
+     *
+     * @param string $tags
+     *
+     * @return array
+     */
+    protected function parseTags($tags)
+    {
+        return array_values(array_filter(array_map('trim', preg_split('/ ?, ?/', (string) $tags)), function ($tag) {
+            return $tag !== '';
+        }));
+    }
+
+    /**
      * Get all components.
      *
      * @return \Illuminate\Http\JsonResponse
@@ -83,9 +97,9 @@ class ComponentController extends AbstractApiController
             throw new BadRequestHttpException();
         }
 
-        if (Binput::has('tags')) {
+        if (!is_null(Binput::get('tags', null))) {
             // The component was added successfully, so now let's deal with the tags.
-            $tags = preg_split('/ ?, ?/', Binput::get('tags'));
+            $tags = $this->parseTags(Binput::get('tags'));
 
             // For every tag, do we need to create it?
             $componentTags = array_map(function ($taggable) use ($component) {
@@ -124,8 +138,8 @@ class ComponentController extends AbstractApiController
             throw new BadRequestHttpException();
         }
 
-        if (Binput::has('tags')) {
-            $tags = preg_split('/ ?, ?/', Binput::get('tags'));
+        if (!is_null(Binput::get('tags', null))) {
+            $tags = $this->parseTags(Binput::get('tags'));
 
             // For every tag, do we need to create it?
             $componentTags = array_map(function ($taggable) use ($component) {

--- a/app/Http/Controllers/Dashboard/ComponentController.php
+++ b/app/Http/Controllers/Dashboard/ComponentController.php
@@ -36,6 +36,20 @@ class ComponentController extends Controller
     protected $subMenu = [];
 
     /**
+     * Parse a comma-separated tags payload into a clean tag list.
+     *
+     * @param string $tags
+     *
+     * @return array
+     */
+    protected function parseTags($tags)
+    {
+        return array_values(array_filter(array_map('trim', preg_split('/ ?, ?/', (string) $tags)), function ($tag) {
+            return $tag !== '';
+        }));
+    }
+
+    /**
      * Creates a new component controller instance.
      *
      * @return void
@@ -145,7 +159,7 @@ class ComponentController extends Controller
         }
 
         // The component was added successfully, so now let's deal with the tags.
-        $tags = preg_split('/ ?, ?/', $tags);
+        $tags = $this->parseTags($tags);
 
         // For every tag, do we need to create it?
         $componentTags = array_map(function ($taggable) use ($component) {
@@ -198,7 +212,7 @@ class ComponentController extends Controller
         }
 
         // The component was added successfully, so now let's deal with the tags.
-        $tags = preg_split('/ ?, ?/', $tags);
+        $tags = $this->parseTags($tags);
 
         // For every tag, do we need to create it?
         $componentTags = array_map(function ($taggable) use ($component) {


### PR DESCRIPTION
Issue link id: #4428

Description:
This resolves the inability to remove the final tag from a component.
Tag parsing now normalizes and filters empty values before sync, and updates accept an explicitly empty tags payload so sync can clear all tag relations.
Applied in both API and dashboard component tag update paths for consistent behavior.