### PR TITLE
Remove debug dump from subscription manage errors

### DIFF
--- a/app/Http/Controllers/SubscribeController.php
+++ b/app/Http/Controllers/SubscribeController.php
@@ -185,8 +185,6 @@ class SubscribeController extends Controller
         try {
             dispatch(new UpdateSubscriberSubscriptionCommand($subscriber, Binput::get('subscriptions')));
         } catch (ValidationException $e) {
-            dd($e->getMessageBag());
-
             return Redirect::route('subscribe.manage', $subscriber->verify_code)
                 ->withInput(Binput::all())
                 ->withTitle(sprintf('%s %s', trans('dashboard.notifications.whoops'), trans('cachet.subscriber.email.failure')))


### PR DESCRIPTION
Issue link id: N/A (proactive bugfix found during subscription-path audit)


Description:
This removes a leftover debug dump call in subscription management error handling.
When validation failed, execution could halt with debug output instead of returning the normal redirect and error messages.
The fix restores expected production error behavior.