### PR TITLE
Fix unsubscribe command argument mismatch

### DIFF
--- a/app/Http/Controllers/SubscribeController.php
+++ b/app/Http/Controllers/SubscribeController.php
@@ -127,7 +127,7 @@ class SubscribeController extends Controller
         if ($subscription) {
             dispatch(new UnsubscribeSubscriptionCommand(Subscription::forSubscriber($subscriber->id)->firstOrFail()));
         } else {
-            dispatch(new UnsubscribeSubscriberCommand($subscriber, $subscription));
+            dispatch(new UnsubscribeSubscriberCommand($subscriber));
         }
 
         return Redirect::route('status-page')


### PR DESCRIPTION
Issue link id: N/A (proactive bugfix found during unsubscribe-path audit)


Description:
Fixes incorrect command dispatch that passed extra arguments to UnsubscribeSubscriberCommand.
The command constructor accepts only the subscriber, so this mismatch can cause runtime issues on stricter PHP versions.
Updated dispatch call to match command signature exactly.