### PR TITLE
Transfer wrapper issues to core

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a Cachet issue
+    url: https://github.com/cachethq/core/issues/new/choose
+    about: Cachet is implemented in cachethq/core. Please report issues there.

--- a/.github/workflows/transfer-issues.yml
+++ b/.github/workflows/transfer-issues.yml
@@ -1,0 +1,29 @@
+name: Transfer Wrapper Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  transfer:
+    name: Transfer issue to core
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Cachet Bot token
+        id: cachet-bot-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.CACHET_BOT_APP_ID }}
+          private-key: ${{ secrets.CACHET_BOT_PRIVATE_KEY }}
+          owner: cachethq
+          repositories: |-
+            cachet
+            core
+
+      - name: Transfer issue
+        env:
+          GH_TOKEN: ${{ steps.cachet-bot-token.outputs.token }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: gh issue transfer "$ISSUE_URL" cachethq/core


### PR DESCRIPTION
## Summary

- direct issue reporters to `cachethq/core`
- transfer every newly opened wrapper-repository issue to `cachethq/core` with Cachet Bot

## Implementation

The workflow generates a short-lived GitHub App token scoped to `cachethq/cachet` and `cachethq/core`, then uses `gh issue transfer`. Native transfers retain issue discussion and redirect the original URL.

## Validation

- `git diff --check`
