### PR TITLE
Fix Atom and RSS content-type headers

### DIFF
--- a/app/Http/Controllers/FeedController.php
+++ b/app/Http/Controllers/FeedController.php
@@ -90,7 +90,10 @@ class FeedController extends Controller
             });
         }
 
-        return $this->feed->render($isRss ? 'rss' : 'atom');
+        $content = $this->feed->render($isRss ? 'rss' : 'atom');
+        $contentType = $isRss ? 'application/rss+xml; charset=UTF-8' : 'application/atom+xml; charset=UTF-8';
+
+        return response($content, 200, ['Content-Type' => $contentType]);
     }
 
     /**


### PR DESCRIPTION
Issue link id: #4364

Description:
This fix ensures feed endpoints return explicit XML media types instead of defaulting to HTML in some environments.
Atom now returns application/atom+xml and RSS returns application/rss+xml with UTF-8 charset.
This improves compatibility with feed readers and validation tooling.