### PR TITLE
Enable WAL journal mode and busy timeout for SQLite by default

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -46,9 +46,9 @@ return [
             'database'                => env('DB_DATABASE', database_path('database.sqlite')),
             'prefix'                  => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
-            'busy_timeout'            => null,
-            'journal_mode'            => null,
-            'synchronous'             => null,
+            'busy_timeout'            => env('DB_BUSY_TIMEOUT', 5000),
+            'journal_mode'            => env('DB_JOURNAL_MODE', 'WAL'),
+            'synchronous'             => env('DB_SYNCHRONOUS', 'NORMAL'),
         ],
 
         'mysql' => [


### PR DESCRIPTION
## Summary

The default SQLite connection left `busy_timeout`, `journal_mode`, and `synchronous` set to `null`, so Laravel's SQLite connector never applied those pragmas. With SQLite's default rollback journal and no busy timeout, concurrent API requests (e.g. `/api/schedules` and `/api/incidents` in quick succession) intermittently fail with "database is locked".

This defaults the connection to:

- `journal_mode = WAL` — readers and writers no longer block each other
- `busy_timeout = 5000` — contending writers wait up to 5s instead of failing immediately
- `synchronous = NORMAL` — the standard, safe pairing with WAL

All three remain overridable via `DB_JOURNAL_MODE`, `DB_BUSY_TIMEOUT`, and `DB_SYNCHRONOUS`.

Fixes #4620

## Verification

Confirmed via tinker against a real connection that the pragmas are applied: `journal_mode = wal`, `busy_timeout = 5000`, `synchronous = 1` (NORMAL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)