### PR TITLE
Fix unsubscribe translation key in incident email

### DIFF
--- a/resources/views/emails/incidents/new-text.blade.php
+++ b/resources/views/emails/incidents/new-text.blade.php
@@ -10,7 +10,7 @@
 
 {!! trans('cachet.subscriber.email.manage') !!} {{ $manage_link }}
 
-{!! trans('cachet.subscriber.email.unsuscribe') !!} {{ $unsubscribe_link }}
+{!! trans('cachet.subscriber.email.unsubscribe') !!} {{ $unsubscribe_link }}
 
 @if($show_support)
 {!! trans('cachet.powered_by', ['app' => $app_name]) !!}


### PR DESCRIPTION
Issue link id: N/A (proactive bugfix found during subscriber email audit)

Description:
Fixes a misspelled translation key in the incident text email template.
The template referenced an invalid key for unsubscribe text, which could break or fallback incorrectly in localized output.
Updated to the correct unsubscribe key.