### PR TITLE
Add incident links to scheduled maintenance entries

### DIFF
--- a/resources/views/partials/schedule.blade.php
+++ b/resources/views/partials/schedule.blade.php
@@ -6,7 +6,7 @@
         <div class="list-group">
             @foreach($scheduled_maintenance as $schedule)
             <div class="list-group-item">
-                <strong>{{ $schedule->name }}</strong> <small class="date"><abbr class="timeago" data-toggle="tooltip" data-placement="right" title="{{ $schedule->scheduled_at_formatted }}" data-timeago="{{ $schedule->scheduled_at_iso }}"></abbr></small>
+                <strong>{{ $schedule->name }}</strong> <small class="date"><a href="{{ route('incident', ['id' => $schedule->id]) }}" class="links"><abbr class="timeago" data-toggle="tooltip" data-placement="right" title="{{ $schedule->scheduled_at_formatted }}" data-timeago="{{ $schedule->scheduled_at_iso }}"></abbr></a></small>
                 {!! $schedule->formattedMessage !!}
             </div>
             @endforeach


### PR DESCRIPTION
Issue link id: #4573


Description:
Planned maintenance entries now link to their incident detail page directly from the scheduled section.
This brings behavior in line with historical incidents and avoids forcing users to guess incident IDs for future maintenance events.