### PR TITLE
Fix incident history pager window navigation

### DIFF
--- a/app/Http/Controllers/StatusPageController.php
+++ b/app/Http/Controllers/StatusPageController.php
@@ -79,11 +79,13 @@ class StatusPageController extends AbstractApiController
         } else {
             $incidentDays = range(0, $daysToShow);
         }
+        $windowSpan = $daysToShow + 1;
+        $oldestDateInWindow = $startDate->copy()->subDays($daysToShow);
 
         $incidentVisibility = Auth::check() ? 0 : 1;
 
         $allIncidents = Incident::notScheduled()->where('visible', '>=', $incidentVisibility)->whereBetween('created_at', [
-            $startDate->copy()->subDays($daysToShow)->format('Y-m-d').' 00:00:00',
+            $oldestDateInWindow->format('Y-m-d').' 00:00:00',
             $startDate->format('Y-m-d').' 23:59:59',
         ])->orderBy('scheduled_at', 'desc')->orderBy('created_at', 'desc')->get()->load('updates')->groupBy(function (Incident $incident) {
             return app(DateFactory::class)->make($incident->is_scheduled ? $incident->scheduled_at : $incident->created_at)->toDateString();
@@ -107,9 +109,9 @@ class StatusPageController extends AbstractApiController
             ->withDaysToShow($daysToShow)
             ->withAllIncidents($allIncidents)
             ->withCanPageForward((bool) $today->gt($startDate))
-            ->withCanPageBackward(Incident::notScheduled()->where('created_at', '<', $startDate->format('Y-m-d'))->count() > 0)
-            ->withPreviousDate($startDate->copy()->subDays($daysToShow)->toDateString())
-            ->withNextDate($startDate->copy()->addDays($daysToShow)->toDateString());
+            ->withCanPageBackward(Incident::notScheduled()->where('created_at', '<', $oldestDateInWindow->format('Y-m-d').' 00:00:00')->count() > 0)
+            ->withPreviousDate($startDate->copy()->subDays($windowSpan)->toDateString())
+            ->withNextDate($startDate->copy()->addDays($windowSpan)->toDateString());
     }
 
     /**


### PR DESCRIPTION
Issue link id: #4435


Description:
This adjusts timeline pagination to move by full non-overlapping windows.
Previously, previous and next links could overlap date ranges and produce confusing navigation.
The fix updates window boundaries and backward availability checks so navigation behaves predictably.