### PR TITLE
Fix PHP 8.5 deprecation for PDO::MYSQL_ATTR_SSL_CA

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -67,7 +67,7 @@ return [
             'strict'         => true,
             'engine'         => null,
             'options'        => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (PHP_VERSION_ID >= 80400 ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -87,7 +87,7 @@ return [
             'strict'         => true,
             'engine'         => null,
             'options'        => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (PHP_VERSION_ID >= 80400 ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 


### PR DESCRIPTION
## Summary
- Replace deprecated `PDO::MYSQL_ATTR_SSL_CA` with `Pdo\Mysql::ATTR_SSL_CA` on PHP 8.4+, falling back to the old constant on PHP 8.2/8.3.
- Avoids the PHP 8.5 deprecation notice: `Constant PDO::MYSQL_ATTR_SSL_CA is deprecated since 8.5, use Pdo\Mysql::ATTR_SSL_CA instead`.

The new `Pdo\Mysql` class was introduced in PHP 8.4, so a `PHP_VERSION_ID` check is required while `composer.json` still allows `php: ^8.2`.

## Test plan
- [ ] Boot the app on PHP 8.5 and confirm the deprecation no longer fires.
- [ ] Boot the app on PHP 8.2/8.3 and confirm `PDO::MYSQL_ATTR_SSL_CA` is still used (no `Class "Pdo\Mysql" not found` error).
- [ ] Verify MySQL/MariaDB connections still negotiate SSL when `MYSQL_ATTR_SSL_CA` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)